### PR TITLE
Only show stack mixins if `--verbose` option is given to `inspect-builder`

### DIFF
--- a/internal/commands/inspect_builder_test.go
+++ b/internal/commands/inspect_builder_test.go
@@ -110,11 +110,6 @@ Created By:
 
 Stack:
   ID: test.stack.id
-  Mixins:
-    mixin1
-    mixin2
-    build:mixin3
-    build:mixin4
 
 Lifecycle:
   Version: 6.7.8
@@ -149,11 +144,6 @@ Created By:
 
 Stack:
   ID: test.stack.id
-  Mixins:
-    mixin1
-    mixin2
-    build:mixin3
-    build:mixin4
 
 Lifecycle:
   Version: 4.5.6
@@ -332,6 +322,33 @@ Detection Order:
 					h.AssertContains(t, outBuf.String(), "Inspecting builder: 'some/image'")
 					h.AssertContains(t, outBuf.String(), remoteOutput)
 					h.AssertContains(t, outBuf.String(), localOutput)
+				})
+			})
+
+			when("the logger is verbose", func() {
+				it.Before(func() {
+					logger = ilogging.NewLogWithWriters(&outBuf, &outBuf, ilogging.WithVerbose())
+					command = commands.InspectBuilder(logger, cfg, mockClient)
+
+					cfg.DefaultBuilder = "some/image"
+					mockClient.EXPECT().InspectBuilder("default/builder", false).Return(remoteInfo, nil)
+					mockClient.EXPECT().InspectBuilder("default/builder", true).Return(localInfo, nil)
+					command.SetArgs([]string{})
+				})
+
+				it("displays stack mixins", func() {
+					stackLabels := `
+Stack:
+  ID: test.stack.id
+  Mixins:
+    mixin1
+    mixin2
+    build:mixin3
+    build:mixin4
+`
+
+					h.AssertNil(t, command.Execute())
+					h.AssertContains(t, outBuf.String(), stackLabels)
 				})
 			})
 		})

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -41,6 +41,12 @@ func WithClock(clock func() time.Time) func(writers *LogWithWriters) {
 	}
 }
 
+func WithVerbose() func(writers *LogWithWriters) {
+	return func(logger *LogWithWriters) {
+		logger.Level = log.DebugLevel
+	}
+}
+
 // NewLogWithWriters creates a logger to be used with pack CLI.
 func NewLogWithWriters(stdout, stderr io.Writer, opts ...func(*LogWithWriters)) *LogWithWriters {
 	lw := &LogWithWriters{


### PR DESCRIPTION
Stacks can have hundreds of mixins which makes the current output of `pack inspect-builder` very verbose. Putting the mixins behind the `--verbose` flag makes the output much easier to read.

The verbose flag is grabbed from the logger (which now has a `WithVerbose` option to make testing easier). The alternative would be to call `cmd.Flags().GetBool("verbose")`, which does work fine since the command inherits the `verbose` flag from the root command. But the unit tests create the command without a root command, so the `verbose` flag would have to be redefined on `InspectBuilder` anyway.