### PR TITLE
Add docs for release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Get started by running through our tutorial: [An App’s Brief Journey from Sour
 
 - [CONTRIBUTING](CONTRIBUTING.md) - Information on how to contribute, including the pull request process.
 - [DEVELOPMENT](DEVELOPMENT.md) - Further detail to help you during the development process.
-
+- [RELEASE](RELEASE.md) - Further details about our release process.
 
 ## Specifications
 `pack` is a CLI implementation of the [Platform Interface Specification][platform-spec] for [Cloud Native Buildpacks][buildpacks.io].

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,6 +32,6 @@ The [release manager](#release-manager) will:
 
 For more information, see the [release process RFC][release-process]
 
-[maintainers]: @buildpacks/platform-mainters
+[maintainers]: https://github.com/buildpacks/community/blob/main/TEAMS.md#platform-team
 [release-process]: https://github.com/buildpacks/rfcs/blob/main/text/0039-release-process.md#change-control-board
 [release]: https://github.com/buildpacks/pack/releases

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,23 +10,20 @@ Our development flow is detailed in [Development](DEVELOPMENT.md)
 
 ## Feature Complete
 ### Process
-5 business days prior to a scheduled release, we enter `feature complete`. A release branch (in the form `release/<VERSION>`) is created, and used for `UAT` (User Acceptance testing).
+5 business days prior to a scheduled release, we enter `feature complete`. A release branch (in the form `release/<VERSION>`) is created, and used for User Acceptance testing (`UAT`).
 
-During this period, relevant changes may be merged into the release branch, based on assessment by the [CCB](#ccb) of the impact, effort and risk of including the changes. Any other change may get merged into `main` through the normal process, and will make it into the next release.
+During this period, relevant changes may be merged into the release branch, based on assessment by the `pack` [maintainers][maintainers] of the impact, effort and risk of including the changes. Any other change may get merged into `main` through the normal process, and will make it into the next release.
 
 ### Roles
-#### CCB
-The `CCB` (Change Control Board) are the `pack` [maintainers][maintainers].
-
 #### Release Manager
-One of the [maintainers][maintainers] is designated as the release manager. They communicate the release status to the working group meetings, schedule additional meetings with the [CCB](#ccb) as needed, and finalize the release. They also take care of whatever release needs may arise.
+One of the [maintainers][maintainers] is designated as the release manager. They communicate the release status to the working group meetings, schedule additional meetings with the `pack` [maintainers][maintainers] as needed, and finalize the release. They also take care of whatever release needs may arise.
 
 ## Release Finalization
 The [release manager](#release-manager) will:
 - Create a [github release][release], containing the **artifacts**, **release notes**, and a **migration guide** (if necessary), documenting breaking changes, and providing actions to migrate from prior versions.
 - Tag the release branch as `v<version>`
 - Merge the release branch into `main`
-- Send out release notifications on
+- Send out release notifications, if deemed necessary, on
   - The [cncf-buildpacks mailing list](https://lists.cncf.io/g/cncf-buildpacks)
   - Twitter
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,37 @@
+# Release Process
+
+Pack follows a 6 week release cadence, composed of 3 phases:
+  - [Development](#development)
+  - [Feature Complete](#feature-complete)
+  - [Release Finalization](#release-finalization)
+
+## Development
+Our development flow is detailed in [Development](DEVELOPMENT.md)
+
+## Feature Complete
+### Process
+5 business days prior to a scheduled release, we enter `feature complete`. A release branch (in the form `release/<VERSION>`) is created, and used for `UAT` (User Acceptance testing).
+
+During this period, relevant changes may be merged into the release branch, based on assessment by the [CCB](#ccb) of the impact, effort and risk of including the changes. Any other change may get merged into `main` through the normal process, and will make it into the next release.
+
+### Roles
+#### CCB
+The `CCB` (Change Control Board) are the `pack` [maintainers][maintainers].
+
+#### Release Manager
+One of the [maintainers][maintainers] is designated as the release manager. They communicate the release status to the working group meetings, schedule additional meetings with the [CCB](#ccb) as needed, and finalize the release. They also take care of whatever release needs may arise.
+
+## Release Finalization
+The [release manager](#release-manager) will:
+- Create a [github release][release], containing the **artifacts**, **release notes**, and a **migration guide** (if necessary), documenting breaking changes, and providing actions to migrate from prior versions.
+- Tag the release branch as `v<version>`
+- Merge the release branch into `main`
+- Send out release notifications on
+  - The [cncf-buildpacks mailing list](https://lists.cncf.io/g/cncf-buildpacks)
+  - Twitter
+
+For more information, see the [release process RFC][release-process]
+
+[maintainers]: @buildpacks/platform-mainters
+[release-process]: https://github.com/buildpacks/rfcs/blob/main/text/0039-release-process.md#change-control-board
+[release]: https://github.com/buildpacks/pack/releases


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This adds a document detailing the pack release process. It was based off the [rfc](https://github.com/buildpacks/rfcs/blob/main/text/0039-release-process.md#timetable)

[Readable](https://github.com/buildpacks/pack/blob/docs/release-process/RELEASE.md)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
https://buildpacks.slack.com/archives/CT4JM0MFZ/p1593697508040200