### PR TITLE
Combine config.Builder with SuggestedBuilder

### DIFF
--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -90,7 +90,7 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 						Build(gomock.Any(), EqBuildOptionsWithTrustedBuilder(true)).
 						Return(nil)
 
-					cfg := config.Config{TrustedBuilders: []config.TrustedBuilder{{Name: "my-builder"}}}
+					cfg := config.Config{TrustedBuilders: []config.Builder{{Image: "my-builder"}}}
 					command := commands.Build(logger, cfg, mockClient)
 
 					logger.WantVerbose(true)

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -83,14 +83,10 @@ func getMirrors(config config.Config) map[string][]string {
 }
 
 func isTrustedBuilder(cfg config.Config, builder string) bool {
-	for _, trustedBuilder := range cfg.TrustedBuilders {
-		if builder == trustedBuilder.Name {
-			return true
-		}
-	}
+	builders := append(cfg.TrustedBuilders, suggestedBuilders...)
 
-	for _, sugBuilder := range suggestedBuilders {
-		if builder == sugBuilder.Image {
+	for _, trustedBuilder := range builders {
+		if builder == trustedBuilder.Image {
 			return true
 		}
 	}

--- a/internal/commands/inspect_builder.go
+++ b/internal/commands/inspect_builder.go
@@ -194,25 +194,8 @@ Detection Order:
 		warnings = append(warnings, fmt.Sprintf("%s does not specify lifecycle platform api version", style.Symbol(imageName)))
 	}
 
-	trusted := false
-	for _, builder := range suggestedBuilders {
-		if builder.Image == imageName {
-			trusted = true
-			break
-		}
-	}
-
-	if !trusted {
-		for _, builder := range cfg.TrustedBuilders {
-			if builder.Name == imageName {
-				trusted = true
-				break
-			}
-		}
-	}
-
 	trustedString := "No"
-	if trusted {
+	if isTrustedBuilder(cfg, imageName) {
 		trustedString = "Yes"
 	}
 

--- a/internal/commands/inspect_builder_test.go
+++ b/internal/commands/inspect_builder_test.go
@@ -372,7 +372,7 @@ Stack:
 			when("the builder has been trusted by the user", func() {
 				it("indicated that it is trusted", func() {
 					builderName := "trusted/builder"
-					cfg.TrustedBuilders = []config.TrustedBuilder{{Name: builderName}}
+					cfg.TrustedBuilders = []config.Builder{{Image: builderName}}
 					command = commands.InspectBuilder(logger, cfg, mockClient)
 
 					command.SetArgs([]string{builderName})

--- a/internal/commands/list_trusted_builders.go
+++ b/internal/commands/list_trusted_builders.go
@@ -23,7 +23,7 @@ func ListTrustedBuilders(logger logging.Logger, cfg config.Config) *cobra.Comman
 			}
 
 			for _, builder := range cfg.TrustedBuilders {
-				trustedBuilders = append(trustedBuilders, builder.Name)
+				trustedBuilders = append(trustedBuilders, builder.Image)
 			}
 
 			sort.Strings(trustedBuilders)

--- a/internal/commands/list_trusted_builders_test.go
+++ b/internal/commands/list_trusted_builders_test.go
@@ -77,7 +77,7 @@ func testListTrustedBuildersCommand(t *testing.T, when spec.G, it spec.S) {
 			listTrustedBuildersCommand := commands.ListTrustedBuilders(
 				logger,
 				config.Config{
-					TrustedBuilders: []config.TrustedBuilder{{Name: builderName}},
+					TrustedBuilders: []config.Builder{{Image: builderName}},
 				},
 			)
 

--- a/internal/commands/suggest_builders.go
+++ b/internal/commands/suggest_builders.go
@@ -8,17 +8,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/buildpacks/pack/internal/config"
 	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/logging"
 )
 
-type SuggestedBuilder struct {
-	Vendor             string
-	Image              string
-	DefaultDescription string
-}
-
-var suggestedBuilders = []SuggestedBuilder{
+var suggestedBuilders = []config.Builder{
 	{
 		Vendor:             "Google",
 		Image:              "gcr.io/buildpacks/builder:v1",
@@ -72,7 +67,7 @@ func suggestBuilders(logger logging.Logger, client PackClient) {
 	WriteSuggestedBuilder(logger, client, suggestedBuilders)
 }
 
-func WriteSuggestedBuilder(logger logging.Logger, client PackClient, builders []SuggestedBuilder) {
+func WriteSuggestedBuilder(logger logging.Logger, client PackClient, builders []config.Builder) {
 	sort.Slice(builders, func(i, j int) bool {
 		if builders[i].Vendor == builders[j].Vendor {
 			return builders[i].Image < builders[j].Image
@@ -90,7 +85,7 @@ func WriteSuggestedBuilder(logger logging.Logger, client PackClient, builders []
 	for i, builder := range builders {
 		wg.Add(1)
 
-		go func(i int, builder SuggestedBuilder) {
+		go func(i int, builder config.Builder) {
 			descriptions[i] = getBuilderDescription(builder, client)
 			wg.Done()
 		}(i, builder)
@@ -107,7 +102,7 @@ func WriteSuggestedBuilder(logger logging.Logger, client PackClient, builders []
 	logger.Info("\tpack inspect-builder <builder-image>")
 }
 
-func getBuilderDescription(builder SuggestedBuilder, client PackClient) string {
+func getBuilderDescription(builder config.Builder, client PackClient) string {
 	info, err := client.InspectBuilder(builder.Image, false)
 	if err == nil && info.Description != "" {
 		return info.Description

--- a/internal/commands/suggest_builders_test.go
+++ b/internal/commands/suggest_builders_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildpacks/pack"
 	"github.com/buildpacks/pack/internal/commands"
 	"github.com/buildpacks/pack/internal/commands/testmocks"
+	"github.com/buildpacks/pack/internal/config"
 	ilogging "github.com/buildpacks/pack/internal/logging"
 	"github.com/buildpacks/pack/logging"
 	h "github.com/buildpacks/pack/testhelpers"
@@ -47,7 +48,7 @@ func testSuggestBuildersCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("displays descriptions from metadata", func() {
-				commands.WriteSuggestedBuilder(logger, mockClient, []commands.SuggestedBuilder{{
+				commands.WriteSuggestedBuilder(logger, mockClient, []config.Builder{{
 					Vendor:             "Builder",
 					Image:              "gcr.io/some/builder:latest",
 					DefaultDescription: "Default description",
@@ -65,7 +66,7 @@ func testSuggestBuildersCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("displays default descriptions", func() {
-				commands.WriteSuggestedBuilder(logger, mockClient, []commands.SuggestedBuilder{{
+				commands.WriteSuggestedBuilder(logger, mockClient, []config.Builder{{
 					Vendor:             "Builder",
 					Image:              "gcr.io/some/builder:latest",
 					DefaultDescription: "Default description",
@@ -81,7 +82,7 @@ func testSuggestBuildersCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("displays default descriptions", func() {
-				commands.WriteSuggestedBuilder(logger, mockClient, []commands.SuggestedBuilder{{
+				commands.WriteSuggestedBuilder(logger, mockClient, []config.Builder{{
 					Vendor:             "Builder",
 					Image:              "gcr.io/some/builder:latest",
 					DefaultDescription: "Default description",

--- a/internal/commands/trust_builder.go
+++ b/internal/commands/trust_builder.go
@@ -22,7 +22,7 @@ func TrustBuilder(logger logging.Logger, cfg config.Config) *cobra.Command {
 			}
 
 			imageName := args[0]
-			builderToTrust := config.TrustedBuilder{Name: imageName}
+			builderToTrust := config.Builder{Image: imageName}
 
 			for _, builder := range cfg.TrustedBuilders {
 				if builder == builderToTrust {

--- a/internal/commands/trust_builder_test.go
+++ b/internal/commands/trust_builder_test.go
@@ -70,7 +70,7 @@ func testTrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 					b, err := ioutil.ReadFile(configPath)
 					h.AssertNil(t, err)
 					h.AssertContains(t, string(b), `[[trusted-builders]]
-  name = "some-builder"`)
+  image = "some-builder"`)
 				})
 			})
 

--- a/internal/commands/untrust_builder.go
+++ b/internal/commands/untrust_builder.go
@@ -16,19 +16,20 @@ func UntrustBuilder(logger logging.Logger, cfg config.Config) *cobra.Command {
 		Long:  "Stop trusting builder.\n\nWhen building with this builder, all lifecycle phases will be no longer be run in a single container using the builder image.",
 		Args:  cobra.ExactArgs(1),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			builderName := args[0]
+			builder := args[0]
+
 			existingBuilders := cfg.TrustedBuilders
-			cfg.TrustedBuilders = []config.TrustedBuilder{}
-			for _, builder := range existingBuilders {
-				if builder.Name == builderName {
+			cfg.TrustedBuilders = []config.Builder{}
+			for _, trustedBuilder := range existingBuilders {
+				if trustedBuilder.Image == builder {
 					continue
 				}
 
-				cfg.TrustedBuilders = append(cfg.TrustedBuilders, builder)
+				cfg.TrustedBuilders = append(cfg.TrustedBuilders, trustedBuilder)
 			}
 
 			if len(existingBuilders) == len(cfg.TrustedBuilders) {
-				logger.Infof("Builder %s wasn't trusted", style.Symbol(builderName))
+				logger.Infof("Builder %s wasn't trusted", style.Symbol(builder))
 				return nil
 			}
 
@@ -41,7 +42,7 @@ func UntrustBuilder(logger logging.Logger, cfg config.Config) *cobra.Command {
 				return errors.Wrap(err, "writing config file")
 			}
 
-			logger.Infof("Builder %s is no longer trusted", style.Symbol(builderName))
+			logger.Infof("Builder %s is no longer trusted", style.Symbol(builder))
 			return nil
 		}),
 	}

--- a/internal/commands/untrust_builder_test.go
+++ b/internal/commands/untrust_builder_test.go
@@ -146,7 +146,7 @@ func (c configManager) configWithTrustedBuilders(trustedBuilders ...string) conf
 
 	cfg := config.Config{}
 	for _, builderName := range trustedBuilders {
-		cfg.TrustedBuilders = append(cfg.TrustedBuilders, config.TrustedBuilder{Name: builderName})
+		cfg.TrustedBuilders = append(cfg.TrustedBuilders, config.Builder{Image: builderName})
 	}
 	err := config.Write(cfg, c.configPath)
 	h.AssertNil(c.testObject, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,11 +9,11 @@ import (
 )
 
 type Config struct {
-	RunImages       []RunImage       `toml:"run-images"`
-	DefaultBuilder  string           `toml:"default-builder-image,omitempty"`
-	DefaultRegistry string           `toml:"default-registry-url,omitempty"`
-	Experimental    bool             `toml:"experimental,omitempty"`
-	TrustedBuilders []TrustedBuilder `toml:"trusted-builders,omitempty"`
+	RunImages       []RunImage `toml:"run-images"`
+	DefaultBuilder  string     `toml:"default-builder-image,omitempty"`
+	DefaultRegistry string     `toml:"default-registry-url,omitempty"`
+	Experimental    bool       `toml:"experimental,omitempty"`
+	TrustedBuilders []Builder  `toml:"trusted-builders,omitempty"`
 }
 
 type RunImage struct {
@@ -21,8 +21,10 @@ type RunImage struct {
 	Mirrors []string `toml:"mirrors"`
 }
 
-type TrustedBuilder struct {
-	Name string `toml:"name"`
+type Builder struct {
+	Vendor             string `toml:"-"`
+	Image              string `toml:"image"`
+	DefaultDescription string `toml:"-"`
 }
 
 func DefaultConfigPath() (string, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,8 +65,8 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 							Mirrors: []string{"example.com/other/run", "example.com/other/mirror"},
 						},
 					},
-					TrustedBuilders: []config.TrustedBuilder{
-						{Name: "some-trusted-builder"},
+					TrustedBuilders: []config.Builder{
+						{Image: "some-trusted-builder"},
 					},
 				}, configPath))
 				b, err := ioutil.ReadFile(configPath)
@@ -81,7 +81,7 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
   mirrors = ["example.com/other/run", "example.com/other/mirror"]`)
 
 				h.AssertContains(t, string(b), `[[trusted-builders]]
-  name = "some-trusted-builder"`)
+  image = "some-trusted-builder"`)
 			})
 		})
 


### PR DESCRIPTION
* Standardize usage of bulider.Image, to minimize language changes
* Use command.isTrustedBuilder to reduce reused logic
* Collapsed 2 loops in commands.isTrustedBuilder to one

Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
As we haven't yet released a pack that writes `TrustedBuilders` into the config, I wanted to standardize the language in it, to reduce future possible tech debt. As such, I combined the `TrustedBuilder` and `SuggestedBuilder` interfaces into a common `config.Builder` interface, and used `builder.Image` in both cases, rather than having `Image` in one and `Name` in another. 

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

