### PR TITLE
Bump default lifecycle version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PACKAGE_BASE=github.com/buildpacks/pack
 PACKAGES:=$(shell $(GOCMD) list ./... | grep -v /testdata/)
 SRC:=$(shell find . -type f -name '*.go' -not -path "*/vendor/*")
 ARCHIVE_NAME=pack-$(PACK_VERSION)
-TEST_TIMEOUT?=600s
+TEST_TIMEOUT?=900s
 UNIT_TIMEOUT?=$(TEST_TIMEOUT)
 ACCEPTANCE_TIMEOUT?=$(TEST_TIMEOUT)
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -53,7 +53,7 @@ const (
 	buildImage = "pack-test/build"
 
 	defaultCompilePackVersion = "0.0.0"
-	defaultPlatformAPIVersion = "0.2"
+	defaultPlatformAPIVersion = "0.3"
 )
 
 var (

--- a/acceptance/testdata/pack_fixtures/report_output.txt
+++ b/acceptance/testdata/pack_fixtures/report_output.txt
@@ -2,7 +2,7 @@ Pack:
   Version:  {{ .Version }}
   OS/Arch:  {{ .OS }}/{{ .Arch }}
 
-Default Lifecycle Version:  0.6.1
+Default Lifecycle Version:  0.7.2
 
 Config:
   default-builder-image = "{{ .DefaultBuilder }}"

--- a/internal/builder/lifecycle.go
+++ b/internal/builder/lifecycle.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DefaultLifecycleVersion    = "0.6.1"
+	DefaultLifecycleVersion    = "0.7.2"
 	DefaultBuildpackAPIVersion = "0.2"
 )
 


### PR DESCRIPTION
Fixes #557.

Also bump test timeout since the latest combo suite runs
a bit longer than 10 minutes.

Signed-off-by: Natalie Arellano <narellano@vmware.com>