### PR TITLE
Add `cloudfoundry/cnb:tiny` to suggested builders

### DIFF
--- a/internal/commands/suggest_builders.go
+++ b/internal/commands/suggest_builders.go
@@ -30,6 +30,11 @@ var suggestedBuilders = []suggestedBuilder{
 		DefaultDescription: "Larger base image with Java, Node.js & Python",
 	},
 	{
+		Name:               "Cloud Foundry",
+		Image:              "cloudfoundry/cnb:tiny",
+		DefaultDescription: "Tiny base image (bionic build image, distroless run image) with buildpacks for Golang",
+	},
+	{
 		Name:               "Heroku",
 		Image:              "heroku/buildpacks:18",
 		DefaultDescription: "heroku-18 base image with buildpacks for Ruby, Java, Node.js, Python, Golang, & PHP",

--- a/internal/commands/suggest_builders_test.go
+++ b/internal/commands/suggest_builders_test.go
@@ -44,6 +44,9 @@ func testSuggestBuildersCommand(t *testing.T, when spec.G, it spec.S) {
 	when("#SuggestBuilders", func() {
 		when("description metadata exists", func() {
 			it.Before(func() {
+				mockClient.EXPECT().InspectBuilder("cloudfoundry/cnb:tiny", false).Return(&pack.BuilderInfo{
+					Description: "Tiny description",
+				}, nil)
 				mockClient.EXPECT().InspectBuilder("cloudfoundry/cnb:bionic", false).Return(&pack.BuilderInfo{
 					Description: "Bionic description",
 				}, nil)
@@ -61,6 +64,7 @@ func testSuggestBuildersCommand(t *testing.T, when spec.G, it spec.S) {
 				h.AssertContains(t, outBuf.String(), "Suggested builders:")
 				h.AssertContainsMatch(t, outBuf.String(), `Cloud Foundry:\s+'cloudfoundry/cnb:bionic'\s+Bionic description`)
 				h.AssertContainsMatch(t, outBuf.String(), `Cloud Foundry:\s+'cloudfoundry/cnb:cflinuxfs3'\s+CFLinuxFS3 description`)
+				h.AssertContainsMatch(t, outBuf.String(), `Cloud Foundry:\s+'cloudfoundry/cnb:tiny'\s+Tiny description`)
 				h.AssertContainsMatch(t, outBuf.String(), `Heroku:\s+'heroku/buildpacks:18'\s+Heroku description`)
 			})
 		})
@@ -98,5 +102,6 @@ func testSuggestBuildersCommand(t *testing.T, when spec.G, it spec.S) {
 func assertDefaultDescriptions(t *testing.T, outBuf bytes.Buffer) {
 	h.AssertContainsMatch(t, outBuf.String(), `Cloud Foundry:\s+'cloudfoundry/cnb:bionic'\s+Small base image with Java & Node.js`)
 	h.AssertContainsMatch(t, outBuf.String(), `Cloud Foundry:\s+'cloudfoundry/cnb:cflinuxfs3'\s+Larger base image with Java, Node.js & Python`)
+	h.AssertContainsMatch(t, outBuf.String(), `Cloud Foundry:\s+'cloudfoundry/cnb:tiny'\s+Tiny base image \(bionic build image, distroless run image\) with buildpacks for Golang`)
 	h.AssertContainsMatch(t, outBuf.String(), `Heroku:\s+'heroku/buildpacks:18'\s+heroku-18 base image with buildpacks for Ruby, Java, Node.js, Python, Golang, & PHP`)
 }


### PR DESCRIPTION
Suggested builder should include the `cloudfoundry:cnb:tiny` builder. 

```
Suggested builders:
	Cloud Foundry:     cloudfoundry/cnb:bionic         Ubuntu bionic base image with buildpacks for Java, NodeJS and Golang
	Cloud Foundry:     cloudfoundry/cnb:cflinuxfs3     cflinuxfs3 base image with buildpacks for Java, .NET, NodeJS, Python, Golang, PHP, HTTPD and NGINX
	Cloud Foundry:     cloudfoundry/cnb:tiny           Tiny base image (bionic build image, distroless run image) with buildpacks for Golang
	Heroku:            heroku/buildpacks:18            heroku-18 base image with buildpacks for Ruby, Java, Node.js, Python, Golang, & PHP

Tip: Learn more about a specific builder with:
	pack inspect-builder [builder image]
```