### PR TITLE
Move stack validation from data object

### DIFF
--- a/builder/config_reader.go
+++ b/builder/config_reader.go
@@ -73,22 +73,17 @@ func ReadConfig(path string) (config Config, warnings []string, err error) {
 	return config, warnings, nil
 }
 
-// Validate a Config
-func (c Config) Validate() error {
-	return c.Stack.Validate()
-}
-
-// Validate a StackConfig
-func (s StackConfig) Validate() error {
-	if s.ID == "" {
+// ValidateConfig validates the config
+func ValidateConfig(c Config) error {
+	if c.Stack.ID == "" {
 		return errors.New("stack.id is required")
 	}
 
-	if s.BuildImage == "" {
+	if c.Stack.BuildImage == "" {
 		return errors.New("stack.build-image is required")
 	}
 
-	if s.RunImage == "" {
+	if c.Stack.RunImage == "" {
 		return errors.New("stack.run-image is required")
 	}
 

--- a/builder/config_reader_test.go
+++ b/builder/config_reader_test.go
@@ -160,7 +160,7 @@ uri = "noop-buildpack.tgz"
 		})
 	})
 
-	when("#Stack.Validate()", func() {
+	when("#ValidateConfig()", func() {
 		var (
 			testID         = "testID"
 			testRunImage   = "test-run-image"
@@ -168,27 +168,30 @@ uri = "noop-buildpack.tgz"
 		)
 
 		it("returns error if no id", func() {
-			config := builder.StackConfig{
-				BuildImage: testBuildImage,
-				RunImage:   testRunImage,
-			}
-			h.AssertError(t, config.Validate(), "stack.id is required")
+			config := builder.Config{
+				Stack: builder.StackConfig{
+					BuildImage: testBuildImage,
+					RunImage:   testRunImage,
+				}}
+			h.AssertError(t, builder.ValidateConfig(config), "stack.id is required")
 		})
 
 		it("returns error if no build image", func() {
-			config := builder.StackConfig{
-				ID:       testID,
-				RunImage: testRunImage,
-			}
-			h.AssertError(t, config.Validate(), "stack.build-image is required")
+			config := builder.Config{
+				Stack: builder.StackConfig{
+					ID:       testID,
+					RunImage: testRunImage,
+				}}
+			h.AssertError(t, builder.ValidateConfig(config), "stack.build-image is required")
 		})
 
 		it("returns error if no run image", func() {
-			config := builder.StackConfig{
-				ID:         testID,
-				BuildImage: testBuildImage,
-			}
-			h.AssertError(t, config.Validate(), "stack.run-image is required")
+			config := builder.Config{
+				Stack: builder.StackConfig{
+					ID:         testID,
+					BuildImage: testBuildImage,
+				}}
+			h.AssertError(t, builder.ValidateConfig(config), "stack.run-image is required")
 		})
 	})
 }

--- a/create_builder.go
+++ b/create_builder.go
@@ -49,7 +49,7 @@ func (c *Client) CreateBuilder(ctx context.Context, opts CreateBuilderOptions) e
 }
 
 func (c *Client) validateConfig(ctx context.Context, opts CreateBuilderOptions) error {
-	if err := opts.Config.Validate(); err != nil {
+	if err := pubbldr.ValidateConfig(opts.Config); err != nil {
 		return errors.Wrap(err, "invalid builder config")
 	}
 


### PR DESCRIPTION
In an earlier PR, validation of the StackConfig was made a func on StackConfig. One of the reviewers noted that that wasn't the best practice, given that we like to separate data and function (https://github.com/buildpacks/pack/pull/613#discussion_r425556467). This addresses that comment. 

cc @jromero  

Signed-off-by: David Freilich <dfreilich@vmware.com>