### PR TITLE
Fail when using an untrusted builder and no lifecycle image available

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -668,17 +668,55 @@ func testAcceptance(
 					launchCacheVolume.Clear(context.TODO())
 				})
 
+				when("builder is untrusted", func() {
+					var untrustedBuilderName string
+
+					it.Before(func() {
+						untrustedBuilderName = createBuilder(t, runImageMirror, configDir, packCreateBuilderPath, lifecyclePath, lifecycleDescriptor)
+					})
+
+					it.After(func() {
+						h.DockerRmi(dockerCli, untrustedBuilderName)
+					})
+
+					it("uses the 5 phases", func() {
+						output := h.Run(t, subjectPack(
+							"build", repoName,
+							"-p", filepath.Join("testdata", "mock_app"),
+							"-B", untrustedBuilderName,
+						))
+
+						lifecycleImageRequired := packSemver.GreaterThan(semver.MustParse("0.10.0")) || packSemver.Equal(semver.MustParse("0.0.0"))
+						if lifecycleImageRequired {
+							h.AssertContains(t, output, "buildpacksio/lifecycle")
+						}
+						h.AssertContains(t, output, "[detector]")
+						h.AssertContains(t, output, "[analyzer]")
+						h.AssertContains(t, output, "[builder]")
+						h.AssertContains(t, output, "[exporter]")
+						h.AssertContains(t, output, fmt.Sprintf("Successfully built image '%s'", repoName))
+					})
+				})
+
 				when("default builder is set", func() {
-					var creatorSupported bool
+					var usingCreator bool
 
 					it.Before(func() {
 						h.Run(t, subjectPack("set-default-builder", builderName))
+
+						var trustBuilder bool
+						if packSupports(packPath, "trust-builder") {
+							h.Run(t, subjectPack("trust-builder", builderName))
+							trustBuilder = true
+						}
 
 						// Technically the creator is supported as of platform API version 0.3 (lifecycle version 0.7.0+) but earlier versions
 						// have bugs that make using the creator problematic.
 						lifecycleSupportsCreator := !lifecycleDescriptor.Info.Version.LessThan(semver.MustParse("0.7.4"))
 						packSupportsCreator := packSemver.GreaterThan(semver.MustParse("0.10.0")) || packSemver.Equal(semver.MustParse("0.0.0"))
-						creatorSupported = lifecycleSupportsCreator && packSupportsCreator
+						creatorSupported := lifecycleSupportsCreator && packSupportsCreator
+
+						usingCreator = creatorSupported && trustBuilder
 					})
 
 					it("creates a runnable, rebuildable image on daemon from app dir", func() {
@@ -739,7 +777,7 @@ func testAcceptance(
 						assertMockAppRunsWithOutput(t, repoName, "Launch Dep Contents", "Cached Dep Contents")
 
 						t.Log("restores the cache")
-						if creatorSupported {
+						if usingCreator {
 							h.AssertContainsMatch(t, output, `(?i)\[creator] Restoring data for "simple/layers:cached-launch-layer" from cache`)
 							h.AssertContainsMatch(t, output, `(?i)\[creator] Restoring metadata for "simple/layers:cached-launch-layer" from app image`)
 						} else {
@@ -748,14 +786,14 @@ func testAcceptance(
 						}
 
 						t.Log("exporter reuses unchanged layers")
-						if creatorSupported {
+						if usingCreator {
 							h.AssertContainsMatch(t, output, `(?i)\[creator] reusing layer 'simple/layers:cached-launch-layer'`)
 						} else {
 							h.AssertContainsMatch(t, output, `(?i)\[exporter] reusing layer 'simple/layers:cached-launch-layer'`)
 						}
 
 						t.Log("cacher reuses unchanged layers")
-						if creatorSupported {
+						if usingCreator {
 							h.AssertContainsMatch(t, output, `(?i)\[creator] Reusing cache layer 'simple/layers:cached-launch-layer'`)
 						} else {
 							h.AssertContainsMatch(t, output, `(?i)\[exporter] Reusing cache layer 'simple/layers:cached-launch-layer'`)
@@ -766,26 +804,26 @@ func testAcceptance(
 						h.AssertContains(t, output, fmt.Sprintf("Successfully built image '%s'", repoName))
 
 						t.Log("skips restore")
-						if !creatorSupported {
+						if !usingCreator {
 							h.AssertContains(t, output, "Skipping 'restore' due to clearing cache")
 						}
 
 						t.Log("skips buildpack layer analysis")
-						if creatorSupported {
+						if usingCreator {
 							h.AssertContainsMatch(t, output, `(?i)\[creator] Skipping buildpack layer analysis`)
 						} else {
 							h.AssertContainsMatch(t, output, `(?i)\[analyzer] Skipping buildpack layer analysis`)
 						}
 
 						t.Log("exporter reuses unchanged layers")
-						if creatorSupported {
+						if usingCreator {
 							h.AssertContainsMatch(t, output, `(?i)\[creator] Reusing layer 'simple/layers:cached-launch-layer'`)
 						} else {
 							h.AssertContainsMatch(t, output, `(?i)\[exporter] reusing layer 'simple/layers:cached-launch-layer'`)
 						}
 
 						t.Log("cacher adds layers")
-						if creatorSupported {
+						if usingCreator {
 							h.AssertContainsMatch(t, output, `(?i)\[creator] Adding cache layer 'simple/layers:cached-launch-layer'`)
 						} else {
 							h.AssertContainsMatch(t, output, `(?i)\[exporter] Adding cache layer 'simple/layers:cached-launch-layer'`)
@@ -848,7 +886,7 @@ func testAcceptance(
 									"--buildpack", buildpackTgz,
 								))
 
-								if creatorSupported {
+								if usingCreator {
 									h.AssertContains(t, output, "[creator] RESULT: Connected to the internet")
 								} else {
 									h.AssertContains(t, output, "[detector] RESULT: Connected to the internet")
@@ -865,7 +903,7 @@ func testAcceptance(
 									"--buildpack", buildpackTgz,
 								))
 
-								if creatorSupported {
+								if usingCreator {
 									h.AssertContains(t, output, "[creator] RESULT: Connected to the internet")
 								} else {
 									h.AssertContains(t, output, "[detector] RESULT: Connected to the internet")
@@ -887,7 +925,7 @@ func testAcceptance(
 									"none",
 								))
 
-								if creatorSupported {
+								if usingCreator {
 									h.AssertContains(t, output, "[creator] RESULT: Disconnected from the internet")
 								} else {
 									h.AssertContains(t, output, "[detector] RESULT: Disconnected from the internet")
@@ -1264,12 +1302,6 @@ func testAcceptance(
 								"--publish",
 								"--network", "host",
 							))
-
-							// Test builder is untrusted by default. Verify that the 5 phases were used.
-							h.AssertContains(t, output, "[detector]")
-							h.AssertContains(t, output, "[analyzer]") // not checking restorer as it doesn't always run
-							h.AssertContains(t, output, "[builder]")
-							h.AssertContains(t, output, "[exporter]")
 							h.AssertContains(t, output, fmt.Sprintf("Successfully built image '%s'", repoName))
 
 							t.Log("checking that registry has contents")
@@ -1306,65 +1338,6 @@ func testAcceptance(
 								h.AssertEq(t, output, expectedOutput)
 							}
 						})
-
-						when("builder is untrusted", func() {
-							it("uses the 5 phases", func() {
-								var buf bytes.Buffer
-								cmd := subjectPack(
-									"build", repoName,
-									"--builder", builderName, // untrusted by default
-									"-p", filepath.Join("testdata", "mock_app"),
-									"--publish",
-									"--network", "host",
-								)
-
-								cmd.Stdout = &buf
-								cmd.Stderr = &buf
-
-								h.AssertNil(t, cmd.Start())
-
-								go terminateAtStep(t, cmd, &buf, "[detector]")
-								err := cmd.Wait()
-								h.AssertNotNil(t, err)
-
-								h.AssertContains(t, buf.String(), "[detector]")
-							})
-						})
-
-						when("builder is trusted", func() {
-							it("uses the creator (when supported)", func() {
-								h.SkipIf(t, !packSupports(packPath, "build --trust-builder"), "trust-builder not supported")
-
-								var buf bytes.Buffer
-								cmd := subjectPack(
-									"build", repoName,
-									"--builder", builderName, // untrusted by default
-									"-p", filepath.Join("testdata", "mock_app"),
-									"--publish",
-									"--network", "host",
-									"--trust-builder",
-								)
-
-								cmd.Stdout = &buf
-								cmd.Stderr = &buf
-
-								h.AssertNil(t, cmd.Start())
-
-								if creatorSupported {
-									go terminateAtStep(t, cmd, &buf, "[creator]")
-									err := cmd.Wait()
-									h.AssertNotNil(t, err)
-
-									h.AssertContains(t, buf.String(), "[creator]")
-								} else {
-									go terminateAtStep(t, cmd, &buf, "[detector]")
-									err := cmd.Wait()
-									h.AssertNotNil(t, err)
-
-									h.AssertContains(t, buf.String(), "[detector]")
-								}
-							})
-						})
 					})
 
 					when("ctrl+c", func() {
@@ -1377,7 +1350,7 @@ func testAcceptance(
 
 							h.AssertNil(t, cmd.Start())
 
-							if creatorSupported {
+							if usingCreator {
 								go terminateAtStep(t, cmd, &buf, "[creator]")
 							} else {
 								go terminateAtStep(t, cmd, &buf, "[detector]")

--- a/build.go
+++ b/build.go
@@ -173,9 +173,11 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		return c.lifecycle.Execute(ctx, lifecycleOpts)
 	}
 
-	lifecycleImageSupported := !lifecycleVersion.LessThan(semver.MustParse("0.7.5"))
+	lifecycleImageSupported := lifecycleVersion.Equal(builder.VersionMustParse("0.6.1")) || !lifecycleVersion.LessThan(semver.MustParse("0.7.5"))
 	if !lifecycleImageSupported {
-		c.logger.Warnf("Lifecycle %s does not have an associated lifecycle image.", lifecycleVersion.String())
+		if opts.Publish && !opts.TrustBuilder {
+			return errors.Errorf("Lifecycle %s does not have an associated lifecycle image. Builder must be trusted to be used when publishing.", lifecycleVersion.String())
+		}
 	} else {
 		lifecycleImage, err := c.imageFetcher.Fetch(
 			ctx,

--- a/build_test.go
+++ b/build_test.go
@@ -1308,9 +1308,9 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 			when("true", func() {
 				it("uses a remote run image", func() {
 					h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
-						Image:   "some/app",
-						Builder: defaultBuilderName,
-						Publish: true,
+						Image:        "some/app",
+						Builder:      defaultBuilderName,
+						Publish:      true,
 						TrustBuilder: true, // happy path
 					}))
 					h.AssertEq(t, fakeLifecycle.Opts.Publish, true)

--- a/build_test.go
+++ b/build_test.go
@@ -1311,6 +1311,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 						Image:   "some/app",
 						Builder: defaultBuilderName,
 						Publish: true,
+						TrustBuilder: true, // happy path
 					}))
 					h.AssertEq(t, fakeLifecycle.Opts.Publish, true)
 
@@ -1340,20 +1341,13 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					when("lifecycle image is not available", func() {
-						it("uses the 5 phases with the provided builder and warns the user", func() {
-							h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+						it("errors", func() {
+							h.AssertNotNil(t, subject.Build(context.TODO(), BuildOptions{
 								Image:        "some/app",
 								Builder:      defaultBuilderName,
 								Publish:      true,
 								TrustBuilder: false,
 							}))
-							h.AssertEq(t, fakeLifecycle.Opts.UseCreator, false)
-							h.AssertEq(t, fakeLifecycle.Opts.LifecycleImage, defaultBuilderImage.Name())
-
-							args := fakeImageFetcher.FetchCalls[fakeLifecycleImage.Name()]
-							h.AssertNil(t, args)
-
-							h.AssertContains(t, outBuf.String(), "Lifecycle 0.3.0 does not have an associated lifecycle image.")
 						})
 					})
 				})

--- a/build_test.go
+++ b/build_test.go
@@ -41,7 +41,7 @@ import (
 	h "github.com/buildpacks/pack/testhelpers"
 )
 
-const defaultBuilderLifecycleVersion = "0.6.1"
+const defaultBuilderLifecycleVersion = "0.3.0"
 
 func TestBuild(t *testing.T) {
 	color.Disable(true)
@@ -326,7 +326,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 							Lifecycle: builder.LifecycleMetadata{
 								LifecycleInfo: builder.LifecycleInfo{
 									Version: &builder.Version{
-										Version: *semver.MustParse("0.6.1"),
+										Version: *semver.MustParse("0.3.0"),
 									},
 								},
 								API: builder.LifecycleAPI{
@@ -1369,7 +1369,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					when("lifecycle doesn't support creator", func() {
-						// the default test builder (example.com/default/builder:tag) has lifecycle version 0.6.1, so creator is not supported
+						// the default test builder (example.com/default/builder:tag) has lifecycle version 0.3.0, so creator is not supported
 						it("uses the 5 phases with the provided builder", func() {
 							h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
 								Image:        "some/app",
@@ -1421,7 +1421,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				when("lifecycle doesn't support creator", func() {
-					// the default test builder (example.com/default/builder:tag) has lifecycle version 0.6.1, so creator is not supported
+					// the default test builder (example.com/default/builder:tag) has lifecycle version 0.3.0, so creator is not supported
 					it("uses the 5 phases with the provided builder", func() {
 						h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
 							Image:        "some/app",
@@ -1577,7 +1577,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 									Lifecycle: builder.LifecycleMetadata{
 										LifecycleInfo: builder.LifecycleInfo{
 											Version: &builder.Version{
-												Version: *semver.MustParse("0.6.1"),
+												Version: *semver.MustParse("0.3.0"),
 											},
 										},
 										API: builder.LifecycleAPI{
@@ -1626,7 +1626,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 								Lifecycle: builder.LifecycleMetadata{
 									LifecycleInfo: builder.LifecycleInfo{
 										Version: &builder.Version{
-											Version: *semver.MustParse("0.6.1"),
+											Version: *semver.MustParse("0.3.0"),
 										},
 									},
 									API: builder.LifecycleAPI{

--- a/build_test.go
+++ b/build_test.go
@@ -41,7 +41,7 @@ import (
 	h "github.com/buildpacks/pack/testhelpers"
 )
 
-const defaultBuilderLifecycleVersion = "0.3.0"
+const defaultBuilderLifecycleVersion = "0.6.1"
 
 func TestBuild(t *testing.T) {
 	color.Disable(true)
@@ -326,7 +326,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 							Lifecycle: builder.LifecycleMetadata{
 								LifecycleInfo: builder.LifecycleInfo{
 									Version: &builder.Version{
-										Version: *semver.MustParse("0.3.0"),
+										Version: *semver.MustParse("0.6.1"),
 									},
 								},
 								API: builder.LifecycleAPI{
@@ -1369,7 +1369,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					when("lifecycle doesn't support creator", func() {
-						// the default test builder (example.com/default/builder:tag) has lifecycle version 0.3.0, so creator is not supported
+						// the default test builder (example.com/default/builder:tag) has lifecycle version 0.6.1, so creator is not supported
 						it("uses the 5 phases with the provided builder", func() {
 							h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
 								Image:        "some/app",
@@ -1421,7 +1421,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				when("lifecycle doesn't support creator", func() {
-					// the default test builder (example.com/default/builder:tag) has lifecycle version 0.3.0, so creator is not supported
+					// the default test builder (example.com/default/builder:tag) has lifecycle version 0.6.1, so creator is not supported
 					it("uses the 5 phases with the provided builder", func() {
 						h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
 							Image:        "some/app",
@@ -1577,7 +1577,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 									Lifecycle: builder.LifecycleMetadata{
 										LifecycleInfo: builder.LifecycleInfo{
 											Version: &builder.Version{
-												Version: *semver.MustParse("0.3.0"),
+												Version: *semver.MustParse("0.6.1"),
 											},
 										},
 										API: builder.LifecycleAPI{
@@ -1626,7 +1626,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 								Lifecycle: builder.LifecycleMetadata{
 									LifecycleInfo: builder.LifecycleInfo{
 										Version: &builder.Version{
-											Version: *semver.MustParse("0.3.0"),
+											Version: *semver.MustParse("0.6.1"),
 										},
 									},
 									API: builder.LifecycleAPI{

--- a/build_test.go
+++ b/build_test.go
@@ -1308,9 +1308,9 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 			when("true", func() {
 				it("uses a remote run image", func() {
 					h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
-						Image:        "some/app",
-						Builder:      defaultBuilderName,
-						Publish:      true,
+						Image:   "some/app",
+						Builder: defaultBuilderName,
+						Publish: true,
 					}))
 					h.AssertEq(t, fakeLifecycle.Opts.Publish, true)
 


### PR DESCRIPTION
Also consider lifecycle image supported when version is 0.6.1 (this version
of the lifecycle does not require the user to be valid in the image, so a
lifecycle image is possible).

Signed-off-by: Natalie Arellano <narellano@vmware.com>