### PR TITLE
Changelog updates

### DIFF
--- a/.github/workflows/build/changelog.js
+++ b/.github/workflows/build/changelog.js
@@ -102,11 +102,13 @@ function createIssueEntry(issue) {
     }
   });
 
+  let line = `* ${issue.title}`;
   if (annotations.length !== 0) {
-    return `* ${issue.title} [${annotations.join(", ")}] (#${issue.number})\n`;
-  } else {
-    return `* ${issue.title} (#${issue.number})\n`;
+    line += ` [${annotations.join(", ")}]`;
   }
+  line += ` (#${issue.number} by @${issue.user.login})\n`;
+
+  return line;
 }
 
 function groupByType(issues) {


### PR DESCRIPTION
## Summary
This change updated the changelog of the release notes. It does the following:

1. Breakaway issues related only to library changes to a seperate section
2. Add PR author to line entry

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### After

```markdown
## Features

* Ensure can't add suggested builder as a trusted builder (#730 by @dfreilich)
* Update default lifecycle to 0.8.0 (#724 by @jromero)
* Change untrusted warning (#723 by @dfreilich)
* Add warning when building with untrusted builder and volumes (#722 by @dfreilich)
* Suggest gcr.io/buildpacks/builder:v1 (#721 by @dgageot)
* Warns if user is using untrusted builder (#720 by @dfreilich)
* Message buildpack overriding in builder creation as DEBUG (#717 by @simonjjones)
* Write stack.toml to container instead of tmp dir (#715 by @jromero)
* Add untrust-builder command (#699 by @simonjjones)
* Add Trusted (Yes/No) output to inspect-builder (#697 by @simonjjones)
* Add list-trusted-builders command (#693 by @simonjjones)
* Standardize params of create-builder and package-buildpack  (#691 by @dfreilich)
* Add flag (--shell) to completion command (#639 by @cappyzawa)

## Fixes

* Explicitly deal with untrusting suggested builder (#725 by @dfreilich)
* Fix/123 no color (#696 by @dfreilich)
* Fix timestamps (#672 by @dfreilich)

## Library

<details><p>
### Features

* Move logger creation into PackCmd creation to allow for external use (#701 by @dfreilich)
* Move stack validation from data object (#677 by @dfreilich)
* Move project.toml parsing out of internal package (#660 by @dgageot)

</p></details>

```
## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No
