### PR TITLE
Warning about default process types

### DIFF
--- a/internal/build/phases.go
+++ b/internal/build/phases.go
@@ -43,10 +43,12 @@ func (l *Lifecycle) Create(ctx context.Context, publish, clearCache bool, runIma
 
 	args = append([]string{"-cache-dir", cacheDir}, args...)
 
-	if l.DefaultProcessType != "" && l.supportsDefaultProcess() {
-		args = append([]string{"-process-type", l.DefaultProcessType}, args...)
-	} else {
-		l.logger.Warn("You specified a default process type but that is not supported by this version of the lifecycle")
+	if l.DefaultProcessType != "" {
+		if l.supportsDefaultProcess() {
+			args = append([]string{"-process-type", l.DefaultProcessType}, args...)
+		} else {
+			l.logger.Warn("You specified a default process type but that is not supported by this version of the lifecycle")
+		}
 	}
 
 	if !publish {
@@ -232,10 +234,12 @@ func (l *Lifecycle) newExport(repoName, runImage string, publish bool, launchCac
 
 	binds := []string{fmt.Sprintf("%s:%s", cacheName, cacheDir)}
 
-	if l.DefaultProcessType != "" && l.supportsDefaultProcess() {
-		args = append([]string{"-process-type", l.DefaultProcessType}, args...)
-	} else {
-		l.logger.Warn("You specified a default process type but that is not supported by this version of the lifecycle")
+	if l.DefaultProcessType != "" {
+		if l.supportsDefaultProcess() {
+			args = append([]string{"-process-type", l.DefaultProcessType}, args...)
+		} else {
+			l.logger.Warn("You specified a default process type but that is not supported by this version of the lifecycle")
+		}
 	}
 
 	if publish {


### PR DESCRIPTION
Don't print a warning if the process-type flag isn't being passed in

Fixes issue #616

Signed-off-by: Yael Harel <yharel@vmware.com>