### PR TITLE
Error for unsupported flag combo

### DIFF
--- a/internal/commands/create_builder.go
+++ b/internal/commands/create_builder.go
@@ -20,7 +20,7 @@ type CreateBuilderFlags struct {
 
 func (c CreateBuilderFlags) validate() error {
 	if c.Publish && c.NoPull {
-		return errors.Errorf("The --publish and --no-pull flags cannot be used together. There is nothing to pull if you are publishing.")
+		return errors.Errorf("The --publish and --no-pull flags cannot be used together. The --publish flag requires the use of remote images.")
 	}
 	return nil
 }

--- a/internal/commands/create_builder_test.go
+++ b/internal/commands/create_builder_test.go
@@ -53,6 +53,20 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#CreateBuilder", func() {
+		when("both --publish and --no-pull flags are specified", func() {
+			it("errors with a descriptive message", func() {
+				command.SetArgs([]string{
+					"some/builder",
+					"--builder-config", "some-config-path",
+					"--publish",
+					"--no-pull",
+				})
+				err := command.Execute()
+				h.AssertNotNil(t, err)
+				h.AssertError(t, err, "The --publish and --no-pull flags cannot be used together. There is nothing to pull if you are publishing.")
+			})
+		})
+
 		when("warnings encountered in builder.toml", func() {
 			it.Before(func() {
 				h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`

--- a/internal/commands/create_builder_test.go
+++ b/internal/commands/create_builder_test.go
@@ -63,7 +63,7 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 				})
 				err := command.Execute()
 				h.AssertNotNil(t, err)
-				h.AssertError(t, err, "The --publish and --no-pull flags cannot be used together. There is nothing to pull if you are publishing.")
+				h.AssertError(t, err, "The --publish and --no-pull flags cannot be used together. The --publish flag requires the use of remote images.")
 			})
 		})
 

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -21,7 +21,7 @@ type PackageBuildpackFlags struct {
 
 func (p PackageBuildpackFlags) validate() error {
 	if p.Publish && p.NoPull {
-		return errors.Errorf("The --publish and --no-pull flags cannot be used together. There is nothing to pull if you are publishing.")
+		return errors.Errorf("The --publish and --no-pull flags cannot be used together. The --publish flag requires the use of remote images.")
 	}
 	return nil
 }

--- a/internal/commands/package_buildpack_test.go
+++ b/internal/commands/package_buildpack_test.go
@@ -27,6 +27,26 @@ func TestPackageBuildpackCommand(t *testing.T) {
 
 func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 	when("PackageBuildpack#Execute", func() {
+		when("both --publish and --no-pull flags are specified", func() {
+			it("errors with a descriptive message", func() {
+				logger := logging.NewLogWithWriters(&bytes.Buffer{}, &bytes.Buffer{})
+				configReader := fakes.NewFakePackageConfigReader()
+				buildpackPackager := &fakes.FakeBuildpackPackager{}
+
+				command := commands.PackageBuildpack(logger, buildpackPackager, configReader)
+				command.SetArgs([]string{
+					"some-image-name",
+					"--package-config", "/path/to/some/file",
+					"--publish",
+					"--no-pull",
+				})
+
+				err := command.Execute()
+				h.AssertNotNil(t, err)
+				h.AssertError(t, err, "The --publish and --no-pull flags cannot be used together. There is nothing to pull if you are publishing.")
+			})
+		})
+
 		it("reads package config from the configured path", func() {
 			fakePackageConfigReader := fakes.NewFakePackageConfigReader()
 			expectedConfigPath := "/path/to/some/file"

--- a/internal/commands/package_buildpack_test.go
+++ b/internal/commands/package_buildpack_test.go
@@ -43,7 +43,7 @@ func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 
 				err := command.Execute()
 				h.AssertNotNil(t, err)
-				h.AssertError(t, err, "The --publish and --no-pull flags cannot be used together. There is nothing to pull if you are publishing.")
+				h.AssertError(t, err, "The --publish and --no-pull flags cannot be used together. The --publish flag requires the use of remote images.")
 			})
 		})
 


### PR DESCRIPTION
- Error when running `create-bui0lder` and `package-buildpack` with both --no-pull and --publish
- Error with `The --publish and --no-pull flags cannot be used together. There is nothing to pull if you are publishing.`

Signed-off-by: Sukhil Suresh <ssukhil@vmware.com>