### PR TITLE
Add codecov to tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [darwin, linux, windows]
+        os: [macos, linux, windows]
         include:
-          - os: darwin
+          - os: macos
             runner: macos-latest
             no_docker: "true"
             pack_bin: pack
@@ -80,10 +80,10 @@ jobs:
           [[ $GITHUB_REF =~ ^refs\/heads\/release/(.*)$ ]] && version=${BASH_REMATCH[1]}
           echo "::set-env name=PACK_VERSION::$version"
         shell: bash
-      - name: Download artifacts - darwin
+      - name: Download artifacts - macos
         uses: actions/download-artifact@v1
         with:
-          name: pack-darwin
+          name: pack-macos
       - name: Download artifacts - linux
         uses: actions/download-artifact@v1
         with:
@@ -92,10 +92,10 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: pack-windows
-      - name: Package artifacts - darwin
+      - name: Package artifacts - macos
         run: |
-          chmod +x pack-darwin/pack
-          tar -C pack-darwin -vzcf pack-darwin.tgz pack
+          chmod +x pack-macos/pack
+          tar -C pack-macos -vzcf pack-macos.tgz pack
       - name: Package artifacts - linux
         run: |
           chmod +x pack-linux/pack
@@ -174,13 +174,13 @@ jobs:
             ## Fixes
 
             ## Breaking Changes
-      - name: Upload Release Asset - darwin
+      - name: Upload Release Asset - macos
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./pack-darwin.tgz
+          asset_path: ./pack-macos.tgz
           asset_name: pack-v${{ env.PACK_VERSION }}-macos.tgz
           asset_content_type: application/gzip
       - name: Upload Release Asset - linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,11 @@ jobs:
         env:
           TEST_COVERAGE: 1
         run: make test
-      - name: Upload coverage to Codecov
+      - name: Upload Coverage
         uses: codecov/codecov-action@v1
         with:
           file: ./out/tests/coverage-unit.txt
-          flags: unit
+          flags: unit,os/${{ matrix.os }}
           fail_ci_if_error: true
       - name: Build
         run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,15 @@ jobs:
         if: matrix.os != 'windows'
         run: make verify
       - name: Test
+        env:
+          TEST_COVERAGE: 1
         run: make test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./out/tests/coverage-unit.txt
+          flags: unit
+          fail_ci_if_error: true
       - name: Build
         run: make build
         env:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ACCEPTANCE_TIMEOUT?=$(TEST_TIMEOUT)
 ARCHIVE_NAME=pack-$(PACK_VERSION)
 GOCMD?=go
 GOFLAGS?=-mod=vendor
+GOTESTFLAGS?=-v -count=1 -parallel=1
 PACKAGE_BASE=github.com/buildpacks/pack
 PACK_BIN?=pack
 PACK_GITSHA1=$(shell git rev-parse --short=7 HEAD)
@@ -66,17 +67,22 @@ lint: install-golangci-lint
 
 test: unit acceptance
 
-unit:
+# append coverage arguments
+ifeq ($(TEST_COVERAGE), 1)
+unit: GOTESTFLAGS:=$(GOTESTFLAGS) -coverprofile=./out/tests/coverage-unit.txt -covermode=atomic
+endif
+unit: out
 	@echo "> Running unit/integration tests..."
-	$(GOCMD) test -v -count=1 -parallel=1 -timeout=$(UNIT_TIMEOUT) ./...
+	$(GOCMD) test $(GOTESTFLAGS) -timeout=$(UNIT_TIMEOUT) ./...
 
-acceptance:
+acceptance: out
 	@echo "> Running acceptance tests..."
-	$(GOCMD) test -v -count=1 -parallel=1 -timeout=$(ACCEPTANCE_TIMEOUT) -tags=acceptance ./acceptance
+	$(GOCMD) test $(GOTESTFLAGS) -timeout=$(ACCEPTANCE_TIMEOUT) -tags=acceptance ./acceptance
 
+acceptance-all: export ACCEPTANCE_SUITE_CONFIG:=$(shell cat ./acceptance/testconfig/all.json)
 acceptance-all:
 	@echo "> Running acceptance tests..."
-	ACCEPTANCE_SUITE_CONFIG=$$(cat ./acceptance/testconfig/all.json) $(GOCMD) test -v -count=1 -parallel=1 -timeout=$(ACCEPTANCE_TIMEOUT) -tags=acceptance ./acceptance
+	$(GOCMD) test $(GOTESTFLAGS) -timeout=$(ACCEPTANCE_TIMEOUT) -tags=acceptance ./acceptance
 
 clean:
 	@echo "> Cleaning workspace..."
@@ -110,6 +116,8 @@ prepare-for-pr: tidy verify test
 	exit 0;
 
 out:
+	# NOTE: Windows doesn't support `-p`
 	mkdir out
+	mkdir out/tests
 
 .PHONY: clean build format imports lint test unit acceptance verify verify-format


### PR DESCRIPTION
This PR adds code coverage support via [codecov.io](https://codecov.io) to unit/integration tests. It does not include coverage from acceptance tests.