### PR TITLE
Warns if user is using untrusted builder

### DIFF
--- a/build.go
+++ b/build.go
@@ -192,7 +192,11 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		}
 	}
 
-	return c.lifecycle.Execute(ctx, lifecycleOpts)
+	if err := c.lifecycle.Execute(ctx, lifecycleOpts); err != nil {
+		return errors.Wrap(err, "executing lifecycle. This may be the result of using an untrusted builder")
+	}
+
+	return nil
 }
 
 func (c *Client) processBuilderName(builderName string) (name.Reference, error) {

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -89,21 +89,11 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				}
 			}
 
-			var cfgTrustedBuilder bool
-			for _, trustedBuilder := range cfg.TrustedBuilders {
-				logger.Debugf("Builder %s is trusted", style.Symbol(trustedBuilder.Name))
-				if flags.Builder == trustedBuilder.Name {
-					cfgTrustedBuilder = true
-					break
-				}
-			}
-
-			var suggestedBuilder bool
-			for _, builder := range suggestedBuilders {
-				if flags.Builder == builder.Image {
-					suggestedBuilder = true
-					break
-				}
+			trustBuilder := isTrustedBuilder(cfg, flags.Builder) || flags.TrustBuilder
+			if trustBuilder {
+				logger.Debugf("Builder %s is trusted", style.Symbol(flags.Builder))
+			} else {
+				logger.Warnf("Builder %s is untrusted", style.Symbol(flags.Builder))
 			}
 
 			if err := packClient.Build(cmd.Context(), pack.BuildOptions{
@@ -117,7 +107,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				Publish:           flags.Publish,
 				NoPull:            flags.NoPull,
 				ClearCache:        flags.ClearCache,
-				TrustBuilder:      flags.TrustBuilder || cfgTrustedBuilder || suggestedBuilder,
+				TrustBuilder:      trustBuilder,
 				Buildpacks:        buildpacks,
 				ContainerConfig: pack.ContainerConfig{
 					Network: flags.Network,

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -93,7 +93,10 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 			if trustBuilder {
 				logger.Debugf("Builder %s is trusted", style.Symbol(flags.Builder))
 			} else {
-				logger.Warnf("Builder %s is untrusted", style.Symbol(flags.Builder))
+				logger.Debugf("Builder %s is untrusted", style.Symbol(flags.Builder))
+				logger.Debug("As a result, the phases of the lifecycle which require root access will be run in separate trusted ephemeral containers.")
+				logger.Debug("There may be some issues as a result.")
+				logger.Debug("For more information, see https://github.com/buildpacks/pack/issues/528")
 			}
 
 			if err := packClient.Build(cmd.Context(), pack.BuildOptions{

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -78,6 +78,7 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 					Build(gomock.Any(), EqBuildOptionsWithImage("my-builder", "image")).
 					Return(nil)
 
+				logger.WantVerbose(true)
 				command.SetArgs([]string{"-B", "my-builder", "image"})
 				h.AssertNil(t, command.Execute())
 				h.AssertContains(t, outBuf.String(), "Builder 'my-builder' is untrusted")

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -81,3 +81,19 @@ func getMirrors(config config.Config) map[string][]string {
 	}
 	return mirrors
 }
+
+func isTrustedBuilder(cfg config.Config, builder string) bool {
+	for _, trustedBuilder := range cfg.TrustedBuilders {
+		if builder == trustedBuilder.Name {
+			return true
+		}
+	}
+
+	for _, sugBuilder := range suggestedBuilders {
+		if builder == sugBuilder.Image {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
* Adds error message attributing lifecycle failure in untrusted case to untrusted builder

Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This adds a warning if building with an untrusted builder, so the user understands that there may be some issues with it. This also adds an error if lifecycle execute fails, clarifying that it may be because the builder is untrusted. 

## Output

#### Before
![image](https://user-images.githubusercontent.com/7035673/86178640-a91a0f80-baf6-11ea-9478-9904ebd74f03.png)

#### After
Untrusted Builder: 
![image](https://user-images.githubusercontent.com/7035673/86178743-da92db00-baf6-11ea-8f02-d4cab9d8343f.png)

With `--trust-builder`:
![image](https://user-images.githubusercontent.com/7035673/86178791-f4ccb900-baf6-11ea-8810-0895e537d09c.png)

## Documentation
- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
Resolves #711 
