### PR TITLE
Add list-trusted-builders command

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -305,6 +305,35 @@ func testWithoutSpecificBuilderRequirement(
 		})
 	})
 
+	when("list-trusted-builders", func() {
+		it.Before(func() {
+			h.SkipIf(t,
+				!packSupports(packPath, "list-trusted-builders"),
+				"pack does not support 'list-trusted-builders",
+			)
+		})
+
+		it("shows default builders from pack suggest-builders", func() {
+			output := h.Run(t, subjectPack("list-trusted-builders"))
+
+			h.AssertContains(t, output, "Trusted Builders:")
+			h.AssertContains(t, output, "gcr.io/buildpacks/builder")
+			h.AssertContains(t, output, "heroku/buildpacks:18")
+			h.AssertContains(t, output, "gcr.io/paketo-buildpacks/builder:base")
+			h.AssertContains(t, output, "gcr.io/paketo-buildpacks/builder:full-cf")
+			h.AssertContains(t, output, "gcr.io/paketo-buildpacks/builder:tiny")
+		})
+
+		it("shows a builder trusted by pack trust-builder", func() {
+			builderName := "some-builder" + h.RandString(10)
+
+			h.Run(t, subjectPack("trust-builder", builderName))
+
+			output := h.Run(t, subjectPack("list-trusted-builders"))
+			h.AssertContains(t, output, builderName)
+		})
+	})
+
 	when("package-buildpack", func() {
 		var tmpDir string
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -63,6 +63,7 @@ func NewPackCommand(logger *clilogger.LogWithWriters) (*cobra.Command, error) {
 	rootCmd.AddCommand(commands.InspectBuilder(logger, cfg, &packClient))
 	rootCmd.AddCommand(commands.SuggestBuilders(logger, &packClient))
 	rootCmd.AddCommand(commands.TrustBuilder(logger, cfg))
+	rootCmd.AddCommand(commands.ListTrustedBuilders(logger, cfg))
 	rootCmd.AddCommand(commands.CreateBuilder(logger, cfg, &packClient))
 
 	rootCmd.AddCommand(commands.PackageBuildpack(logger, &packClient, buildpackage.NewConfigReader()))

--- a/internal/commands/list_trusted_builders.go
+++ b/internal/commands/list_trusted_builders.go
@@ -27,6 +27,6 @@ func ListTrustedBuilders(logger logging.Logger, cfg config.Config) *cobra.Comman
 		}),
 	}
 
-	AddHelpFlag(cmd, "trust-builder")
+	AddHelpFlag(cmd, "list-trusted-builders")
 	return cmd
 }

--- a/internal/commands/list_trusted_builders.go
+++ b/internal/commands/list_trusted_builders.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"sort"
+
 	"github.com/spf13/cobra"
 
 	"github.com/buildpacks/pack/internal/config"
@@ -15,12 +17,19 @@ func ListTrustedBuilders(logger logging.Logger, cfg config.Config) *cobra.Comman
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			logger.Info("Trusted Builders:")
 
+			var trustedBuilders []string
 			for _, builder := range suggestedBuilders {
-				logger.Infof("  %s", builder.Image)
+				trustedBuilders = append(trustedBuilders, builder.Image)
 			}
 
 			for _, builder := range cfg.TrustedBuilders {
-				logger.Infof("  %s", builder.Name)
+				trustedBuilders = append(trustedBuilders, builder.Name)
+			}
+
+			sort.Strings(trustedBuilders)
+
+			for _, builder := range trustedBuilders {
+				logger.Infof("  %s", builder)
 			}
 
 			return nil

--- a/internal/commands/list_trusted_builders.go
+++ b/internal/commands/list_trusted_builders.go
@@ -1,0 +1,32 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/logging"
+)
+
+func ListTrustedBuilders(logger logging.Logger, cfg config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-trusted-builders",
+		Short: "List Trusted Builders",
+		Long:  "List Trusted Builders.\n\nShow the builders that are either trusted by default or have been explicitly trusted locally using `trust-builder`",
+		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			logger.Info("Trusted Builders:")
+
+			for _, builder := range suggestedBuilders {
+				logger.Infof("  %s", builder.Image)
+			}
+
+			for _, builder := range cfg.TrustedBuilders {
+				logger.Infof("  %s", builder.Name)
+			}
+
+			return nil
+		}),
+	}
+
+	AddHelpFlag(cmd, "trust-builder")
+	return cmd
+}

--- a/internal/commands/list_trusted_builders_test.go
+++ b/internal/commands/list_trusted_builders_test.go
@@ -1,0 +1,93 @@
+package commands_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/buildpacks/pack/internal/config"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/commands"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestListTrustedBuilders(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "Commands", testListTrustedBuildersCommand, spec.Random(), spec.Report(report.Terminal{}))
+}
+
+func testListTrustedBuildersCommand(t *testing.T, when spec.G, it spec.S) {
+	var (
+		command      *cobra.Command
+		logger       logging.Logger
+		outBuf       bytes.Buffer
+		tempPackHome string
+	)
+
+	it.Before(func() {
+		var err error
+
+		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+		command = commands.ListTrustedBuilders(logger, config.Config{})
+
+		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		h.AssertNil(t, err)
+		h.AssertNil(t, os.Setenv("PACK_HOME", tempPackHome))
+	})
+
+	it.After(func() {
+		h.AssertNil(t, os.Unsetenv("PACK_HOME"))
+		h.AssertNil(t, os.RemoveAll(tempPackHome))
+	})
+
+	when("#ListTrustedBuilders", func() {
+		it("succeeds", func() {
+			h.AssertNil(t, command.Execute())
+		})
+
+		it("shows header", func() {
+			h.AssertNil(t, command.Execute())
+
+			h.AssertContains(t, outBuf.String(), "Trusted Builders:")
+		})
+
+		it("shows suggested builders", func() {
+			h.AssertNil(t, command.Execute())
+
+			output := outBuf.String()
+			h.AssertContains(t, output, "gcr.io/buildpacks/builder")
+			h.AssertContains(t, output, "heroku/buildpacks:18")
+			h.AssertContains(t, output, "gcr.io/paketo-buildpacks/builder:base")
+			h.AssertContains(t, output, "gcr.io/paketo-buildpacks/builder:full-cf")
+			h.AssertContains(t, output, "gcr.io/paketo-buildpacks/builder:tiny")
+		})
+
+		it("shows custom builder added as trusted", func() {
+			builderName := "some-builder-" + h.RandString(8)
+
+			h.AssertNil(t, command.Execute())
+			h.AssertNotContains(t, outBuf.String(), builderName)
+
+			listTrustedBuildersCommand := commands.ListTrustedBuilders(
+				logger,
+				config.Config{
+					TrustedBuilders: []config.TrustedBuilder{{Name: builderName}},
+				},
+			)
+
+			outBuf.Reset()
+
+			h.AssertNil(t, listTrustedBuildersCommand.Execute())
+			h.AssertContains(t, outBuf.String(), builderName)
+		})
+	})
+}

--- a/internal/commands/list_trusted_builders_test.go
+++ b/internal/commands/list_trusted_builders_test.go
@@ -60,22 +60,19 @@ func testListTrustedBuildersCommand(t *testing.T, when spec.G, it spec.S) {
 			h.AssertContains(t, outBuf.String(), "Trusted Builders:")
 		})
 
-		it("shows suggested builders", func() {
-			h.AssertNil(t, command.Execute())
-
-			output := outBuf.String()
-			h.AssertContains(t, output, "gcr.io/buildpacks/builder")
-			h.AssertContains(t, output, "heroku/buildpacks:18")
-			h.AssertContains(t, output, "gcr.io/paketo-buildpacks/builder:base")
-			h.AssertContains(t, output, "gcr.io/paketo-buildpacks/builder:full-cf")
-			h.AssertContains(t, output, "gcr.io/paketo-buildpacks/builder:tiny")
-		})
-
-		it("shows custom builder added as trusted", func() {
-			builderName := "some-builder-" + h.RandString(8)
+		it("shows suggested builders and locally trusted builder in alphabetical order", func() {
+			builderName := "great-builder-" + h.RandString(8)
 
 			h.AssertNil(t, command.Execute())
 			h.AssertNotContains(t, outBuf.String(), builderName)
+			h.AssertContainsAllInOrder(t,
+				outBuf,
+				"gcr.io/buildpacks/builder",
+				"gcr.io/paketo-buildpacks/builder:base",
+				"gcr.io/paketo-buildpacks/builder:full-cf",
+				"gcr.io/paketo-buildpacks/builder:tiny",
+				"heroku/buildpacks:18",
+			)
 
 			listTrustedBuildersCommand := commands.ListTrustedBuilders(
 				logger,
@@ -87,7 +84,16 @@ func testListTrustedBuildersCommand(t *testing.T, when spec.G, it spec.S) {
 			outBuf.Reset()
 
 			h.AssertNil(t, listTrustedBuildersCommand.Execute())
-			h.AssertContains(t, outBuf.String(), builderName)
+
+			h.AssertContainsAllInOrder(t,
+				outBuf,
+				"gcr.io/buildpacks/builder",
+				"gcr.io/paketo-buildpacks/builder:base",
+				"gcr.io/paketo-buildpacks/builder:full-cf",
+				"gcr.io/paketo-buildpacks/builder:tiny",
+				builderName,
+				"heroku/buildpacks:18",
+			)
 		})
 	})
 }

--- a/internal/commands/trust_builder_test.go
+++ b/internal/commands/trust_builder_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/heroku/color"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
@@ -28,18 +27,16 @@ func TestTrustBuilder(t *testing.T) {
 
 func testTrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 	var (
-		command        *cobra.Command
-		logger         logging.Logger
-		outBuf         bytes.Buffer
-		mockController *gomock.Controller
-		tempPackHome   string
-		configPath     string
+		command      *cobra.Command
+		logger       logging.Logger
+		outBuf       bytes.Buffer
+		tempPackHome string
+		configPath   string
 	)
 
 	it.Before(func() {
 		var err error
 
-		mockController = gomock.NewController(t)
 		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
 		command = commands.TrustBuilder(logger, config.Config{})
 
@@ -51,7 +48,6 @@ func testTrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it.After(func() {
-		mockController.Finish()
 		h.AssertNil(t, os.Unsetenv("PACK_HOME"))
 		h.AssertNil(t, os.RemoveAll(tempPackHome))
 	})

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -108,6 +108,35 @@ func AssertContains(t *testing.T, actual, expected string) {
 	}
 }
 
+func AssertContainsAllInOrder(t *testing.T, actual bytes.Buffer, expected ...string) {
+	t.Helper()
+
+	var tested []byte
+
+	for _, exp := range expected {
+		b, found := readUntilString(&actual, exp)
+		tested = append(tested, b...)
+
+		if !found {
+			t.Fatalf("Expected '%s' to include all of '%s' in order", string(tested), strings.Join(expected, ", "))
+		}
+	}
+}
+
+func readUntilString(b *bytes.Buffer, expected string) (read []byte, found bool) {
+	for {
+		s, err := b.ReadBytes(expected[len(expected)-1])
+		if err != nil {
+			return append(read, s...), false
+		}
+
+		read = append(read, s...)
+		if bytes.HasSuffix(read, []byte(expected)) {
+			return read, true
+		}
+	}
+}
+
 // AssertContainsMatch matches on content by regular expression
 func AssertContainsMatch(t *testing.T, actual, exp string) {
 	t.Helper()


### PR DESCRIPTION
## Summary
Provide a way for pack users to see which builders are trusted

## Output
```
$ pack list-trusted-builders
Trusted Builders:
  gcr.io/buildpacks/builder
  heroku/buildpacks:18
  gcr.io/paketo-buildpacks/builder:base
  gcr.io/paketo-buildpacks/builder:full-cf
  gcr.io/paketo-buildpacks/builder:tiny

$ pack trust-builder simons-new-builder
Builder simons-new-builder is now trusted

$  ./out/pack list-trusted-builders
Trusted Builders:
  gcr.io/buildpacks/builder
  heroku/buildpacks:18
  gcr.io/paketo-buildpacks/builder:base
  gcr.io/paketo-buildpacks/builder:full-cf
  gcr.io/paketo-buildpacks/builder:tiny
  simons-new-builder
```

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No (I don't think so, it doesn't look like `trust-builder` is documented, so if we want to we should document both

Resolves #567
