### PR TITLE
Change `pack version` to format `<semver>+<gitsha1, first 7 chars>`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 GOCMD?=go
 GOENV=CGO_ENABLED=0
 GOFLAGS?=-mod=vendor
-PACK_VERSION?=dev-$(shell date +%Y-%m-%d-%H:%M:%S)
+PACK_VERSION?=0.0.0
+PACK_GITSHA1?=$(shell git rev-parse --short=7 HEAD)
 PACK_BIN?=pack
 PACKAGE_BASE=github.com/buildpack/pack
 PACKAGES:=$(shell $(GOCMD) list ./... | grep -v /testdata/)
 SRC:=$(shell find . -type f -name '*.go' -not -path "*/vendor/*")
 ARCHIVE_NAME=pack-$(PACK_VERSION)
+
+# append git sha to version, if not-empty
+ifneq ($(strip ${PACK_GITSHA1}),)
+PACK_VERSION:=${PACK_VERSION}+${PACK_GITSHA1}
+endif
 
 export GOFLAGS:=$(GOFLAGS)
 


### PR DESCRIPTION
- `make build` in a git repo at sha abc1234xyz... will yield `0.0.0+abc1234`
- `PACK_VERSION=1.2.3 make build` in a git repo at sha abc1234xyz... will yield `1.2.3+abc1234`
- `PACK_VERSION=1.2.3 PACK_GITSHA1=abc1234xyz make build` will always yield `1.2.3+abc1234xyz`
- When not in git repo or when `PACK_GITSHA1= make build`, version will be `<semver>` only
- Implement via Makefile for the same reason `PACK_VERSION` is set in Makefile - it is not intrinsic to pack codebase, rather comes from the version control system of the codebase and also should be overridable
- Complex Makefile conditional/strip syntax is meant to handle messy whitespace if git fails or is not present (see `ifeq` section): https://www.gnu.org/software/make/manual/html_node/Conditional-Syntax.html)

Resolves #390