### PR TITLE
Send Release Dispatch to Samples as well

### DIFF
--- a/.github/workflows/delivery-release-dispatch.yml
+++ b/.github/workflows/delivery-release-dispatch.yml
@@ -6,12 +6,15 @@ on:
       - published
 
 jobs:
-  dispatch2docs:
+  send-release-dispatch:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['buildpacks/docs', 'buildpacks/samples']
     steps:
-      - name: Repository Dispatch to Docs
+      - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.BOT_TOKEN }}
           event-type: pack-release
-          repository: buildpacks/docs
+          repository: ${{ matrix.repo }}


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This sends a release dispatch, upon release of pack, to the `buildpacks/samples` repo. The token was already generated, so it should work as expected. 

It follows the suggestions from [here](https://github.com/peter-evans/repository-dispatch#dispatch-to-multiple-repositories) on dispatching to multiple repositories. 

## Documentation
- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
References buildpacks/samples#75
