### PR TITLE
GH: Publish to Arch Linux upon release

### DIFF
--- a/.github/workflows/delivery-archlinux-git.yml
+++ b/.github/workflows/delivery-archlinux-git.yml
@@ -1,0 +1,51 @@
+name: delivery / archlinux / git
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  pack-cli-git:
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_NAME: pack-cli-git
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup working dir
+        run: |
+          mkdir -p ${{ env.PACKAGE_NAME }}
+          cp .github/workflows/delivery/archlinux/${{ env.PACKAGE_NAME }}/PKGBUILD ${{ env.PACKAGE_NAME }}/PKGBUILD
+      - name: Metadata
+        id: metadata
+        run: |
+          git_description=$(git describe --tags --long)
+          version=$(echo "${git_description}" | awk -F- '{print $(1)}' | sed 's/^v//')
+          revision=$(echo "${git_description}" | awk -F- '{print $(NF-1)}')
+          commit=$(echo "${git_description}" | awk -F- '{print $(NF)}'  | sed 's/^g//')
+          echo "::set-output name=version::$version"
+          echo "::set-output name=revision::$revision"
+          echo "::set-output name=commit::$commit"
+      - name: Fill PKGBUILD
+        uses: cschleiden/replace-tokens@v1
+        with:
+          files: ${{ env.PACKAGE_NAME }}/PKGBUILD
+          tokenPrefix: '{{'
+          tokenSuffix: '}}'
+        env:
+          PACK_VERSION: ${{ steps.metadata.outputs.version }}
+          GIT_REVISION: ${{ steps.metadata.outputs.revision }}
+          GIT_COMMIT: ${{ steps.metadata.outputs.commit }}
+      - name: Print PKGBUILD
+        run: cat ${{ env.PACKAGE_NAME }}/PKGBUILD
+      - name: Test
+        uses: docker://archlinux:latest
+        with:
+          entrypoint: .github/workflows/delivery/archlinux/test-install-package.sh
+      - name: Publish
+        uses: docker://archlinux:latest
+        env:
+          PACK_VERSION: ${{ steps.metadata.outputs.version }}
+          AUR_KEY: ${{ secrets.AUR_KEY }}
+        with:
+          entrypoint: .github/workflows/delivery/archlinux/publish-package.sh

--- a/.github/workflows/delivery-archlinux.yml
+++ b/.github/workflows/delivery-archlinux.yml
@@ -1,45 +1,35 @@
 name: delivery / archlinux
 
 on:
-  push:
-    branches:
-      - master
-      - 'release/**'
-  pull_request:
-    branches:
-      - master
-      - 'release/**'
+  release:
+    types:
+      - published
 
 jobs:
-  test-pack-cli:
+  pack-cli:
     runs-on: ubuntu-latest
     env:
       PACKAGE_NAME: pack-cli
     steps:
       - uses: actions/checkout@v2
       - name: Determine version
-        run: |
-          [[ $GITHUB_REF =~ ^refs\/heads\/release/(.*)$ ]] && version=${BASH_REMATCH[1]} || version=0.0.0
-          echo "::set-env name=PACK_VERSION::$version"
+        run: echo "::set-env name=PACK_VERSION::`echo ${{ github.event.release.tag_name }} | cut -d "v" -f2`"
         shell: bash
       - name: Setup working dir
         run: |
           mkdir -p ${{ env.PACKAGE_NAME }}
           cp .github/workflows/delivery/archlinux/${{ env.PACKAGE_NAME }}/PKGBUILD ${{ env.PACKAGE_NAME }}/PKGBUILD
-      - name: Package source
-        id: package_source
+      - name: Metadata
+        id: metadata
         run: |
+          url=https://github.com/buildpacks/pack/archive/v${{ env.PACK_VERSION }}.tar.gz
           filename=pack-${{ env.PACK_VERSION }}.tgz
-          fullpath=${{ env.PACKAGE_NAME }}/$filename
-          tar czvf $fullpath --exclude='./.git/*' --exclude="./${{ env.PACKAGE_NAME }}/*" . --transform s/^\./pack-${{ env.PACK_VERSION }}/
+          fullpath=`pwd`/$filename
 
-          # debug info
-          ls -al $fullpath
-          sha512sum $fullpath
-          
-          sha=$(sha512sum $fullpath | awk '{ print $1 }')
-          echo "::set-output name=sha::$sha"
-          echo "::set-output name=filename::$filename"
+          curl -sSL "$url" -o "$fullpath"
+          sha512=$(sha512sum "$fullpath" | awk '{ print $1 }')
+          echo "::set-output name=url::$url"
+          echo "::set-output name=sha512::$sha512"
       - name: Fill PKGBUILD
         uses: cschleiden/replace-tokens@v1
         with:
@@ -48,15 +38,21 @@ jobs:
           tokenSuffix: '}}'
         env:
           PACK_VERSION: ${{ env.PACK_VERSION }}
-          SRC_TGZ_URL: ${{ steps.package_source.outputs.filename }}
-          SRC_TGZ_SHA: ${{ steps.package_source.outputs.sha }}
+          SRC_TGZ_URL: ${{ steps.metadata.outputs.url }}
+          SRC_TGZ_SHA: ${{ steps.metadata.outputs.sha512 }}
       - name: Print PKGBUILD
         run: cat ${{ env.PACKAGE_NAME }}/PKGBUILD
       - name: Test
         uses: docker://archlinux:latest
         with:
           entrypoint: .github/workflows/delivery/archlinux/test-install-package.sh
-  test-pack-cli-bin:
+      - name: Publish
+        uses: docker://archlinux:latest
+        env:
+          AUR_KEY: ${{ secrets.AUR_KEY }}
+        with:
+          entrypoint: .github/workflows/delivery/archlinux/publish-package.sh
+  pack-cli-bin:
     runs-on: ubuntu-latest
     env:
       PACKAGE_NAME: pack-cli-bin

--- a/.github/workflows/delivery-archlinux.yml
+++ b/.github/workflows/delivery-archlinux.yml
@@ -59,41 +59,32 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Determine version
-        run: |
-          [[ $GITHUB_REF =~ ^refs\/heads\/release/(.*)$ ]] && version=${BASH_REMATCH[1]} || version=0.0.0
-          echo "::set-env name=PACK_VERSION::$version"
+        run: echo "::set-env name=PACK_VERSION::`echo ${{ github.event.release.tag_name }} | cut -d "v" -f2`"
         shell: bash
-      - name: Set up go
-        uses: actions/setup-go@v2-beta
-        with:
-          go-version: '1.14'
-      - name: Set up go env
-        run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
-      - name: Build and Package
-        run: make build package
-        env:
-          PACK_BUILD: ${{ github.run_number }}
       - name: Setup working dir
         run: |
           mkdir -p ${{ env.PACKAGE_NAME }}/
           cp .github/workflows/delivery/archlinux/${{ env.PACKAGE_NAME }}/PKGBUILD ${{ env.PACKAGE_NAME }}/PKGBUILD
-      - name: Package bin
-        id: package_bin
+          
+      - name: Lookup assets
+        uses: actions/github-script@v1
+        id: assets
+        with:
+          script: |
+            context.payload.release.assets.forEach(asset => {
+              if (asset.name.includes("linux")) {
+                core.setOutput("linux_name", asset.name);
+                core.setOutput("linux_url", asset.browser_download_url);
+              }
+            });
+      - name: Metadata
+        id: metadata
         run: |
-          filename=pack-${{ env.PACK_VERSION }}.tgz
-          fullpath=${{ env.PACKAGE_NAME }}/$filename
+          curl -sSL ${{ steps.assets.outputs.linux_url }} -o ${{ steps.assets.outputs.linux_name }}
+          sha512=$(sha512sum ${{ steps.assets.outputs.linux_name }} | cut -d ' ' -f1)
 
-          mv ./out/*.tgz $fullpath
-
-          # debug info
-          ls -al $fullpath
-          sha512sum $fullpath
-
-          sha=$(sha512sum $fullpath | awk '{ print $1 }')
-          echo "::set-output name=sha::$sha"
-          echo "::set-output name=filename::$filename"
+          echo "::set-output name=url::${{ steps.assets.outputs.linux_url }}"
+          echo "::set-output name=sha512::$sha512"
       - name: Fill PKGBUILD
         uses: cschleiden/replace-tokens@v1
         with:
@@ -102,11 +93,17 @@ jobs:
           tokenSuffix: '}}'
         env:
           PACK_VERSION: ${{ env.PACK_VERSION }}
-          BIN_TGZ_URL: ${{ steps.package_bin.outputs.filename }}
-          BIN_TGZ_SHA: ${{ steps.package_bin.outputs.sha }}
+          BIN_TGZ_URL: ${{ steps.metadata.outputs.url }}
+          BIN_TGZ_SHA: ${{ steps.metadata.outputs.sha512 }}
       - name: Print PKGBUILD
         run: cat ${{ env.PACKAGE_NAME }}/PKGBUILD
       - name: Test
         uses: docker://archlinux:latest
         with:
           entrypoint: .github/workflows/delivery/archlinux/test-install-package.sh
+      - name: Publish
+        uses: docker://archlinux:latest
+        env:
+          AUR_KEY: ${{ secrets.AUR_KEY }}
+        with:
+          entrypoint: .github/workflows/delivery/archlinux/publish-package.sh

--- a/.github/workflows/delivery/archlinux/README.md
+++ b/.github/workflows/delivery/archlinux/README.md
@@ -15,8 +15,7 @@ The following depicts the current state of automation:
 | ---          | ---    | ---         |
 | pack-cli     | yes    | yes         |
 | pack-cli-bin | yes    | yes         |
-| pack-cli-git | no     | no          |
-
+| pack-cli-git | yes    | yes         |
 
 ## Run Locally
 
@@ -29,5 +28,8 @@ docker pull archlinux:latest
 export GITHUB_TOKEN="<YOUR_GH_TOKEN>"
 export AUR_KEY="<AUR_KEY>"
 
-act -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -j pack-cli-bin -e .github/workflows/testdata/event-release.json -s GITHUB_TOKEN -s AUR_KEY
+act -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 \
+    -e .github/workflows/testdata/event-release.json \
+    -s GITHUB_TOKEN -s AUR_KEY \
+    -j <JOB_NAME>
 ```

--- a/.github/workflows/delivery/archlinux/README.md
+++ b/.github/workflows/delivery/archlinux/README.md
@@ -13,6 +13,21 @@ The following depicts the current state of automation:
 
 | package      | tested | distributed |
 | ---          | ---    | ---         |
-| pack-cli     | yes    | no          |
-| pack-cli-bin | yes    | no          |
+| pack-cli     | yes    | yes         |
+| pack-cli-bin | yes    | yes         |
 | pack-cli-git | no     | no          |
+
+
+## Run Locally
+
+> **CAUTION:** This makes changes directly to the published packages. To prevent changes, comment out `git push` in `publish-package.sh`.
+
+```shell script
+docker pull nektos/act-environments-ubuntu:18.04
+docker pull archlinux:latest
+
+export GITHUB_TOKEN="<YOUR_GH_TOKEN>"
+export AUR_KEY="<AUR_KEY>"
+
+act -P ubuntu-latest=nektos/act-environments-ubuntu:18.04 -j pack-cli-bin -e .github/workflows/testdata/event-release.json -s GITHUB_TOKEN -s AUR_KEY
+```

--- a/.github/workflows/delivery/archlinux/pack-cli-bin/PKGBUILD
+++ b/.github/workflows/delivery/archlinux/pack-cli-bin/PKGBUILD
@@ -7,7 +7,6 @@ pkgdesc="CLI for building apps using Cloud Native Buildpacks"
 arch=('x86_64')
 url="https://buildpacks.io/"
 license=('Apache')
-depends=('docker')
 provides=('pack-cli')
 conflicts=('pack-cli')
 source=("{{BIN_TGZ_URL}}")

--- a/.github/workflows/delivery/archlinux/pack-cli-git/PKGBUILD
+++ b/.github/workflows/delivery/archlinux/pack-cli-git/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: Michael William Le Nguyen <michael at mail dot ttp dot codes>
+# Maintainer: Buildpacks Maintainers <cncf-buildpacks-maintainers at lists dot cncf dot io>
+pkgname=pack-cli-git
+pkgver={{PACK_VERSION}}+r{{GIT_REVISION}}.g{{GIT_COMMIT}}
+pkgrel=1
+pkgdesc="CLI for building apps using Cloud Native Buildpacks"
+arch=('x86_64')
+url="https://buildpacks.io/"
+license=('Apache')
+makedepends=(
+	'git'
+	'go-pie'
+)
+provides=('pack-cli')
+conflicts=('pack-cli')
+source=("${pkgname}::git+https://github.com/buildpacks/pack")
+sha512sums=("SKIP")
+build() {
+	export GOPATH="${srcdir}/go"
+	cd "${srcdir}/${pkgname}"
+	PACK_VERSION={{PACK_VERSION}} make build
+}
+package() {
+	export GOPATH="${srcdir}/go"
+	go clean -modcache
+	install -D -m755 "${srcdir}/${pkgname}/out/pack" "${pkgdir}/usr/bin/pack"
+}

--- a/.github/workflows/delivery/archlinux/pack-cli/PKGBUILD
+++ b/.github/workflows/delivery/archlinux/pack-cli/PKGBUILD
@@ -7,7 +7,6 @@ pkgdesc="CLI for building apps using Cloud Native Buildpacks"
 arch=('x86_64')
 url="https://buildpacks.io/"
 license=('Apache')
-depends=('docker')
 makedepends=('go-pie')
 source=("{{SRC_TGZ_URL}}")
 sha512sums=("{{SRC_TGZ_SHA}}")
@@ -15,12 +14,6 @@ build() {
 	export GOPATH="${srcdir}/go"
 	cd "${srcdir}/pack-${pkgver}"
 	PACK_VERSION="v${pkgver}" make build
-}
-check() {
-	export GOPATH="${srcdir}/go"
-	export PATH="$PATH:${srcdir}/go/bin"
-	cd "${srcdir}/pack-${pkgver}"
-	make verify
 }
 package() {
 	export GOPATH="${srcdir}/go"

--- a/.github/workflows/delivery/archlinux/publish-package.sh
+++ b/.github/workflows/delivery/archlinux/publish-package.sh
@@ -37,7 +37,6 @@ echo '> Adding AUR_KEY...'
 ssh-add - <<< "$AUR_KEY"
 
 echo '> Cloning aur...'
-rm -rf "${PACKAGE_AUR_DIR}" # TODO: Remove
 git clone "ssh://aur@aur.archlinux.org/${PACKAGE_NAME}.git" "${PACKAGE_AUR_DIR}"
 chown -R archie "${PACKAGE_AUR_DIR}"
 pushd "${PACKAGE_AUR_DIR}" > /dev/null
@@ -54,6 +53,6 @@ pushd "${PACKAGE_AUR_DIR}" > /dev/null
   git diff --color | cat
   git add .
   git commit -m "Version ${PACK_VERSION}"
-  #git push
+  git push
 
 popd > /dev/null

--- a/.github/workflows/delivery/archlinux/publish-package.sh
+++ b/.github/workflows/delivery/archlinux/publish-package.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -e
+set -u
+
+# ensure variable is set
+: "$PACK_VERSION"
+: "$PACKAGE_NAME"
+: "$AUR_KEY"
+: "$GITHUB_WORKSPACE"
+
+PACKAGE_DIR="${GITHUB_WORKSPACE}/${PACKAGE_NAME}"
+PACKAGE_AUR_DIR="${GITHUB_WORKSPACE}/${PACKAGE_NAME}-aur"
+
+# setup non-root user
+useradd -m archie
+
+# add non-root user to sudoers
+pacman -Sy --noconfirm sudo
+echo 'archie ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+echo '> Install dependencies'
+pacman -Sy --noconfirm git openssh base-devel libffi
+
+echo '> Configuring ssh...'
+SSH_HOME="/root/.ssh"
+mkdir -p "${SSH_HOME}"
+chmod 700 "${SSH_HOME}"
+
+echo '> Starting ssh-agent...'
+eval $(ssh-agent)
+
+echo '> Add Github to known_hosts...'
+ssh-keyscan -H aur.archlinux.org >> "${SSH_HOME}/known_hosts"
+chmod 644 "${SSH_HOME}/known_hosts"
+
+echo '> Adding AUR_KEY...'
+ssh-add - <<< "$AUR_KEY"
+
+echo '> Cloning aur...'
+rm -rf "${PACKAGE_AUR_DIR}" # TODO: Remove
+git clone "ssh://aur@aur.archlinux.org/${PACKAGE_NAME}.git" "${PACKAGE_AUR_DIR}"
+chown -R archie "${PACKAGE_AUR_DIR}"
+pushd "${PACKAGE_AUR_DIR}" > /dev/null
+  
+  echo '> Applying changes...'
+  rm -rf ./*
+  cp -R "${PACKAGE_DIR}"/* ./
+  
+  su archie -c "makepkg --printsrcinfo" > .SRCINFO  
+  
+  echo '> Commiting changes...'
+  git config --global user.name "github-bot"
+  git config --global user.email "action@github.com"
+  git diff --color | cat
+  git add .
+  git commit -m "Version ${PACK_VERSION}"
+  #git push
+
+popd > /dev/null

--- a/.github/workflows/delivery/archlinux/test-install-package.sh
+++ b/.github/workflows/delivery/archlinux/test-install-package.sh
@@ -21,14 +21,18 @@ chown -R archie "$WORKSPACE"
 # run everything else as non-root user
 pushd "$WORKSPACE" > /dev/null
 su archie << "EOF"
-# debug info
+echo -n '> Debug info:'
 ls -al
 sha512sum ./*
 
-# setup AUR packaging deps
+echo -n '> Installing AUR packaging deps...'
 sudo pacman -Sy --noconfirm git base-devel libffi
 
-# install package
+echo -n '> Installing package...'
 makepkg -sri --noconfirm
+
+# print version
+echo -n '> Installed pack version: '
+pack --version
 EOF
-popd
+popd > /dev/null

--- a/.github/workflows/delivery/archlinux/test-install-package.sh
+++ b/.github/workflows/delivery/archlinux/test-install-package.sh
@@ -13,14 +13,14 @@ useradd -m archie
 pacman -Sy --noconfirm sudo
 echo 'archie ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# run everything else as non-root user
-su archie << "EOF"
 # setup workspace
-WORKSPACE=$GITHUB_WORKSPACE/$PACKAGE_NAME
-sudo chown -R archie $WORKSPACE
-sudo chmod -R +w $WORKSPACE
-cd $WORKSPACE
+WORKSPACE=$(mktemp -d -t "$PACKAGE_NAME-XXXXXXXXXX")
+cp -R "$GITHUB_WORKSPACE/$PACKAGE_NAME/"* "$WORKSPACE"
+chown -R archie "$WORKSPACE"
 
+# run everything else as non-root user
+pushd "$WORKSPACE" > /dev/null
+su archie << "EOF"
 # debug info
 ls -al
 sha512sum ./*
@@ -31,3 +31,4 @@ sudo pacman -Sy --noconfirm git base-devel libffi
 # install package
 makepkg -sri --noconfirm
 EOF
+popd

--- a/.github/workflows/delivery/archlinux/test-install-package.sh
+++ b/.github/workflows/delivery/archlinux/test-install-package.sh
@@ -4,6 +4,7 @@ set -u
 
 # ensure variable is set
 : "$PACKAGE_NAME"
+: "$GITHUB_WORKSPACE"
 
 # setup non-root user
 useradd -m archie

--- a/.github/workflows/testdata/event-release.json
+++ b/.github/workflows/testdata/event-release.json
@@ -1,15 +1,15 @@
 {
   "action": "published",
   "release": {
-    "url": "https://api.github.com/repos/buildpacks/pack/releases/25508391",
-    "assets_url": "https://api.github.com/repos/buildpacks/pack/releases/25508391/assets",
-    "upload_url": "https://uploads.github.com/repos/buildpacks/pack/releases/25508391/assets{?name,label}",
-    "html_url": "https://github.com/buildpacks/pack/releases/tag/v0.10.0",
-    "id": 25508391,
-    "node_id": "MDc6UmVsZWFzZTI1NTA4Mzkx",
-    "tag_name": "v0.10.0",
-    "target_commitish": "release/0.10.0",
-    "name": "pack v0.10.0",
+    "url": "https://api.github.com/repos/buildpacks/pack/releases/26958076",
+    "assets_url": "https://api.github.com/repos/buildpacks/pack/releases/26958076/assets",
+    "upload_url": "https://uploads.github.com/repos/buildpacks/pack/releases/26958076/assets{?name,label}",
+    "html_url": "https://github.com/buildpacks/pack/releases/tag/v0.11.0",
+    "id": 26958076,
+    "node_id": "MDc6UmVsZWFzZTI2OTU4MDc2",
+    "tag_name": "v0.11.0",
+    "target_commitish": "release/0.11.0",
+    "name": "pack v0.11.0",
     "draft": false,
     "author": {
       "login": "github-actions[bot]",
@@ -32,14 +32,14 @@
       "site_admin": false
     },
     "prerelease": false,
-    "created_at": "2020-04-14T23:22:54Z",
-    "published_at": "2020-04-15T14:51:31Z",
+    "created_at": "2020-05-27T17:51:17Z",
+    "published_at": "2020-05-27T20:32:39Z",
     "assets": [
       {
-        "url": "https://api.github.com/repos/buildpacks/pack/releases/assets/19804529",
-        "id": 19804529,
-        "node_id": "MDEyOlJlbGVhc2VBc3NldDE5ODA0NTI5",
-        "name": "pack-v0.10.0-linux.tgz",
+        "url": "https://api.github.com/repos/buildpacks/pack/releases/assets/21112685",
+        "id": 21112685,
+        "node_id": "MDEyOlJlbGVhc2VBc3NldDIxMTEyNjg1",
+        "name": "pack-v0.11.0-linux.tgz",
         "label": "",
         "uploader": {
           "login": "github-actions[bot]",
@@ -63,17 +63,17 @@
         },
         "content_type": "application/gzip",
         "state": "uploaded",
-        "size": 4688798,
-        "download_count": 608,
-        "created_at": "2020-04-14T23:39:14Z",
-        "updated_at": "2020-04-14T23:39:14Z",
-        "browser_download_url": "https://github.com/buildpacks/pack/releases/download/v0.10.0/pack-v0.10.0-linux.tgz"
+        "size": 6043552,
+        "download_count": 363,
+        "created_at": "2020-05-27T17:58:35Z",
+        "updated_at": "2020-05-27T17:58:35Z",
+        "browser_download_url": "https://github.com/buildpacks/pack/releases/download/v0.11.0/pack-v0.11.0-linux.tgz"
       },
       {
-        "url": "https://api.github.com/repos/buildpacks/pack/releases/assets/19804528",
-        "id": 19804528,
-        "node_id": "MDEyOlJlbGVhc2VBc3NldDE5ODA0NTI4",
-        "name": "pack-v0.10.0-macos.tgz",
+        "url": "https://api.github.com/repos/buildpacks/pack/releases/assets/21112684",
+        "id": 21112684,
+        "node_id": "MDEyOlJlbGVhc2VBc3NldDIxMTEyNjg0",
+        "name": "pack-v0.11.0-macos.tgz",
         "label": "",
         "uploader": {
           "login": "github-actions[bot]",
@@ -97,17 +97,17 @@
         },
         "content_type": "application/gzip",
         "state": "uploaded",
-        "size": 4880023,
-        "download_count": 594,
-        "created_at": "2020-04-14T23:39:13Z",
-        "updated_at": "2020-04-14T23:39:14Z",
-        "browser_download_url": "https://github.com/buildpacks/pack/releases/download/v0.10.0/pack-v0.10.0-macos.tgz"
+        "size": 6294528,
+        "download_count": 476,
+        "created_at": "2020-05-27T17:58:34Z",
+        "updated_at": "2020-05-27T17:58:34Z",
+        "browser_download_url": "https://github.com/buildpacks/pack/releases/download/v0.11.0/pack-v0.11.0-macos.tgz"
       },
       {
-        "url": "https://api.github.com/repos/buildpacks/pack/releases/assets/19804530",
-        "id": 19804530,
-        "node_id": "MDEyOlJlbGVhc2VBc3NldDE5ODA0NTMw",
-        "name": "pack-v0.10.0-windows.zip",
+        "url": "https://api.github.com/repos/buildpacks/pack/releases/assets/21112686",
+        "id": 21112686,
+        "node_id": "MDEyOlJlbGVhc2VBc3NldDIxMTEyNjg2",
+        "name": "pack-v0.11.0-windows.zip",
         "label": "",
         "uploader": {
           "login": "github-actions[bot]",
@@ -131,16 +131,16 @@
         },
         "content_type": "application/zip",
         "state": "uploaded",
-        "size": 4699161,
-        "download_count": 91,
-        "created_at": "2020-04-14T23:39:15Z",
-        "updated_at": "2020-04-14T23:39:15Z",
-        "browser_download_url": "https://github.com/buildpacks/pack/releases/download/v0.10.0/pack-v0.10.0-windows.zip"
+        "size": 6069063,
+        "download_count": 90,
+        "created_at": "2020-05-27T17:58:35Z",
+        "updated_at": "2020-05-27T17:58:36Z",
+        "browser_download_url": "https://github.com/buildpacks/pack/releases/download/v0.11.0/pack-v0.11.0-windows.zip"
       }
     ],
-    "tarball_url": "https://api.github.com/repos/buildpacks/pack/tarball/v0.10.0",
-    "zipball_url": "https://api.github.com/repos/buildpacks/pack/zipball/v0.10.0",
-    "body": "# pack v0.10.0\r\n> This is a **beta** release of the Cloud Native Buildpack local CLI. This platform implementation should be relatively stable and reliable, but breaking changes in the underlying [specification](https://github.com/buildpack/spec) may be implemented without notice. Note that pack is intended for local image builds, and thus requires a Docker daemon. The [lifecycle](https://github.com/buildpack/lifecycle) should be used directly when building on cloud platforms.\r\n\r\n## Prerequisites\r\n\r\n- The [Docker daemon](https://www.docker.com/get-started) must be installed on your workstation or accessible over the network.\r\n\r\n## Install\r\n\r\nIf you're on macOS, you can use Homebrew:\r\n\r\n```bash\r\n$ brew install buildpacks/tap/pack\r\n```\r\n\r\nOtherwise:\r\n\r\n1. Download the `.tgz` or `.zip` file for your platform\r\n2. Extract the `pack` binary\r\n3. (Optional) Add the directory containing `pack` to `PATH`, or copy `pack` to a directory like `/usr/local/bin`\r\n\r\n## Run\r\n\r\nRun the command `pack`.\r\n\r\nYou should see the following output\r\n\r\n```text\r\nUsage:\r\n  pack [command]\r\n\r\nAvailable Commands:\r\n  build                 Generate app image from source code\r\n  rebase                Rebase app image with latest run image\r\n  inspect-image         Show information about a built image\r\n  create-builder        Create builder image\r\n  package-buildpack     Package buildpack in OCI format.\r\n  set-run-image-mirrors Set mirrors to other repositories for a given run image\r\n  inspect-builder       Show information about a builder\r\n  set-default-builder   Set default builder used by other commands\r\n  suggest-builders      Display list of recommended builders\r\n  suggest-stacks        Display list of recommended stacks\r\n  version               Show current 'pack' version\r\n  report                Display useful information for reporting an issue\r\n  completion            Outputs completion script location\r\n  help                  Help about any command\r\n\r\nFlags:\r\n  -h, --help         Help for 'pack'\r\n      --no-color     Disable color output\r\n  -q, --quiet        Show less output\r\n      --timestamps   Enable timestamps in output\r\n  -v, --verbose      Show more output\r\n      --version      Show current 'pack' version\r\n\r\nUse \"pack [command] --help\" for more information about a command.\r\n```\r\n\r\n## Info\r\n\r\nBuilders created with this release of the `pack` will  contain [lifecycle v0.7.2](https://github.com/buildpack/lifecycle/releases/tag/v0.7.2) by default.\r\n\r\n## Features\r\n- Volumes provided via `pack build --volume` are now accessible during phase detect. (#526)\r\n- `pack create-package` can output a `.cnb` file via `--format=file`. (#536)\r\n- `pack build --buildpack` supports `.cnb` file.  (#563)\r\n- `pack build` accepts a `--default-process` flag to set the default process type on app image. (#546)\r\n- Include and exclude feature of the `package.toml` extension is now supported. (#511)\r\n- Contents of `builder.toml` for `pack create-builder` are now validated. (#510)\r\n- Added support for buildpack `homepage`. (#506)\r\n\r\n## Improvements\r\n- `pack` binaries are now noticeably smaller. (#527)\r\n\r\n## Fixes\r\n- `pack` will pass new flag `-run-image` instead of `image` to the lifecycle as part of Platform API 0.3. (#560)"
+    "tarball_url": "https://api.github.com/repos/buildpacks/pack/tarball/v0.11.0",
+    "zipball_url": "https://api.github.com/repos/buildpacks/pack/zipball/v0.11.0",
+    "body": "# pack v0.11.0\r\n> This is a **beta** release of the Cloud Native Buildpack local CLI. This platform implementation should be relatively stable and reliable, but breaking changes in the underlying [specification](https://github.com/buildpack/spec) may be implemented without notice. Note that pack is intended for local image builds, and thus requires a Docker daemon. The [lifecycle](https://github.com/buildpack/lifecycle) should be used directly when building on cloud platforms.\r\n\r\n## Prerequisites\r\n\r\n- The [Docker daemon](https://www.docker.com/get-started) must be installed on your workstation or accessible over the network.\r\n\r\n## Install\r\n\r\n#### macOS\r\n\r\nIf you're on macOS, you can use Homebrew:\r\n\r\n```bash\r\n$ brew install buildpacks/tap/pack\r\n```\r\n\r\n#### Linux\r\n\r\nOn Linux you can use the one of the following methods of installation.\r\n\r\n##### Arch Linux\r\n\r\n- [pack-cli](https://aur.archlinux.org/packages/pack-cli/)\r\n- [pack-cli-bin](https://aur.archlinux.org/packages/pack-cli-bin/)\r\n\r\n##### Command\r\n\r\n```bash\r\n(export GH=buildpacks/pack; export LATEST=$(curl -s https://api.github.com/repos/$GH/releases/latest | grep -o -E \"https://.+?-linux.tgz\" | head -1); echo \"$LATEST\"; curl -sSL \"$LATEST\" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv $(basename $GH))\r\n```\r\n\r\n#### Others\r\n\r\nOtherwise:\r\n\r\n1. Download the `.tgz` or `.zip` file for your platform\r\n2. Extract the `pack` binary\r\n3. (Optional) Add the directory containing `pack` to `PATH`, or copy `pack` to a directory like `/usr/local/bin`\r\n\r\n## Run\r\n\r\nRun the command `pack`.\r\n\r\nYou should see the following output\r\n\r\n```text\r\nUsage:\r\n  pack [command]\r\n\r\nAvailable Commands:\r\n  build                 Generate app image from source code\r\n  rebase                Rebase app image with latest run image\r\n  inspect-image         Show information about a built image\r\n  set-run-image-mirrors Set mirrors to other repositories for a given run image\r\n  set-default-builder   Set default builder used by other commands\r\n  inspect-builder       Show information about a builder\r\n  suggest-builders      Display list of recommended builders\r\n  trust-builder         Trust builder\r\n  create-builder        Create builder image\r\n  package-buildpack     Package buildpack in OCI format.\r\n  suggest-stacks        Display list of recommended stacks\r\n  version               Show current 'pack' version\r\n  report                Display useful information for reporting an issue\r\n  completion            Outputs completion script location\r\n  help                  Help about any command\r\n\r\nFlags:\r\n  -h, --help         Help for 'pack'\r\n      --no-color     Disable color output\r\n  -q, --quiet        Show less output\r\n      --timestamps   Enable timestamps in output\r\n  -v, --verbose      Show more output\r\n      --version      Show current 'pack' version\r\n\r\nUse \"pack [command] --help\" for more information about a command.\r\n```\r\n\r\n## Info\r\n\r\nBuilders created with this release of the pack CLI continue to contain [lifecycle v0.7.5](https://github.com/buildpack/lifecycle/releases/tag/v0.7.5) by default.\r\n\r\n## Features\r\n\r\n* Performance and security improvements ([learn more](https://medium.com/buildpacks/faster-more-secure-builds-with-pack-0-11-0-4d0c633ca619))\r\n    * Trusted builders (#634, #644)\r\n    * Run `analyze`, `restore`, and `export` via a trusted lifecycle image (#631)\r\n    * Run `creator` from the lifecycle (#595)\r\n* Hide stack mixins for `inspect-builder` behind `--verbose` option (#630)\r\n* Add `.cnb` file support for `package-buildpack` dependencies (#633)\r\n* Support `.cnb` files in `create-builder` (#611)\r\n* Overwrite permissions in zip files for FAT formatted entries (#598)\r\n* Error when `--publish` and `--no-pull` are used in an unsupported fashion (#594)\r\n* Adds experimental flagging (#576)\r\n* Add Google builder to `suggest-builders` (#637)\r\n* Update `suggest-builders` to use Paketo builders instead of Cloud Foundry builders (#559)\r\n* Support windows containers for `create-builder` [experimental] (#571)\r\n* Support buildpacks from buildpack registry for `create-builder` and `build` [experimental] (#540)\r\n\r\n## Fixes\r\n\r\n* Propagate verbose logging flag to `analyze` and `build` phases (#636)\r\n* `build ... --publish` now respects default process type (#602)\r\n* Support substitution for config files such as from `envsubst` (#592)\r\n* Remove daemon access from `restore` phase (#589)\r\n* `create-builder` can now handle when both `uri` and `image` buildpacks as provided (#625)\r\n\r\n## Breaking Changes\r\n\r\n*  Network mode is now respected for all phases of the lifecycle (#595)\r\n    * This means that publishing (`--publish`) might be impacted if the network mode does not have access to the registry to which the image is being published to. Previously, `analyze` and `export` phases used `host` network mode when publishing and now use the `default` (aka `bridge`) network mode.\r\n    * Related conversations: [Slack](https://buildpacks.slack.com/archives/CJ6B92ZSB/p1586528175087900)\r\n    * Solution:\r\n        * Network mode can be configured via the `--network` flag.\r\n* Builders with lifecycle versions that don't have a published lifecycle image will error (#644)\r\n    * This would only impacts builders that are not trusted.\r\n    * Solutions:\r\n        * Set builder as trusted via `pack trust-builder ...` or pass `--trust-builder` to the `build` command.\r\n        * Update builder to use the latest versions of supported lifecycle versions."
   },
   "repository": {
     "id": 138544269,


### PR DESCRIPTION
Provides full automation of publishing the Arch Linux packages `pack-cli` and `pack-cli-bin` when a new release is published on GitHub.