### PR TITLE
Use markdown instead of img html for choco delivery

### DIFF
--- a/.github/workflows/delivery/chocolatey/pack.nuspec
+++ b/.github/workflows/delivery/chocolatey/pack.nuspec
@@ -31,7 +31,7 @@ This package installs/upgrades the pack - Buildpacks CLI release.
 
 ## Usage
 
-<img src="https://github.com/buildpacks/pack/raw/main/resources/pack-build.gif" width="600px" />
+![Usage](https://github.com/buildpacks/pack/raw/main/resources/pack-build.gif)
 
 ## Getting Started
 


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
Fix this error: https://github.com/buildpacks/pack/runs/846975725?check_suite_focus=true

```
The element 'http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd:description' cannot contain child element 'http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd:img' because the parent element's content model is text only.
```
## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
