### PR TITLE
GH actions: auto-merge release branches into master

### DIFF
--- a/.github/workflows/release-merge.yml
+++ b/.github/workflows/release-merge.yml
@@ -1,5 +1,5 @@
 # Merges changes to release branches back into master.
-name: release-sync
+name: release-merge
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
       - 'release/**'
 
 jobs:
-  sync:
+  merge:
     runs-on: ubuntu-latest
     steps:
       - name: Merge

--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -1,0 +1,39 @@
+# Merges changes to release branches back into master.
+name: release-sync
+
+on:
+  push:
+    branches:
+      - 'release/**'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge
+        run: |
+          echo '> Configuring ssh...'
+          SSH_HOME="/root/.ssh"
+          mkdir -p "${SSH_HOME}"
+          chmod 700 "${SSH_HOME}"
+
+          echo '> Starting ssh-agent...'
+          eval $(ssh-agent)
+
+          echo '> Add Github to known_hosts...'
+          ssh-keyscan -H github.com >> "${SSH_HOME}/known_hosts"
+          chmod 644 "${SSH_HOME}/known_hosts"
+
+          echo '> Adding DEPLOY_KEY...'
+          ssh-add - <<< "${{ secrets.DEPLOY_KEY }}"
+
+          echo '> Attempting merge...'
+          ls -al
+          git config --global user.name "github-bot"
+          git config --global user.email "action@github.com"
+          git clone git@github.com:${GITHUB_REPOSITORY}.git
+          cd pack
+          git checkout master
+          git merge origin/${GITHUB_REF#refs/heads/} --no-edit
+          git show -1
+          git push


### PR DESCRIPTION
This new workflow would automatically attempt to merge commits to `release/**` into `master`. This is a common workflow that is currently done manually to ensure that `master` gets any latest fixes that might be introduced in the release branches as part of the "feature complete" phase.

The implementation of this uses SSH deployment keys as oppose to GITHUB_TOKEN to workaround a [constraint](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) imposed on GH actions when using GITHUB_TOKENs:

> When you use the repository's GITHUB_TOKEN to perform tasks on behalf of the GitHub Actions app, events triggered by the GITHUB_TOKEN will not create a new workflow run.