### PR TITLE
Explicitly deal with untrusting suggested builder

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -89,11 +89,5 @@ func isTrustedBuilder(cfg config.Config, builder string) bool {
 		}
 	}
 
-	for _, sugBuilder := range suggestedBuilders {
-		if builder == sugBuilder.Image {
-			return true
-		}
-	}
-
-	return false
+	return isSuggestedBuilder(builder)
 }

--- a/internal/commands/suggest_builders.go
+++ b/internal/commands/suggest_builders.go
@@ -115,3 +115,13 @@ func getBuilderDescription(builder SuggestedBuilder, client PackClient) string {
 
 	return builder.DefaultDescription
 }
+
+func isSuggestedBuilder(builder string) bool {
+	for _, sugBuilder := range suggestedBuilders {
+		if builder == sugBuilder.Image {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/commands/untrust_builder_test.go
+++ b/internal/commands/untrust_builder_test.go
@@ -20,7 +20,7 @@ import (
 	h "github.com/buildpacks/pack/testhelpers"
 )
 
-func TestUntrustBuilder(t *testing.T) {
+func TestUntrustBuilderCommand(t *testing.T) {
 	color.Disable(true)
 	defer color.Disable(false)
 	spec.Run(t, "Commands", testUntrustBuilderCommand, spec.Random(), spec.Report(report.Terminal{}))
@@ -124,6 +124,17 @@ func testUntrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 					outBuf.String(),
 					fmt.Sprintf("Builder %s wasn't trusted", style.Symbol(neverTrustedBuilder)),
 				)
+			})
+		})
+
+		when("builder is a suggested builder", func() {
+			it("does nothing and reports that ", func() {
+				builder := "gcr.io/paketo-buildpacks/builder:base"
+				command := commands.UntrustBuilder(logger, config.Config{})
+				command.SetArgs([]string{builder})
+
+				err := command.Execute()
+				h.AssertError(t, err, fmt.Sprintf("Builder %s is a suggested builder, and is trusted by default", style.Symbol(builder)))
 			})
 		})
 	})


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
Currently, we have a few holes in our coverage of trusted builders, due to our implementation decision of having 2 separate slices: one written in the config, and the other our `suggestedBuilders`. This attempts to explicitly deal with one of them: 
- If a user attempts to run `pack untrust-builder <SOME_SUGGESTED_BUILDER>`, it should explicitly tell the user that it's not going to do anything, in order that users don't think it's a bug. Alternatively, if we decide on a course of action to do, I'm happy to drive that in this PR; I just think that leaving the hole open leaves it as an open bug.  

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
This isn't true:
![image](https://user-images.githubusercontent.com/7035673/86298693-56ab2280-bbcc-11ea-82f2-505ce109f301.png)

#### After
This is explicit about the limitation:
![image](https://user-images.githubusercontent.com/7035673/86413258-bec23d00-bc8e-11ea-97fc-dcc5f6b91265.png)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, when we document trust-builders in general

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Relates to https://github.com/buildpacks/pack/issues/670#issuecomment-646019133