### PR TITLE
Add Trusted (Yes/No) output to inspect-builder

### DIFF
--- a/acceptance/testdata/pack_fixtures/inspect_builder_output.txt
+++ b/acceptance/testdata/pack_fixtures/inspect_builder_output.txt
@@ -6,6 +6,8 @@ Created By:
   Name: Pack CLI
   Version: {{.pack_version}}
 
+Trusted: {{.trusted}}
+
 Stack:
   ID: pack.test.stack
   Mixins:
@@ -41,6 +43,8 @@ LOCAL:
 Created By:
   Name: Pack CLI
   Version: {{.pack_version}}
+
+Trusted: {{.trusted}}
 
 Stack:
   ID: pack.test.stack

--- a/internal/commands/inspect_builder.go
+++ b/internal/commands/inspect_builder.go
@@ -111,6 +111,8 @@ Created By:
 
 {{ end -}}
 
+Trusted: {{.Trusted}}
+
 Stack:
   ID: {{ .Info.Stack }}
 {{- if .Verbose}}
@@ -192,18 +194,42 @@ Detection Order:
 		warnings = append(warnings, fmt.Sprintf("%s does not specify lifecycle platform api version", style.Symbol(imageName)))
 	}
 
+	trusted := false
+	for _, builder := range suggestedBuilders {
+		if builder.Image == imageName {
+			trusted = true
+			break
+		}
+	}
+
+	if !trusted {
+		for _, builder := range cfg.TrustedBuilders {
+			if builder.Name == imageName {
+				trusted = true
+				break
+			}
+		}
+	}
+
+	trustedString := "No"
+	if trusted {
+		trustedString = "Yes"
+	}
+
 	return warnings, tpl.Execute(writer, &struct {
 		Info       pack.BuilderInfo
 		Buildpacks string
 		RunImages  string
 		Order      string
 		Verbose    bool
+		Trusted    string
 	}{
 		info,
 		bps,
 		runImgs,
 		order,
 		verbose,
+		trustedString,
 	})
 }
 

--- a/internal/commands/inspect_builder_test.go
+++ b/internal/commands/inspect_builder_test.go
@@ -108,6 +108,8 @@ Created By:
   Name: Pack CLI
   Version: 1.2.3
 
+Trusted: No
+
 Stack:
   ID: test.stack.id
 
@@ -141,6 +143,8 @@ Description: Some local description
 Created By:
   Name: Pack CLI
   Version: 4.5.6
+
+Trusted: No
 
 Stack:
   ID: test.stack.id
@@ -349,6 +353,34 @@ Stack:
 
 					h.AssertNil(t, command.Execute())
 					h.AssertContains(t, outBuf.String(), stackLabels)
+				})
+			})
+
+			when("the builder is suggested", func() {
+				it("indicates that it is trusted", func() {
+					suggestedBuilder := "gcr.io/paketo-buildpacks/builder:tiny"
+
+					command.SetArgs([]string{suggestedBuilder})
+					mockClient.EXPECT().InspectBuilder(suggestedBuilder, false).Return(remoteInfo, nil)
+					mockClient.EXPECT().InspectBuilder(suggestedBuilder, true).Return(nil, nil)
+
+					h.AssertNil(t, command.Execute())
+					h.AssertContains(t, outBuf.String(), "Trusted: Yes")
+				})
+			})
+
+			when("the builder has been trusted by the user", func() {
+				it("indicated that it is trusted", func() {
+					builderName := "trusted/builder"
+					cfg.TrustedBuilders = []config.TrustedBuilder{{Name: builderName}}
+					command = commands.InspectBuilder(logger, cfg, mockClient)
+
+					command.SetArgs([]string{builderName})
+					mockClient.EXPECT().InspectBuilder(builderName, false).Return(remoteInfo, nil)
+					mockClient.EXPECT().InspectBuilder(builderName, true).Return(localInfo, nil)
+
+					h.AssertNil(t, command.Execute())
+					h.AssertContains(t, outBuf.String(), "Trusted: Yes")
 				})
 			})
 		})


### PR DESCRIPTION
Signed-off-by: Simon Jones <simonjones@vmware.com>

## Summary
`pack inspect-builder <builder-name>` now includes an additional output line called `Trusted` that indicates whether `pack` will treat the named builder as *trusted*. In practice right now, this will indicated whether a `pack build` command would use the `creator` lifecycle phase or separate phases.

## Output

#### Before
```
$ pack inspect-builder heroku/buildpacks:18
Inspecting builder: heroku/buildpacks:18

REMOTE:

Created By:
  Name: Pack CLI
  Version: 0.11.1+git-d69a91f.build-644

Stack:
  ID: heroku-18

Lifecycle:
  Version: 0.7.5
  Buildpack API: 0.2
  Platform API: 0.3

Run Images:
  heroku/pack:18

Buildpacks:
  ID                          VERSION        HOMEPAGE
  heroku/maven                0.1
  heroku/jvm                  0.1
  heroku/java                 0.1
  heroku/ruby                 0.0.1
  heroku/procfile             0.5
  heroku/python               0.2
  heroku/gradle               0.2
  heroku/scala                0.2
  heroku/php                  0.2
  heroku/go                   0.2
  heroku/nodejs-engine        0.4.3
  heroku/nodejs-npm           0.1.4
  heroku/nodejs-yarn          0.0.1
  heroku/nodejs               0.1

Detection Order:
  Group #1:
    heroku/ruby
    heroku/procfile    (optional)
  Group #2:
    heroku/python
    heroku/procfile    (optional)
  Group #3:
    heroku/java
  Group #4:
    heroku/scala
    heroku/procfile    (optional)
  Group #5:
    heroku/php
    heroku/procfile    (optional)
  Group #6:
    heroku/go
    heroku/procfile    (optional)
  Group #7:
    heroku/nodejs
LOCAL:
(not present)
```

#### After
```
$  pack inspect-builder heroku/buildpacks:18
Inspecting builder: heroku/buildpacks:18

REMOTE:

Created By:
  Name: Pack CLI
  Version: 0.11.1+git-d69a91f.build-644

Trusted: Yes

Stack:
  ID: heroku-18

Lifecycle:
  Version: 0.7.5
  Buildpack API: 0.2
  Platform API: 0.3

Run Images:
  heroku/pack:18

Buildpacks:
  ID                          VERSION        HOMEPAGE
  heroku/maven                0.1
  heroku/jvm                  0.1
  heroku/java                 0.1
  heroku/ruby                 0.0.1
  heroku/procfile             0.5
  heroku/python               0.2
  heroku/gradle               0.2
  heroku/scala                0.2
  heroku/php                  0.2
  heroku/go                   0.2
  heroku/nodejs-engine        0.4.3
  heroku/nodejs-npm           0.1.4
  heroku/nodejs-yarn          0.0.1
  heroku/nodejs               0.1

Detection Order:
  Group #1:
    heroku/ruby
    heroku/procfile    (optional)
  Group #2:
    heroku/python
    heroku/procfile    (optional)
  Group #3:
    heroku/java
  Group #4:
    heroku/scala
    heroku/procfile    (optional)
  Group #5:
    heroku/php
    heroku/procfile    (optional)
  Group #6:
    heroku/go
    heroku/procfile    (optional)
  Group #7:
    heroku/nodejs

LOCAL:
(not present)
```


## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No - for similar reasons to #693 we haven't opted to document our trusted builder functionality as part of the individual issues

## Related
Unblocks #670 along with #693 

Resolves #669
