### PR TITLE
Fix failing test

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -580,7 +580,6 @@ func testAcceptance(t *testing.T, when spec.G, it spec.S, packFixturesDir, packP
 								"build", repoName,
 								"--default-process", "hello",
 								"-p", filepath.Join("testdata", "mock_app"),
-								"--buildpack", filepath.Join("testdata", "mock_buildpacks", "0.2", "simple-layers-buildpack"),
 							))
 
 							assertMockAppLogs(t, repoName, "hello world")


### PR DESCRIPTION
We cannot use directory based buildpacks on Windows. The simple-layers-buildpack
is already on the default builder, so it doesn't need to be explicitly added.

Signed-off-by: Natalie Arellano <narellano@vmware.com>