### PR TITLE
Support process substitution for config files

### DIFF
--- a/builder/config_reader.go
+++ b/builder/config_reader.go
@@ -43,7 +43,6 @@ type Config struct {
 	Order       dist.Order          `toml:"order"`
 	Stack       StackConfig         `toml:"stack"`
 	Lifecycle   LifecycleConfig     `toml:"lifecycle"`
-	groups      []interface{}
 }
 
 type BuildpackConfig struct {
@@ -123,10 +122,6 @@ func parseConfig(reader io.Reader, relativeToDir, path string) (Config, []string
 			return Config{}, warnings, errors.Wrap(err, "transforming lifecycle URI")
 		}
 		builderConfig.Lifecycle.URI = uri
-	}
-
-	if len(builderConfig.groups) > 0 {
-		warnings = append(warnings, fmt.Sprintf("%s field is obsolete in favor of %s", style.Symbol("groups"), style.Symbol("order")))
 	}
 
 	return builderConfig, warnings, nil


### PR DESCRIPTION
When building, you may want to make some things dynamic. When using `bash`/`make` I like to use `envsubst` for this and do process substitution. For example:

```toml
# Buildpacks to include in builder
[[buildpacks]]
id = "com.my.buildpacks.nodejs"
version = "0.0.1"
uri = "${PWD}/buildpacks/nodejs"

# Order used for detection
[[order]]
[[order.group]]
id = "com.my.buildpacks.nodejs"

# Stack that will be used by the builder
[stack]
id = "com.my.buildpacks.baseos.bionic"
run-image = "${REGISTRY}/baseos-cnb-test/run:bionic"
build-image = "${REGISTRY}/baseos-cnb-test/build:bionic"
```

And my `Makefile`:

```
#!make
SHELL=/bin/bash
REGISTRY?=my.personal.registry.net:7002
PREFIX?=$(REGISTRY)/baseos-cnb-test

build:
  pack create-builder $(PREFIX)/builder:bionic --builder-config <(cat builders/bionic/builder.toml | envsubst) --no-pull --publish $(PACK_FLAGS)
```

Since `pack` currently uses `io.Seek` on the file to scan for warnings first and then parse the TOML second, it can't read from file descriptors that point to pipes.

This PR updates `pack` to scan for warnings and read in the config in a single pass.