### PR TITLE
Add warning when building with untrusted builder and volumes

### DIFF
--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -100,7 +100,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 			}
 
 			if !trustBuilder && len(flags.Volumes) > 0 {
-				logger.Warn("Using untrusted builder with volume mounts. If there is sensitive data in the volumes, this may present a security vulnerability")
+				logger.Warn("Using untrusted builder with volume mounts. If there is sensitive data in the volumes, this may present a security vulnerability.")
 			}
 
 			if err := packClient.Build(cmd.Context(), pack.BuildOptions{

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -99,6 +99,10 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				logger.Debug("For more information, see https://github.com/buildpacks/pack/issues/528")
 			}
 
+			if !trustBuilder && len(flags.Volumes) > 0 {
+				logger.Warn("Using untrusted builder with volume mounts. If there is sensitive data in the volumes, this may present a security vulnerability")
+			}
+
 			if err := packClient.Build(cmd.Context(), pack.BuildOptions{
 				AppPath:           flags.AppPath,
 				Builder:           flags.Builder,

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -143,6 +143,16 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 				command.SetArgs([]string{"image", "--builder", "my-builder", "--volume", "a:b", "--volume", "c:d"})
 				h.AssertNil(t, command.Execute())
 			})
+
+			it("warns when running with an untrusted builder", func() {
+				mockClient.EXPECT().
+					Build(gomock.Any(), EqBuildOptionsWithVolumes([]string{"a:b", "c:d"})).
+					Return(nil)
+
+				command.SetArgs([]string{"image", "--builder", "my-builder", "--volume", "a:b", "--volume", "c:d"})
+				h.AssertNil(t, command.Execute())
+				h.AssertContains(t, outBuf.String(), "Warning: Using untrusted builder with volume mounts")
+			})
 		})
 
 		when("a default process is specified", func() {


### PR DESCRIPTION
* Fix 529

Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This adds a warning when running `pack build test -p path -B untrusted-builder --volume a:b`

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### After
![image](https://user-images.githubusercontent.com/7035673/86277065-16d04500-bba4-11ea-9833-2a8e755f13c8.png)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #529 
