### PR TITLE
`pack report` should not display error when config.toml is not present

### DIFF
--- a/internal/commands/report.go
+++ b/internal/commands/report.go
@@ -52,7 +52,7 @@ Config:
 	if path, err := config.DefaultConfigPath(); err != nil {
 		configData = fmt.Sprintf("(error: %s)", err.Error())
 	} else if data, err := ioutil.ReadFile(path); err != nil {
-		configData = fmt.Sprintf("(error: %s)", err.Error())
+		configData = fmt.Sprintf("(no config file found at %s)", path)
 	} else {
 		var padded strings.Builder
 		for _, line := range strings.Split(string(data), "\n") {

--- a/internal/commands/report_test.go
+++ b/internal/commands/report_test.go
@@ -1,0 +1,81 @@
+package commands_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/commands"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestReportCommand(t *testing.T) {
+	spec.Run(t, "Commands", testReportCommand, spec.Random(), spec.Report(report.Terminal{}))
+}
+
+func testReportCommand(t *testing.T, when spec.G, it spec.S) {
+	var (
+		command         *cobra.Command
+		logger          logging.Logger
+		outBuf          bytes.Buffer
+		packHome        string
+		packConfigPath  string
+		packMissingHome string
+	)
+
+	it.Before(func() {
+		var err error
+		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+		command = commands.Report(logger)
+
+		packHome, err = ioutil.TempDir("", "")
+		h.AssertNil(t, err)
+		packConfigPath = filepath.Join(packHome, "config.toml")
+		h.AssertNil(t, ioutil.WriteFile(packConfigPath, []byte(`default-builder-image = "some/image"`), 0666))
+		packMissingHome, err = ioutil.TempDir("", "")
+		h.AssertNil(t, err)
+	})
+
+	it.After(func() {
+		os.RemoveAll(packHome)
+		os.RemoveAll(packMissingHome)
+	})
+
+	when("#ReportCommand", func() {
+		when("config.toml is present", func() {
+			it.Before(func() {
+				os.Setenv("PACK_HOME", packHome)
+			})
+
+			it.After(func() {
+				os.Unsetenv("PACK_HOME")
+			})
+
+			it("presents output", func() {
+				h.AssertNil(t, command.Execute())
+				h.AssertContains(t, outBuf.String(), `default-builder-image = "some/image"`)
+			})
+		})
+		when("config.toml is not present", func() {
+			it.Before(func() {
+				os.Setenv("PACK_HOME", packMissingHome)
+			})
+			it.After(func() {
+				os.Unsetenv("PACK_HOME")
+			})
+			it("logs a message", func() {
+				h.AssertNil(t, command.Execute())
+				h.AssertContains(t, outBuf.String(), fmt.Sprintf("(no config file found at %s)", filepath.Join(packMissingHome, "config.toml")))
+			})
+		})
+	})
+}


### PR DESCRIPTION
fixes #433 