### PR TITLE
Move tests that don't require specific builders to their own suite

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -145,16 +145,21 @@ func TestAcceptance(t *testing.T) {
 	suiteManager = &SuiteManager{out: t.Logf}
 	suite := spec.New("acceptance suite", spec.Report(report.Terminal{}))
 
-	suite("p_current", func(t *testing.T, when spec.G, it spec.S) {
-		testWithoutSpecificBuilderRequirement(
-			t,
-			when,
-			it,
-			currentPackFixturesDir,
-			packPath,
-			api.MustParse(builder.DefaultBuildpackAPIVersion),
-		)
-	}, spec.Report(report.Terminal{}))
+	for _, combo := range combos {
+		if combo.Pack == "current" {
+			suite("p_current", func(t *testing.T, when spec.G, it spec.S) {
+				testWithoutSpecificBuilderRequirement(
+					t,
+					when,
+					it,
+					currentPackFixturesDir,
+					packPath,
+					api.MustParse(builder.DefaultBuildpackAPIVersion),
+				)
+			}, spec.Report(report.Terminal{}))
+			break
+		}
+	}
 
 	resolvedCombos, err := resolveRunCombinations(
 		combos,

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -228,8 +228,8 @@ func testWithoutSpecificBuilderRequirement(
 	bpVersion *api.Version,
 ) {
 	var (
-		bpDir      = buildpacksDir(*bpVersion)
-		packHome   string
+		bpDir    = buildpacksDir(*bpVersion)
+		packHome string
 	)
 
 	// subjectPack creates a pack `exec.Cmd` based on the current configuration

--- a/acceptance/run_combination.go
+++ b/acceptance/run_combination.go
@@ -14,6 +14,8 @@ import (
 
 const envAcceptanceSuiteConfig = "ACCEPTANCE_SUITE_CONFIG"
 
+var currentPackFixturesDir = filepath.Join("testdata", "pack_fixtures")
+
 type runCombo struct {
 	Pack              string `json:"pack"`
 	PackCreateBuilder string `json:"pack_create_builder"`
@@ -39,9 +41,7 @@ func (c *runCombo) String() string {
 //nolint
 func getRunCombinations() ([]runCombo, error) {
 	combos := []runCombo{
-		{Pack: "current", PackCreateBuilder: "current", Lifecycle: "default"}, // TODO: the current behavior for
-		// `make acceptance` is to test current-current-current which is actually current-current-default when no
-		// lifecycle path is provided. Confirm if we should keep this behavior going forward.
+		{Pack: "current", PackCreateBuilder: "current", Lifecycle: "default"},
 	}
 
 	suiteConfig := os.Getenv(envAcceptanceSuiteConfig)
@@ -99,8 +99,8 @@ func resolveRunCombinations(
 	resolved := map[string]resolvedRunCombo{}
 	for _, c := range combos {
 		rc := resolvedRunCombo{
-			packFixturesDir:              filepath.Join("testdata", "pack_fixtures"),
-			packCreateBuilderFixturesDir: filepath.Join("testdata", "pack_fixtures"),
+			packFixturesDir:              currentPackFixturesDir,
+			packCreateBuilderFixturesDir: currentPackFixturesDir,
 			packPath:                     packPath,
 			packCreateBuilderPath:        packPath,
 			lifecyclePath:                lifecyclePath,

--- a/acceptance/run_combination.go
+++ b/acceptance/run_combination.go
@@ -14,6 +14,9 @@ import (
 
 const envAcceptanceSuiteConfig = "ACCEPTANCE_SUITE_CONFIG"
 
+//nolint:unused // TODO: nolint directives in this file shouldn't be necessary, as
+// all of the code is used. However lint errors are returned without these directives.
+// Possibly related to https://github.com/golangci/golangci-lint/issues/791.
 var currentPackFixturesDir = filepath.Join("testdata", "pack_fixtures")
 
 type runCombo struct {
@@ -22,9 +25,7 @@ type runCombo struct {
 	Lifecycle         string `json:"lifecycle"`
 }
 
-//nolint:unused // TODO: nolint directives in this file shouldn't be necessary, as
-// all of the code is used. However lint errors are returned without these directives.
-// Possibly related to https://github.com/golangci/golangci-lint/issues/791.
+//nolint:unused
 type resolvedRunCombo struct {
 	packCreateBuilderFixturesDir string
 	packFixturesDir              string

--- a/acceptance/testdata/pack_previous_fixtures_overrides/inspect_X.Y.Z_builder_output.txt
+++ b/acceptance/testdata/pack_previous_fixtures_overrides/inspect_X.Y.Z_builder_output.txt
@@ -1,0 +1,1 @@
+Files like these represent the expected output of calling `pack inspect-builder` on a builder created with pack vX.Y.Z


### PR DESCRIPTION
The current setup requires complicated workarounds when the output of
specific commands changes.

For example, we require the pack_previous_fixtures_overrides directory
and files such as inspect_X.Y.Z_builder_output.txt to change the desired
expectation when a previous version of pack is used to either
create a builder or inspect a builder.

This is cumbersome. We can reduce the number of tests that require
these workarounds by only applying the compatibility matrix for tests
that truly require a compatibility check. For example, we do not need to
re-evaluate the output of `pack suggest-builders` from a previous version
of pack.

Signed-off-by: Natalie Arellano <narellano@vmware.com>