### PR TITLE
GHA: Fetch all git history to properly describe

### DIFF
--- a/.github/workflows/delivery-archlinux-git.yml
+++ b/.github/workflows/delivery-archlinux-git.yml
@@ -12,6 +12,8 @@ jobs:
       PACKAGE_NAME: pack-cli-git
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup working dir
         run: |
           mkdir -p ${{ env.PACKAGE_NAME }}


### PR DESCRIPTION
`git describe --tags --long` fails without having tags present.