### PR TITLE
Bump default lifecycle version

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -51,6 +51,8 @@ const (
 
 	runImage   = "pack-test/run"
 	buildImage = "pack-test/build"
+
+	defaultPlatformAPIVersion = "0.2"
 )
 
 var (
@@ -110,7 +112,7 @@ func TestAcceptance(t *testing.T) {
 		},
 		API: builder.LifecycleAPI{
 			BuildpackVersion: api.MustParse(builder.DefaultBuildpackAPIVersion),
-			PlatformVersion:  api.MustParse(builder.DefaultPlatformAPIVersion),
+			PlatformVersion:  api.MustParse(defaultPlatformAPIVersion),
 		},
 	}
 	lifecyclePath := os.Getenv(envLifecyclePath)

--- a/acceptance/testdata/pack_fixtures/report_output.txt
+++ b/acceptance/testdata/pack_fixtures/report_output.txt
@@ -2,7 +2,7 @@ Pack:
   Version:  {{ .Version }}
   OS/Arch:  {{ .OS }}/{{ .Arch }}
 
-Default Lifecycle Version:  0.5.0
+Default Lifecycle Version:  0.6.0
 
 Config:
   default-builder-image = "{{ .DefaultBuilder }}"

--- a/internal/builder/lifecycle.go
+++ b/internal/builder/lifecycle.go
@@ -15,9 +15,8 @@ import (
 )
 
 const (
-	DefaultLifecycleVersion    = "0.5.0"
+	DefaultLifecycleVersion    = "0.6.0"
 	DefaultBuildpackAPIVersion = "0.2"
-	DefaultPlatformAPIVersion  = "0.1"
 )
 
 type Blob interface {


### PR DESCRIPTION
Also bump default platform api version since lifecycle 0.6.0 implements
a newer api.

Closes: #465 