### PR TITLE
Add support for project.toml

### DIFF
--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -140,6 +140,122 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, command.Execute())
 			})
 		})
+
+		when("user specifies an invalid project descriptor file", func() {
+			it("should show an error", func() {
+				projectTomlPath := "/incorrect/path/to/project.toml"
+				mockClient.EXPECT().
+					Build(gomock.Any(), EqBuildOptionsWithImage("my-builder", "image")).
+					Return(nil)
+
+				command.SetArgs([]string{"--builder", "my-builder", "--descriptor", projectTomlPath, "image"})
+				h.AssertNotNil(t, command.Execute())
+			})
+		})
+
+		when("repo has a project.toml", func() {
+			when("that is invalid", func() {
+				var projectTomlPath string
+
+				it.Before(func() {
+					projectToml, err := ioutil.TempFile("", "project.toml")
+					h.AssertNil(t, err)
+					defer projectToml.Close()
+
+					projectToml.WriteString("project]")
+					projectTomlPath = projectToml.Name()
+				})
+
+				it.After(func() {
+					h.AssertNil(t, os.RemoveAll(projectTomlPath))
+				})
+
+				it("fails to build", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithImage("my-builder", "image")).
+						Return(nil)
+
+					command.SetArgs([]string{"--builder", "my-builder", "--descriptor", projectTomlPath, "image"})
+					h.AssertNotNil(t, command.Execute())
+				})
+			})
+
+			when("that is not in the root dir", func() {
+				var projectTomlPath string
+
+				it.Before(func() {
+					projectToml, err := ioutil.TempFile("", "project.toml")
+					h.AssertNil(t, err)
+					defer projectToml.Close()
+
+					projectToml.WriteString(`
+[project]
+name = "Sample"
+
+[[build.buildpacks]]
+id = "example/lua"
+version = "1.0"
+
+[[build.env]]
+name = "KEY1"
+value = "VALUE1"
+
+[[build.env]]
+name = "KEY2"
+value = "VALUE2"
+`)
+					projectTomlPath = projectToml.Name()
+				})
+
+				it.After(func() {
+					h.AssertNil(t, os.RemoveAll(projectTomlPath))
+				})
+
+				it("builds an image with the env variables", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithEnv(map[string]string{
+							"KEY1": "VALUE1",
+							"KEY2": "VALUE2",
+						})).
+						Return(nil)
+
+					command.SetArgs([]string{"--builder", "my-builder", "--descriptor", projectTomlPath, "image"})
+					h.AssertNil(t, command.Execute())
+				})
+
+				it("builds an image with the buildpacks", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithBuildpacks([]string{
+							"example/lua@1.0",
+						})).
+						Return(nil)
+
+					command.SetArgs([]string{"--builder", "my-builder", "--descriptor", projectTomlPath, "image"})
+					h.AssertNil(t, command.Execute())
+				})
+			})
+
+			when("that is in the root dir", func() {
+				it.Before(func() {
+					h.AssertNil(t, os.Chdir("testdata"))
+				})
+
+				it.After(func() {
+					h.AssertNil(t, os.Chdir(".."))
+				})
+
+				it("builds an image with the env variables", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithEnv(map[string]string{
+							"KEY1": "VALUE1",
+						})).
+						Return(nil)
+
+					command.SetArgs([]string{"--builder", "my-builder", "image"})
+					h.AssertNil(t, command.Execute())
+				})
+			})
+		})
 	})
 }
 
@@ -180,6 +296,25 @@ func EqBuildOptionsWithEnv(env map[string]string) gomock.Matcher {
 	}
 }
 
+func EqBuildOptionsWithBuildpacks(buildpacks []string) gomock.Matcher {
+	return buildOptionsMatcher{
+		description: fmt.Sprintf("Buildpacks=%+v", buildpacks),
+		equals: func(o pack.BuildOptions) bool {
+			for _, bp := range o.Buildpacks {
+				if !contains(buildpacks, bp) {
+					return false
+				}
+			}
+			for _, bp := range buildpacks {
+				if !contains(o.Buildpacks, bp) {
+					return false
+				}
+			}
+			return true
+		},
+	}
+}
+
 type buildOptionsMatcher struct {
 	equals      func(pack.BuildOptions) bool
 	description string
@@ -194,4 +329,13 @@ func (m buildOptionsMatcher) Matches(x interface{}) bool {
 
 func (m buildOptionsMatcher) String() string {
 	return "is a BuildOptions with " + m.description
+}
+
+func contains(arr []string, str string) bool {
+	for _, a := range arr {
+		if a == str {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/commands/testdata/project.toml
+++ b/internal/commands/testdata/project.toml
@@ -1,0 +1,10 @@
+[project]
+name = "Sample"
+
+[[build.buildpacks]]
+id = "example/lua"
+version = "1.0"
+
+[[build.env]]
+name = "KEY1"
+value = "VALUE1"

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,0 +1,86 @@
+package project
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/BurntSushi/toml"
+	"github.com/pkg/errors"
+)
+
+type Buildpack struct {
+	ID      string `toml:"id"`
+	Version string `toml:"version"`
+	URI     string `toml:"uri"`
+}
+
+type EnvVar struct {
+	Name  string `toml:"name"`
+	Value string `toml:"value"`
+}
+
+type Build struct {
+	Include    []string    `toml:"include"`
+	Exclude    []string    `toml:"exclude"`
+	Buildpacks []Buildpack `toml:"buildpacks"`
+	Env        []EnvVar    `toml:"env"`
+}
+
+type License struct {
+	Type string `toml:"type"`
+	URI  string `toml:"uri"`
+}
+
+type Project struct {
+	Name     string    `toml:"name"`
+	Licenses []License `toml:"licenses"`
+}
+
+type Descriptor struct {
+	Project  Project                `toml:"project"`
+	Build    Build                  `toml:"build"`
+	Metadata map[string]interface{} `toml:"metadata"`
+}
+
+func ReadProjectDescriptor(pathToFile string) (Descriptor, error) {
+	if _, err := os.Stat(pathToFile); os.IsNotExist(err) {
+		return Descriptor{}, err
+	}
+	projectTomlContents, err := ioutil.ReadFile(pathToFile)
+	if err != nil {
+		fmt.Print(err)
+	}
+
+	var descriptor Descriptor
+	_, err = toml.Decode(string(projectTomlContents), &descriptor)
+	if err != nil {
+		return Descriptor{}, err
+	}
+
+	return descriptor, descriptor.validate()
+}
+
+func (p Descriptor) validate() error {
+	if p.Build.Exclude != nil && p.Build.Include != nil {
+		return errors.New("project.toml: cannot have both include and exclude defined")
+	}
+	if len(p.Project.Licenses) > 0 {
+		for _, license := range p.Project.Licenses {
+			if license.Type == "" && license.URI == "" {
+				return errors.New("project.toml: must have a type or uri defined for each license")
+			}
+		}
+	}
+
+	for _, bp := range p.Build.Buildpacks {
+		if bp.ID == "" && bp.URI == "" {
+			return errors.New("project.toml: buildpacks must have an id or url defined")
+		}
+		if bp.URI != "" && bp.Version != "" {
+			return errors.New("project.toml: buildpacks cannot have both uri and version defined")
+		}
+	}
+
+	return nil
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,0 +1,234 @@
+package project
+
+import (
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestProject(t *testing.T) {
+	h.RequireDocker(t)
+	color.Disable(true)
+	defer color.Disable(false)
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	spec.Run(t, "Provider", testProject, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func testProject(t *testing.T, when spec.G, it spec.S) {
+	when("#ReadProjectDescriptor", func() {
+		it("should parse a valid project.toml file", func() {
+			projectToml := `
+[project]
+name = "gallant"
+[[project.licenses]]
+type = "MIT"
+[build]
+exclude = [ "*.jar" ]
+[[build.buildpacks]]
+id = "example/lua"
+version = "1.0"
+[[build.buildpacks]]
+uri = "https://example.com/buildpack"
+[[build.env]]
+name = "JAVA_OPTS"
+value = "-Xmx300m"
+[metadata]
+pipeline = "Lucerne"
+`
+			tmpProjectToml, err := createTmpProjectTomlFile(projectToml)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			projectDescriptor, err := ReadProjectDescriptor(tmpProjectToml.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var expected string
+
+			expected = "gallant"
+			if projectDescriptor.Project.Name != expected {
+				t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
+					expected, projectDescriptor.Project.Name)
+			}
+
+			expected = "example/lua"
+			if projectDescriptor.Build.Buildpacks[0].ID != expected {
+				t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
+					expected, projectDescriptor.Build.Buildpacks[0].ID)
+			}
+
+			expected = "1.0"
+			if projectDescriptor.Build.Buildpacks[0].Version != expected {
+				t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
+					expected, projectDescriptor.Build.Buildpacks[0].Version)
+			}
+
+			expected = "https://example.com/buildpack"
+			if projectDescriptor.Build.Buildpacks[1].URI != expected {
+				t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
+					expected, projectDescriptor.Build.Buildpacks[1].URI)
+			}
+
+			expected = "JAVA_OPTS"
+			if projectDescriptor.Build.Env[0].Name != expected {
+				t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
+					expected, projectDescriptor.Build.Env[0].Name)
+			}
+
+			expected = "-Xmx300m"
+			if projectDescriptor.Build.Env[0].Value != expected {
+				t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
+					expected, projectDescriptor.Build.Env[0].Value)
+			}
+
+			expected = "MIT"
+			if projectDescriptor.Project.Licenses[0].Type != expected {
+				t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
+					expected, projectDescriptor.Project.Licenses[0].Type)
+			}
+
+			expected = "Lucerne"
+			if projectDescriptor.Metadata["pipeline"] != expected {
+				t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
+					expected, projectDescriptor.Metadata["pipeline"])
+			}
+		})
+
+		it("should create empty build ENV", func() {
+			projectToml := `
+[project]
+name = "gallant"
+`
+			tmpProjectToml, err := createTmpProjectTomlFile(projectToml)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			projectDescriptor, err := ReadProjectDescriptor(tmpProjectToml.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expected := 0
+			if len(projectDescriptor.Build.Env) != 0 {
+				t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
+					expected, string(len(projectDescriptor.Build.Env)))
+			}
+
+			for _, envVar := range projectDescriptor.Build.Env {
+				t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
+					"[]", envVar)
+			}
+		})
+
+		it("should fail for an invalid project.toml path", func() {
+			_, err := ReadProjectDescriptor("/path/that/does/not/exist/project.toml")
+
+			if !os.IsNotExist(err) {
+				t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
+					"project.toml does not exist error", "no error")
+			}
+		})
+	})
+
+	it("should enforce mutual exclusivity between exclude and include", func() {
+		projectToml := `
+[project]
+name = "bad excludes and includes"
+
+[build]
+exclude = [ "*.jar" ]
+include = [ "*.jpg" ]
+`
+		tmpProjectToml, err := createTmpProjectTomlFile(projectToml)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = ReadProjectDescriptor(tmpProjectToml.Name())
+		if err == nil {
+			t.Fatalf(
+				"Expected error for having both exclude and include defined")
+		}
+	})
+
+	it("should have an id or uri defined for buildpacks", func() {
+		projectToml := `
+[project]
+name = "missing buildpacks id and uri"
+
+[[build.buildpacks]]
+version = "1.2.3"
+`
+		tmpProjectToml, err := createTmpProjectTomlFile(projectToml)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = ReadProjectDescriptor(tmpProjectToml.Name())
+		if err == nil {
+			t.Fatalf("Expected error for NOT having id or uri defined for buildpacks")
+		}
+	})
+
+	it("should not allow both uri and version", func() {
+		projectToml := `
+[project]
+name = "cannot have both uri and version defined"
+
+[[build.buildpacks]]
+uri = "https://example.com/buildpack"
+version = "1.2.3"
+`
+		tmpProjectToml, err := createTmpProjectTomlFile(projectToml)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = ReadProjectDescriptor(tmpProjectToml.Name())
+		if err == nil {
+			t.Fatal("Expected error for having both uri and version defined for a buildpack(s)")
+		}
+	})
+
+	it("should require either a type or uri for licenses", func() {
+		projectToml := `
+[project]
+name = "licenses should have either a type or uri defined"
+
+[[project.licenses]]
+`
+		tmpProjectToml, err := createTmpProjectTomlFile(projectToml)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = ReadProjectDescriptor(tmpProjectToml.Name())
+		if err == nil {
+			t.Fatal("Expected error for having neither type or uri defined for licenses")
+		}
+	})
+}
+
+func createTmpProjectTomlFile(projectToml string) (*os.File, error) {
+	tmpProjectToml, err := ioutil.TempFile(os.TempDir(), "project-")
+	if err != nil {
+		log.Fatal("Failed to create temporary project toml file", err)
+	}
+
+	if _, err := tmpProjectToml.Write([]byte(projectToml)); err != nil {
+		log.Fatal("Failed to write to temporary file", err)
+	}
+	return tmpProjectToml, err
+}


### PR DESCRIPTION
This PR adds initial support for the Project Descriptor defined in [Project Descriptor RFC](https://github.com/buildpacks/rfcs/pull/32)

The `project.toml` file path is specified via the `--descriptor` flag (defaults to `project.toml`).  The project file is then parsed to support the following features of the `project.toml` RFC:

* **[project]** for specifying `name`, `id`, and `version`
* **[project.licenses]** for specifying license `type` or `uri` information
* **[[build.buildpacks]]** to specify the buildpacks that the platform should use on the repo.
* **[[build.env]]** for setting environment variables at build time

The plan is to provide additional features in later PR(s), such as the following:
* **[build.include]** A list of files to include in the build (while excluding everything else
* **[build.exclude]** A list of files to exclude from the build (while including everything else)