### PR TITLE
Add untrust-builder command

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -305,6 +305,25 @@ func testWithoutSpecificBuilderRequirement(
 		})
 	})
 
+	when("untrust-builder", func() {
+		it("removes the previously trusted builder from ~/${PACK_HOME}/config.toml", func() {
+			h.SkipIf(t, !packSupports(packPath, "untrust-builder"), "pack does not support 'untrust-builder'")
+			builderName := "some-builder" + h.RandString(10)
+
+			h.Run(t, subjectPack("trust-builder", builderName))
+
+			packConfigFileContents, err := ioutil.ReadFile(filepath.Join(packHome, "config.toml"))
+			h.AssertNil(t, err)
+			h.AssertContains(t, string(packConfigFileContents), builderName)
+
+			h.Run(t, subjectPack("untrust-builder", builderName))
+
+			packConfigFileContents, err = ioutil.ReadFile(filepath.Join(packHome, "config.toml"))
+			h.AssertNil(t, err)
+			h.AssertNotContains(t, string(packConfigFileContents), builderName)
+		})
+	})
+
 	when("list-trusted-builders", func() {
 		it.Before(func() {
 			h.SkipIf(t,

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -63,6 +63,7 @@ func NewPackCommand(logger *clilogger.LogWithWriters) (*cobra.Command, error) {
 	rootCmd.AddCommand(commands.InspectBuilder(logger, cfg, &packClient))
 	rootCmd.AddCommand(commands.SuggestBuilders(logger, &packClient))
 	rootCmd.AddCommand(commands.TrustBuilder(logger, cfg))
+	rootCmd.AddCommand(commands.UntrustBuilder(logger, cfg))
 	rootCmd.AddCommand(commands.ListTrustedBuilders(logger, cfg))
 	rootCmd.AddCommand(commands.CreateBuilder(logger, cfg, &packClient))
 

--- a/internal/commands/untrust_builder.go
+++ b/internal/commands/untrust_builder.go
@@ -14,13 +14,8 @@ func UntrustBuilder(logger logging.Logger, cfg config.Config) *cobra.Command {
 		Use:   "untrust-builder <builder-name>",
 		Short: "Stop trusting builder",
 		Long:  "Stop trusting builder.\n\nWhen building with this builder, all lifecycle phases will be no longer be run in a single container using the builder image.",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			if len(args) < 1 || args[0] == "" {
-				logger.Infof("Usage:\n\t%s\n", cmd.UseLine())
-				return nil
-			}
-
 			builderName := args[0]
 			existingBuilders := cfg.TrustedBuilders
 			cfg.TrustedBuilders = []config.TrustedBuilder{}

--- a/internal/commands/untrust_builder.go
+++ b/internal/commands/untrust_builder.go
@@ -1,0 +1,56 @@
+package commands
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
+)
+
+func UntrustBuilder(logger logging.Logger, cfg config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "untrust-builder <builder-name>",
+		Short: "Stop trusting builder",
+		Long:  "Stop trusting builder.\n\nWhen building with this builder, all lifecycle phases will be no longer be run in a single container using the builder image.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 || args[0] == "" {
+				logger.Infof("Usage:\n\t%s\n", cmd.UseLine())
+				return nil
+			}
+
+			builderName := args[0]
+			existingBuilders := cfg.TrustedBuilders
+			cfg.TrustedBuilders = []config.TrustedBuilder{}
+			for _, builder := range existingBuilders {
+				if builder.Name == builderName {
+					continue
+				}
+
+				cfg.TrustedBuilders = append(cfg.TrustedBuilders, builder)
+			}
+
+			if len(existingBuilders) == len(cfg.TrustedBuilders) {
+				logger.Infof("Builder %s wasn't trusted", style.Symbol(builderName))
+				return nil
+			}
+
+			configPath, err := config.DefaultConfigPath()
+			if err != nil {
+				return errors.Wrap(err, "getting config path")
+			}
+			err = config.Write(cfg, configPath)
+			if err != nil {
+				return errors.Wrap(err, "writing config file")
+			}
+
+			logger.Infof("Builder %s is no longer trusted", style.Symbol(builderName))
+			return nil
+		}),
+	}
+
+	AddHelpFlag(cmd, "untrust-builder")
+	return cmd
+}

--- a/internal/commands/untrust_builder_test.go
+++ b/internal/commands/untrust_builder_test.go
@@ -59,7 +59,10 @@ func testUntrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 				cfg := configManager.configWithTrustedBuilders()
 				command := commands.UntrustBuilder(logger, cfg)
 				command.SetArgs([]string{})
-				h.AssertNil(t, command.Execute())
+				command.SetOut(&outBuf)
+
+				err := command.Execute()
+				h.AssertError(t, err, "accepts 1 arg(s), received 0")
 				h.AssertContains(t, outBuf.String(), "Usage:")
 			})
 		})

--- a/internal/commands/untrust_builder_test.go
+++ b/internal/commands/untrust_builder_test.go
@@ -1,0 +1,148 @@
+package commands_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildpacks/pack/internal/style"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/commands"
+	"github.com/buildpacks/pack/internal/config"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestUntrustBuilder(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "Commands", testUntrustBuilderCommand, spec.Random(), spec.Report(report.Terminal{}))
+}
+
+func testUntrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
+	var (
+		logger       logging.Logger
+		outBuf       bytes.Buffer
+		tempPackHome string
+		configPath   string
+	)
+
+	it.Before(func() {
+		var err error
+
+		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+
+		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		h.AssertNil(t, err)
+		h.AssertNil(t, os.Setenv("PACK_HOME", tempPackHome))
+
+		configPath = filepath.Join(tempPackHome, "config.toml")
+	})
+
+	it.After(func() {
+		h.AssertNil(t, os.Unsetenv("PACK_HOME"))
+		h.AssertNil(t, os.RemoveAll(tempPackHome))
+	})
+
+	when("#UntrustBuilder", func() {
+		when("no builder is provided", func() {
+			it("prints usage", func() {
+				command := untrustBuilderCommandWithTrustedBuilders(t, logger, configPath)
+				command.SetArgs([]string{})
+				h.AssertNil(t, command.Execute())
+				h.AssertContains(t, outBuf.String(), "Usage:")
+			})
+		})
+
+		when("builder is already trusted", func() {
+			it("removes builder from the config", func() {
+				builderName := "some-builder"
+
+				command := untrustBuilderCommandWithTrustedBuilders(t, logger, configPath, builderName)
+				command.SetArgs([]string{builderName})
+
+				h.AssertNil(t, command.Execute())
+
+				b, err := ioutil.ReadFile(configPath)
+				h.AssertNil(t, err)
+				h.AssertNotContains(t, string(b), builderName)
+
+				h.AssertContains(t,
+					outBuf.String(),
+					fmt.Sprintf("Builder %s is no longer trusted", style.Symbol(builderName)),
+				)
+			})
+
+			it("removes only the named builder when multiple builders are trusted", func() {
+				untrustBuilder := "stop/trusting:me"
+				stillTrustedBuilder := "very/safe/builder"
+
+				command := untrustBuilderCommandWithTrustedBuilders(t,
+					logger,
+					configPath,
+					untrustBuilder,
+					stillTrustedBuilder,
+				)
+				command.SetArgs([]string{untrustBuilder})
+
+				h.AssertNil(t, command.Execute())
+
+				b, err := ioutil.ReadFile(configPath)
+				h.AssertNil(t, err)
+				h.AssertContains(t, string(b), stillTrustedBuilder)
+				h.AssertNotContains(t, string(b), untrustBuilder)
+			})
+		})
+
+		when("builder wasn't already trusted", func() {
+			it("does nothing and reports builder wasn't trusted", func() {
+				neverTrustedBuilder := "never/trusted-builder"
+				stillTrustedBuilder := "very/safe/builder"
+
+				command := untrustBuilderCommandWithTrustedBuilders(t, logger, configPath, stillTrustedBuilder)
+				command.SetArgs([]string{neverTrustedBuilder})
+
+				h.AssertNil(t, command.Execute())
+
+				b, err := ioutil.ReadFile(configPath)
+				h.AssertNil(t, err)
+				h.AssertContains(t, string(b), stillTrustedBuilder)
+				h.AssertNotContains(t, string(b), neverTrustedBuilder)
+
+				h.AssertContains(t,
+					outBuf.String(),
+					fmt.Sprintf("Builder %s wasn't trusted", style.Symbol(neverTrustedBuilder)),
+				)
+			})
+		})
+	})
+}
+
+//nolint:whitespace // A leading line of whitespace is left after a method declaration with multi-line arguments
+func untrustBuilderCommandWithTrustedBuilders(
+	t *testing.T,
+	logger logging.Logger,
+	configPath string,
+	trustedBuilders ...string,
+) *cobra.Command {
+
+	t.Helper()
+
+	cfg := config.Config{}
+	for _, builderName := range trustedBuilders {
+		cfg.TrustedBuilders = append(cfg.TrustedBuilders, config.TrustedBuilder{Name: builderName})
+	}
+	err := config.Write(cfg, configPath)
+	h.AssertNil(t, err)
+
+	return commands.UntrustBuilder(logger, cfg)
+}


### PR DESCRIPTION
Signed-off-by: Simon Jones <simonjones@vmware.com>

## Summary
`pack untrust-builder <builder-name>` will remove the named builder from `pack`'s local configuration for trusted builders, set with `pack trust-builder <builder-name>`

## Output
#### AC1 from #670
```
$  pack trust-builder simons-new-builder
Builder simons-new-builder is now trusted
$  pack list-trusted-builders
Trusted Builders:
  gcr.io/buildpacks/builder
  gcr.io/paketo-buildpacks/builder:base
  gcr.io/paketo-buildpacks/builder:full-cf
  gcr.io/paketo-buildpacks/builder:tiny
  heroku/buildpacks:18
  simons-new-builder
$  pack untrust-builder simons-new-builder
Builder simons-new-builder is no longer trusted
$  pack list-trusted-builders
Trusted Builders:
  gcr.io/buildpacks/builder
  gcr.io/paketo-buildpacks/builder:base
  gcr.io/paketo-buildpacks/builder:full-cf
  gcr.io/paketo-buildpacks/builder:tiny
  heroku/buildpacks:18
```

#### AC2 from #670 - builder must exist
```
$  pack trust-builder simons-new-builder
Builder simons-new-builder is now trusted
$  pack inspect-builder simons-new-builder
Inspecting builder: simons-new-builder
...
Created By:
  Name: Pack CLI
  Version: 0.0.0+git-79d84ba

Trusted: Yes

Stack:
  ID: pack.test.stack
...
$  pack untrust-builder simons-new-builder
Builder simons-new-builder is no longer trusted
$  pack inspect-builder simons-new-builder
Inspecting builder: simons-new-builder
...
Created By:
  Name: Pack CLI
  Version: 0.0.0+git-79d84ba

Trusted: No

Stack:
  ID: pack.test.stack
...
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
Resolves #670
