### PR TITLE
Release Docker Image

### DIFF
--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -1,0 +1,25 @@
+name: delivery / docker
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  deliver-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Determine version
+        run: echo "::set-env name=PACK_VERSION::`echo ${{ github.event.release.tag_name }} | cut -d "v" -f2`"
+        shell: bash
+      - name: Build and Push Image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: cnbs/pack
+          tags: latest, ${{ env.PACK_VERSION }}
+          tag_with_sha: true
+          path: .github/workflows/delivery/docker
+          build_args: PACK_VERSION=${{ env.PACK_VERSION }}

--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -11,15 +11,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Determine version
-        run: echo "::set-env name=PACK_VERSION::`echo ${{ github.event.release.tag_name }} | cut -d "v" -f2`"
+        id: version
         shell: bash
+        run: |
+          echo "::set-output name=VERSION::$(echo ${{ github.event.release.tag_name }} | cut -d "v" -f2)"
       - name: Build and Push Image
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: cnbs/pack
-          tags: latest, ${{ env.PACK_VERSION }}
+          tags: latest, ${{ steps.version.outputs.VERSION }}
           tag_with_sha: true
           path: .github/workflows/delivery/docker
-          build_args: PACK_VERSION=${{ env.PACK_VERSION }}
+          build_args: VERSION=${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -20,8 +20,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: cnbs/pack
-          tags: latest, ${{ steps.version.outputs.VERSION }}
-          tag_with_sha: true
+          repository: buildpacksio/pack
           path: .github/workflows/delivery/docker
           build_args: VERSION=${{ steps.version.outputs.VERSION }}
+          tags: latest, ${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/delivery/docker/Dockerfile
+++ b/.github/workflows/delivery/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.10
+
+ARG PACK_VERSION
+ENV PACK_URL https://github.com/buildpack/pack/releases/download/${PACK_VERSION}/pack-${PACK_VERSION}-linux.tgz
+RUN wget -O- "${PACK_URL}" | tar -C /usr/local/bin -xz pack
+ENTRYPOINT ["/usr/local/bin/pack"]

--- a/.github/workflows/delivery/docker/Dockerfile
+++ b/.github/workflows/delivery/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.10
 
-ARG PACK_VERSION
-ENV PACK_URL https://github.com/buildpack/pack/releases/download/${PACK_VERSION}/pack-${PACK_VERSION}-linux.tgz
+ARG VERSION
+ENV PACK_URL "https://github.com/buildpack/pack/releases/download/v${VERSION}/pack-v${VERSION}-linux.tgz"
 RUN wget -O- "${PACK_URL}" | tar -C /usr/local/bin -xz pack
 ENTRYPOINT ["/usr/local/bin/pack"]


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
This PR adds a Github action to release a `pack` Docker image to `cnbs/pack` on a new release. It currently creates three tags:
* `buildpacksio/pack:0.11.2`
* `buildpacksio/pack:latest`

I ran it, and created the images at `dfreilich/pack:...`
 
## Output
<!-- If applicable, please provide examples of the output changes. -->
`$ act -j deliver-docker -s DOCKER_USERNAME=dfreilich -s DOCKER_PASSWORD=<PWD> -e .github/event.json`
![image](https://user-images.githubusercontent.com/7035673/85479371-06104580-b58c-11ea-876b-6dc5aeef27ad.png)

## Documentation
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #468 
