### PR TITLE
Pass --volume options to creator phase

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -965,9 +965,9 @@ func testAcceptance(
 							))
 
 							if packSemver.GreaterThan(semver.MustParse("0.9.0")) || packSemver.Equal(semver.MustParse("0.0.0")) {
-								h.AssertContains(t, output, "Detect: Reading file '/platform/my-volume-mount-target/some-file':")
+								h.AssertContains(t, output, "Detect: Reading file '/platform/my-volume-mount-target/some-file': some-string")
 							}
-							h.AssertContains(t, output, "Build: Reading file '/platform/my-volume-mount-target/some-file':")
+							h.AssertContains(t, output, "Build: Reading file '/platform/my-volume-mount-target/some-file': some-string")
 						})
 					})
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -933,9 +933,16 @@ func testAcceptance(
 						var buildpackTgz, tempVolume string
 
 						it.Before(func() {
+							packVer, err := packVersion(packPath)
+							h.AssertNil(t, err)
+							packSemver := semver.MustParse(strings.TrimPrefix(strings.Split(packVer, " ")[0], "v"))
+							h.SkipIf(t,
+								packSemver.Equal(semver.MustParse("0.11.0")),
+								"pack 0.11.0 shipped with a volume mounting bug",
+							)
+
 							buildpackTgz = h.CreateTGZ(t, filepath.Join(bpDir, "volume-buildpack"), "./", 0755)
 
-							var err error
 							tempVolume, err = ioutil.TempDir("", "my-volume-mount-source")
 							h.AssertNil(t, err)
 							h.AssertNil(t, os.Chmod(tempVolume, 0755)) // Override umask

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -957,10 +957,10 @@ func testAcceptance(
 						})
 
 						it.After(func() {
-							h.AssertNil(t, os.Remove(buildpackTgz))
-							h.AssertNil(t, h.DockerRmi(dockerCli, repoName))
+							_ = os.Remove(buildpackTgz)
+							_ = h.DockerRmi(dockerCli, repoName)
 
-							h.AssertNil(t, os.RemoveAll(tempVolume))
+							_ = os.RemoveAll(tempVolume)
 						})
 
 						it("mounts the provided volume in the detect and build phases", func() {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -127,7 +127,18 @@ func (l *Lifecycle) Execute(ctx context.Context, opts LifecycleOptions) error {
 		return l.Export(ctx, opts.Image.Name(), opts.RunImage, opts.Publish, launchCache.Name(), buildCache.Name(), opts.Network, phaseFactory)
 	}
 
-	return l.Create(ctx, opts.Publish, opts.ClearCache, opts.RunImage, launchCache.Name(), buildCache.Name(), opts.Image.Name(), opts.Network, phaseFactory)
+	return l.Create(
+		ctx,
+		opts.Publish,
+		opts.ClearCache,
+		opts.RunImage,
+		launchCache.Name(),
+		buildCache.Name(),
+		opts.Image.Name(),
+		opts.Network,
+		opts.Volumes,
+		phaseFactory,
+	)
 }
 
 func (l *Lifecycle) Setup(opts LifecycleOptions) {

--- a/internal/build/phases.go
+++ b/internal/build/phases.go
@@ -36,7 +36,12 @@ type PhaseFactory interface {
 	New(provider *PhaseConfigProvider) RunnerCleaner
 }
 
-func (l *Lifecycle) Create(ctx context.Context, publish, clearCache bool, runImage, launchCacheName, cacheName, repoName, networkMode string, phaseFactory PhaseFactory) error {
+func (l *Lifecycle) Create(
+	ctx context.Context,
+	publish, clearCache bool,
+	runImage, launchCacheName, cacheName, repoName, networkMode string,
+	volumes []string,
+	phaseFactory PhaseFactory) error {
 	var configProvider *PhaseConfigProvider
 
 	args := []string{
@@ -44,7 +49,7 @@ func (l *Lifecycle) Create(ctx context.Context, publish, clearCache bool, runIma
 		repoName,
 	}
 
-	binds := []string{fmt.Sprintf("%s:%s", cacheName, cacheDir)}
+	binds := append(volumes, fmt.Sprintf("%s:%s", cacheName, cacheDir))
 
 	if clearCache {
 		args = append([]string{"-skip-restore"}, args...)

--- a/internal/build/phases_test.go
+++ b/internal/build/phases_test.go
@@ -128,30 +128,6 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, configProvider.HostConfig().NetworkMode, container.NetworkMode(expectedNetworkMode))
 		})
 
-		it("configures the phase with both cache binds and custom volume mounts", func() {
-			lifecycle := newTestLifecycle(t, false)
-			fakePhaseFactory := fakes.NewFakePhaseFactory()
-			expectedBind := "some-mount-source:/some-mount-target"
-			expectedBinds := []string{expectedBind, "some-cache:/cache", "some-launch-cache:/launch-cache"}
-
-			err := lifecycle.Create(
-				context.Background(),
-				false,
-				false,
-				"test",
-				"some-launch-cache",
-				"some-cache",
-				"test",
-				"test",
-				[]string{expectedBind},
-				fakePhaseFactory,
-			)
-			h.AssertNil(t, err)
-
-			configProvider := fakePhaseFactory.NewCalledWithProvider
-			h.AssertSliceContains(t, configProvider.HostConfig().Binds, expectedBinds...)
-		})
-
 		when("clear cache", func() {
 			it("configures the phase with the expected arguments", func() {
 				verboseLifecycle := newTestLifecycle(t, true)
@@ -212,7 +188,8 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 			it("configures the phase with binds", func() {
 				lifecycle := newTestLifecycle(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
-				expectedBinds := []string{"some-cache:/cache"}
+				volumeMount := "custom-mount-source:/custom-mount-target"
+				expectedBinds := []string{volumeMount, "some-cache:/cache"}
 
 				err := lifecycle.Create(
 					context.Background(),
@@ -223,7 +200,7 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 					"some-cache",
 					"test",
 					"test",
-					[]string{},
+					[]string{volumeMount},
 					fakePhaseFactory,
 				)
 				h.AssertNil(t, err)
@@ -332,7 +309,8 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 			it("configures the phase with binds", func() {
 				lifecycle := newTestLifecycle(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
-				expectedBinds := []string{"some-cache:/cache", "some-launch-cache:/launch-cache"}
+				volumeMount := "custom-mount-source:/custom-mount-target"
+				expectedBinds := []string{volumeMount, "some-cache:/cache", "some-launch-cache:/launch-cache"}
 
 				err := lifecycle.Create(
 					context.Background(),
@@ -343,7 +321,7 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 					"some-cache",
 					"test",
 					"test",
-					[]string{},
+					[]string{volumeMount},
 					fakePhaseFactory,
 				)
 				h.AssertNil(t, err)

--- a/internal/build/phases_test.go
+++ b/internal/build/phases_test.go
@@ -57,7 +57,18 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 			fakePhase := &fakes.FakePhase{}
 			fakePhaseFactory := fakes.NewFakePhaseFactory(fakes.WhichReturnsForNew(fakePhase))
 
-			err := lifecycle.Create(context.Background(), false, false, "test", "test", "test", "test", "test", fakePhaseFactory)
+			err := lifecycle.Create(
+				context.Background(),
+				false,
+				false,
+				"test",
+				"test",
+				"test",
+				"test",
+				"test",
+				[]string{},
+				fakePhaseFactory,
+			)
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, fakePhase.CleanupCallCount, 1)
@@ -70,7 +81,18 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 			expectedRepoName := "some-repo-name"
 			expectedRunImage := "some-run-image"
 
-			err := verboseLifecycle.Create(context.Background(), false, false, expectedRunImage, "test", "test", expectedRepoName, "test", fakePhaseFactory)
+			err := verboseLifecycle.Create(
+				context.Background(),
+				false,
+				false,
+				expectedRunImage,
+				"test",
+				"test",
+				expectedRepoName,
+				"test",
+				[]string{},
+				fakePhaseFactory,
+			)
 			h.AssertNil(t, err)
 
 			configProvider := fakePhaseFactory.NewCalledWithProvider
@@ -88,11 +110,46 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 			fakePhaseFactory := fakes.NewFakePhaseFactory()
 			expectedNetworkMode := "some-network-mode"
 
-			err := lifecycle.Create(context.Background(), false, false, "test", "test", "test", "test", expectedNetworkMode, fakePhaseFactory)
+			err := lifecycle.Create(
+				context.Background(),
+				false,
+				false,
+				"test",
+				"test",
+				"test",
+				"test",
+				expectedNetworkMode,
+				[]string{},
+				fakePhaseFactory,
+			)
 			h.AssertNil(t, err)
 
 			configProvider := fakePhaseFactory.NewCalledWithProvider
 			h.AssertEq(t, configProvider.HostConfig().NetworkMode, container.NetworkMode(expectedNetworkMode))
+		})
+
+		it("configures the phase with both cache binds and custom volume mounts", func() {
+			lifecycle := newTestLifecycle(t, false)
+			fakePhaseFactory := fakes.NewFakePhaseFactory()
+			expectedBind := "some-mount-source:/some-mount-target"
+			expectedBinds := []string{expectedBind, "some-cache:/cache", "some-launch-cache:/launch-cache"}
+
+			err := lifecycle.Create(
+				context.Background(),
+				false,
+				false,
+				"test",
+				"some-launch-cache",
+				"some-cache",
+				"test",
+				"test",
+				[]string{expectedBind},
+				fakePhaseFactory,
+			)
+			h.AssertNil(t, err)
+
+			configProvider := fakePhaseFactory.NewCalledWithProvider
+			h.AssertSliceContains(t, configProvider.HostConfig().Binds, expectedBinds...)
 		})
 
 		when("clear cache", func() {
@@ -100,7 +157,18 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 				verboseLifecycle := newTestLifecycle(t, true)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := verboseLifecycle.Create(context.Background(), false, true, "test", "test", "test", "test", "test", fakePhaseFactory)
+				err := verboseLifecycle.Create(
+					context.Background(),
+					false,
+					true,
+					"test",
+					"test",
+					"test",
+					"test",
+					"test",
+					[]string{},
+					fakePhaseFactory,
+				)
 				h.AssertNil(t, err)
 
 				configProvider := fakePhaseFactory.NewCalledWithProvider
@@ -117,7 +185,18 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 				verboseLifecycle := newTestLifecycle(t, true)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := verboseLifecycle.Create(context.Background(), false, false, "test", "test", "test", "test", "test", fakePhaseFactory)
+				err := verboseLifecycle.Create(
+					context.Background(),
+					false,
+					false,
+					"test",
+					"test",
+					"test",
+					"test",
+					"test",
+					[]string{},
+					fakePhaseFactory,
+				)
 				h.AssertNil(t, err)
 
 				configProvider := fakePhaseFactory.NewCalledWithProvider
@@ -135,7 +214,18 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedBinds := []string{"some-cache:/cache"}
 
-				err := lifecycle.Create(context.Background(), true, false, "test", "test", "some-cache", "test", "test", fakePhaseFactory)
+				err := lifecycle.Create(
+					context.Background(),
+					true,
+					false,
+					"test",
+					"test",
+					"some-cache",
+					"test",
+					"test",
+					[]string{},
+					fakePhaseFactory,
+				)
 				h.AssertNil(t, err)
 
 				configProvider := fakePhaseFactory.NewCalledWithProvider
@@ -146,7 +236,18 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 				lifecycle := newTestLifecycle(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := lifecycle.Create(context.Background(), true, false, "test", "test", "test", "test", "test", fakePhaseFactory)
+				err := lifecycle.Create(
+					context.Background(),
+					true,
+					false,
+					"test",
+					"test",
+					"test",
+					"test",
+					"test",
+					[]string{},
+					fakePhaseFactory,
+				)
 				h.AssertNil(t, err)
 
 				configProvider := fakePhaseFactory.NewCalledWithProvider
@@ -158,7 +259,18 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedRepos := "some-repo-name"
 
-				err := lifecycle.Create(context.Background(), true, false, "test", "test", "test", expectedRepos, "test", fakePhaseFactory)
+				err := lifecycle.Create(
+					context.Background(),
+					true,
+					false,
+					"test",
+					"test",
+					"test",
+					expectedRepos,
+					"test",
+					[]string{},
+					fakePhaseFactory,
+				)
 				h.AssertNil(t, err)
 
 				configProvider := fakePhaseFactory.NewCalledWithProvider
@@ -171,7 +283,18 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 				verboseLifecycle := newTestLifecycle(t, true)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := verboseLifecycle.Create(context.Background(), false, false, "test", "test", "test", "test", "test", fakePhaseFactory)
+				err := verboseLifecycle.Create(
+					context.Background(),
+					false,
+					false,
+					"test",
+					"test",
+					"test",
+					"test",
+					"test",
+					[]string{},
+					fakePhaseFactory,
+				)
 				h.AssertNil(t, err)
 
 				configProvider := fakePhaseFactory.NewCalledWithProvider
@@ -187,7 +310,18 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 				lifecycle := newTestLifecycle(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := lifecycle.Create(context.Background(), false, false, "test", "some-launch-cache", "some-cache", "test", "test", fakePhaseFactory)
+				err := lifecycle.Create(
+					context.Background(),
+					false,
+					false,
+					"test",
+					"some-launch-cache",
+					"some-cache",
+					"test",
+					"test",
+					[]string{},
+					fakePhaseFactory,
+				)
 				h.AssertNil(t, err)
 
 				configProvider := fakePhaseFactory.NewCalledWithProvider
@@ -200,7 +334,18 @@ func testPhases(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedBinds := []string{"some-cache:/cache", "some-launch-cache:/launch-cache"}
 
-				err := lifecycle.Create(context.Background(), false, false, "test", "some-launch-cache", "some-cache", "test", "test", fakePhaseFactory)
+				err := lifecycle.Create(
+					context.Background(),
+					false,
+					false,
+					"test",
+					"some-launch-cache",
+					"some-cache",
+					"test",
+					"test",
+					[]string{},
+					fakePhaseFactory,
+				)
 				h.AssertNil(t, err)
 
 				configProvider := fakePhaseFactory.NewCalledWithProvider


### PR DESCRIPTION
This resolves a bug where we weren't configuring the `creator` phase with any binds configured with the `--volume` option

Resolves #674

Signed-off-by: Simon Jones <simonjones@vmware.com>