### PR TITLE
Ensure can't add suggested builder as a trusted builder

### DIFF
--- a/internal/commands/trust_builder.go
+++ b/internal/commands/trust_builder.go
@@ -24,11 +24,9 @@ func TrustBuilder(logger logging.Logger, cfg config.Config) *cobra.Command {
 			imageName := args[0]
 			builderToTrust := config.TrustedBuilder{Name: imageName}
 
-			for _, builder := range cfg.TrustedBuilders {
-				if builder == builderToTrust {
-					logger.Infof("Builder %s is already trusted", style.Symbol(imageName))
-					return nil
-				}
+			if isTrustedBuilder(cfg, imageName) {
+				logger.Infof("Builder %s is already trusted", style.Symbol(imageName))
+				return nil
 			}
 
 			cfg.TrustedBuilders = append(cfg.TrustedBuilders, builderToTrust)

--- a/internal/commands/trust_builder_test.go
+++ b/internal/commands/trust_builder_test.go
@@ -19,7 +19,7 @@ import (
 	h "github.com/buildpacks/pack/testhelpers"
 )
 
-func TestTrustBuilder(t *testing.T) {
+func TestTrustBuilderCommand(t *testing.T) {
 	color.Disable(true)
 	defer color.Disable(false)
 	spec.Run(t, "Commands", testTrustBuilderCommand, spec.Random(), spec.Report(report.Terminal{}))
@@ -87,6 +87,18 @@ func testTrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 					newContents, err := ioutil.ReadFile(configPath)
 					h.AssertNil(t, err)
 					h.AssertEq(t, newContents, oldContents)
+				})
+			})
+
+			when("builder is a suggested builder", func() {
+				it("does nothing", func() {
+					h.AssertNil(t, ioutil.WriteFile(configPath, []byte(""), os.ModePerm))
+
+					command.SetArgs([]string{"gcr.io/paketo-buildpacks/builder:base"})
+					h.AssertNil(t, command.Execute())
+					oldContents, err := ioutil.ReadFile(configPath)
+					h.AssertNil(t, err)
+					h.AssertEq(t, string(oldContents), "")
 				})
 			})
 		})


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This resolves a concern where people could add a suggested builder as a trusted builder, and then see it appear twice using list-trusted-builders

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
![image](https://user-images.githubusercontent.com/7035673/86413740-0ac1b180-bc90-11ea-8d81-72638e01941d.png)

#### After
![image](https://user-images.githubusercontent.com/7035673/86413392-1bbdf300-bc8f-11ea-9941-4f8c4eb6b451.png)

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
https://buildpacks.slack.com/archives/CT4JM0MFZ/p1593717575041200
