### PR TITLE
Add setup to run changelog generation locally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,8 +138,8 @@ jobs:
           result-encoding: string
           script: |
             const path = require('path');
-            const scriptPath = path.resolve('.github/workflows/build/changelog.js');
-            require(scriptPath)({core, github, context});
+            const scriptPath = path.resolve('.github/workflows/build/changelog/index.js');
+            require(scriptPath)({core, github, context, version: ${{ env.PACK_VERSION }}});
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest

--- a/.github/workflows/build/changelog/.gitignore
+++ b/.github/workflows/build/changelog/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+changelog.md

--- a/.github/workflows/build/changelog/README.md
+++ b/.github/workflows/build/changelog/README.md
@@ -1,0 +1,37 @@
+## Changelog
+
+A simple script that generates the changelog for pack based on a pack version (aka milestone).
+
+### Usage
+
+#### Github Action
+
+```yaml
+  - uses: actions/github-script@v1
+    id: changelog
+    with:
+      github-token: ${{secrets.GITHUB_TOKEN}}
+      result-encoding: string
+      script: |
+        const path = require('path');
+        const scriptPath = path.resolve('.github/workflows/build/changelog/index.js');
+        require(scriptPath)({core, github, context, version: ${{ env.PACK_VERSION }}});
+```
+
+#### Local
+
+To run/test locally:
+
+```shell
+# install deps
+npm install
+
+# set required info
+export GITHUB_ACTION="<GITHUB_PAT_TOKEN>"
+export PACK_VERSION="<PACK_VERSION>"
+
+# run locally
+npm run local
+```
+
+Notice that a file `changelog.md` is created as well for further inspection.

--- a/.github/workflows/build/changelog/index.js
+++ b/.github/workflows/build/changelog/index.js
@@ -14,9 +14,10 @@ const annotationLabelsMap = {
   "breaking": "breaking-change",
 };
 
-module.exports = async ({core, github}) => {
-  const milestone = process.env.PACK_VERSION;
-  const repository = process.env.GITHUB_REPOSITORY;
+module.exports = async ({core, github, context, version}) => {
+  const milestone = version;
+  const repository = context.repository;
+
   console.log("looking up PRs for milestone", milestone, "in repo", repository);
 
   return await github.paginate("GET /search/issues", {
@@ -49,7 +50,7 @@ module.exports = async ({core, github}) => {
     for (let key in typeLabelsMap) {
       let issues = (groupedCliIssues[typeLabelsMap[key]] || []);
       if (issues.length > 0) {
-        output += `## ${key}\n\n`;
+        output += `### ${key}\n\n`;
         issues.forEach(issue => {
           output += createIssueEntry(issue);
         });
@@ -59,12 +60,12 @@ module.exports = async ({core, github}) => {
 
     // library issues
     if (Object.keys(groupedLibIssues).length > 0) {
-      output += "## Library\n\n";
-      output += "<details><p>\n";
+      output += "### Library\n\n";
+      output += "<details><summary>Changes that only affect `pack` as a library usage...</summary><p>\n\n";
       for (let key in typeLabelsMap) {
         let issues = (groupedLibIssues[typeLabelsMap[key]] || []);
         if (issues.length > 0) {
-          output += `### ${key}\n\n`;
+          output += `#### ${key}\n\n`;
           issues.forEach(issue => {
             output += createIssueEntry(issue);
           });
@@ -84,7 +85,7 @@ module.exports = async ({core, github}) => {
       }
     });
 
-    console.log("OUTPUT:\n", output);
+    console.log(`CHANGELOG:\n${output}`);
 
     core.setOutput('contents', output);
     core.setOutput('file', 'changelog.md');

--- a/.github/workflows/build/changelog/local.js
+++ b/.github/workflows/build/changelog/local.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const scriptPath = path.resolve('index.js');
+const {Octokit} = require("@octokit/rest");
+
+const core = require('@actions/core');
+const github = new Octokit({auth: mustGetEnvVar('GITHUB_TOKEN')});
+const context = {
+  repository: "buildpacks/pack"
+};
+
+require(scriptPath)({
+  core,
+  github,
+  context,
+  version: mustGetEnvVar('PACK_VERSION'),
+});
+
+
+function mustGetEnvVar(envVar) {
+  let value = process.env[envVar];
+  if (!value) {
+    console.error(`'${envVar}' env var must be set.`);
+    process.exit(1);
+  }
+  return value;
+}

--- a/.github/workflows/build/changelog/package-lock.json
+++ b/.github/workflows/build/changelog/package-lock.json
@@ -1,0 +1,308 @@
+{
+  "name": "build",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@actions/core": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
+      "integrity": "sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg=="
+    },
+    "@octokit/auth-token": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+      "requires": {
+        "@octokit/types": "^5.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-yPyQSmxIXLieEIRikk2w8AEtWkFdfG/LXcw1KvEtK3iP0ENZLW/WYQmdzOKqfSaLhooz4CJ9D+WY79C8ZliACw==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.4.0",
+        "@octokit/types": "^5.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^5.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.3.tgz",
+      "integrity": "sha512-Y900+r0gIz+cWp6ytnkibbD95ucEzDSKzlEnaWS52hbCDNcCJYO5mRmWW7HRAnDc7am+N/5Lnd8MppSaTYx1Yg==",
+      "requires": {
+        "@octokit/types": "^5.0.0",
+        "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^5.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.1.tgz",
+      "integrity": "sha512-qgMsROG9K2KxDs12CO3bySJaYoUu2aic90qpFrv7A8sEBzZ7UFGvdgPKiLw5gOPYEYbS0Xf8Tvf84tJutHPulQ==",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^5.0.0",
+        "universal-user-agent": "^5.0.0"
+      }
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.3.tgz",
+      "integrity": "sha512-eKTs91wXnJH8Yicwa30jz6DF50kAh7vkcqCQ9D7/tvBAP5KKkg6I2nNof8Mp/65G0Arjsb4QcOJcIEQY+rK1Rg==",
+      "requires": {
+        "@octokit/types": "^5.0.0"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.0.0.tgz",
+      "integrity": "sha512-emS6gysz4E9BNi9IrCl7Pm4kR+Az3MmVB0/DoDCmF4U48NbYG3weKyDlgkrz6Jbl4Mu4nDx8YWZwC4HjoTdcCA==",
+      "requires": {
+        "@octokit/types": "^5.0.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.5.tgz",
+      "integrity": "sha512-atAs5GAGbZedvJXXdjtKljin+e2SltEs48B3naJjqWupYl2IUBbB/CJisyjbNHcKpHzb3E+OYEZ46G8eakXgQg==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^5.0.0",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^5.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+      "requires": {
+        "@octokit/types": "^5.0.1",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.0.tgz",
+      "integrity": "sha512-4G/a42lry9NFGuuECnua1R1eoKkdBYJap97jYbWDNYBOUboWcM75GJ1VIcfvwDV/pW0lMPs7CEmhHoVrSV5shg==",
+      "requires": {
+        "@octokit/core": "^3.0.0",
+        "@octokit/plugin-paginate-rest": "^2.2.0",
+        "@octokit/plugin-request-log": "^1.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "4.0.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.0.1.tgz",
+      "integrity": "sha512-GorvORVwp244fGKEt3cgt/P+M0MGy4xEDbckw+K5ojEezxyMDgCaYPKVct+/eWQfZXOT7uq0xRpmrl/+hliabA==",
+      "requires": {
+        "@types/node": ">= 8"
+      }
+    },
+    "@types/node": {
+      "version": "14.0.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.19.tgz",
+      "integrity": "sha512-yf3BP/NIXF37BjrK5klu//asUWitOEoUP5xE1mhSUjazotwJ/eJDgEmMQNlOeWOVv72j24QQ+3bqXHE++CFGag=="
+    },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "is-plain-object": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g=="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "macos-release": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.0.tgz",
+      "integrity": "sha512-ko6deozZYiAkqa/0gmcsz+p4jSy3gY7/ZsCEokPaYd8k+6/aXGkiTgr61+Owup7Sf+xjqW8u2ElhoM9SEcEfuA=="
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "os-name": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+      "requires": {
+        "macos-release": "^2.2.0",
+        "windows-release": "^3.1.0"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "universal-user-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+      "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
+      "requires": {
+        "os-name": "^3.1.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "windows-release": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.1.tgz",
+      "integrity": "sha512-Pngk/RDCaI/DkuHPlGTdIkDiTAnAkyMjoQMZqRsxydNl1qGXNIoZrB7RK8g53F2tEgQBMqQJHQdYZuQEEAu54A==",
+      "requires": {
+        "execa": "^1.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/.github/workflows/build/changelog/package.json
+++ b/.github/workflows/build/changelog/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "build",
+  "version": "1.0.0",
+  "scripts": {
+    "local": "node local.js"
+  },
+  "dependencies": {
+    "@actions/core": "^1.2.4",
+    "@octokit/rest": "^18.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
Add setup and guide to run changelog generation locally for development purposes.

## Output

```
$ npm run local

> build@1.0.0 local /Users/javier.romero/dev/buildpacks/pack/.github/workflows/build/changelog
> node local.js

looking up PRs for milestone 0.12.0 in repo buildpacks/pack
CLI issues: 35
Library issues: 4
Note: some issues may not be presented (eg. type/chore)
CHANGELOG:
### Features

* Ensure can't add suggested builder as a trusted builder (#730 by @dfreilich)
* Update default lifecycle to 0.8.0 (#724 by @jromero)
* Change untrusted warning (#723 by @dfreilich)
* Add warning when building with untrusted builder and volumes (#722 by @dfreilich)
* Suggest gcr.io/buildpacks/builder:v1 (#721 by @dgageot)
* Warns if user is using untrusted builder (#720 by @dfreilich)
* Message buildpack overriding in builder creation as DEBUG (#717 by @simonjjones)
* Write stack.toml to container instead of tmp dir (#715 by @jromero)
* Add untrust-builder command (#699 by @simonjjones)
* Add Trusted (Yes/No) output to inspect-builder (#697 by @simonjjones)
* Add list-trusted-builders command (#693 by @simonjjones)
* Standardize params of create-builder and package-buildpack  (#691 by @dfreilich)
* Add flag (--shell) to completion command (#639 by @cappyzawa)

### Fixes

* Explicitly deal with untrusting suggested builder (#725 by @dfreilich)
* Fix/123 no color (#696 by @dfreilich)
* Fix timestamps (#672 by @dfreilich)

### Library

<details><summary>Changes that only affect `pack` as a library usage...</summary><p>

#### Features

* Move logger creation into PackCmd creation to allow for external use (#701 by @dfreilich)
* Move stack validation from data object (#677 by @dfreilich)
* Move project.toml parsing out of internal package (#660 by @dgageot)

</p></details>
::set-output name=contents::### Features%0A%0A* Ensure can't add suggested builder as a trusted builder (#730 by @dfreilich)%0A* Update default lifecycle to 0.8.0 (#724 by @jromero)%0A* Change untrusted warning (#723 by @dfreilich)%0A* Add warning when building with untrusted builder and volumes (#722 by @dfreilich)%0A* Suggest gcr.io/buildpacks/builder:v1 (#721 by @dgageot)%0A* Warns if user is using untrusted builder (#720 by @dfreilich)%0A* Message buildpack overriding in builder creation as DEBUG (#717 by @simonjjones)%0A* Write stack.toml to container instead of tmp dir (#715 by @jromero)%0A* Add untrust-builder command (#699 by @simonjjones)%0A* Add Trusted (Yes/No) output to inspect-builder (#697 by @simonjjones)%0A* Add list-trusted-builders command (#693 by @simonjjones)%0A* Standardize params of create-builder and package-buildpack  (#691 by @dfreilich)%0A* Add flag (--shell) to completion command (#639 by @cappyzawa)%0A%0A### Fixes%0A%0A* Explicitly deal with untrusting suggested builder (#725 by @dfreilich)%0A* Fix/123 no color (#696 by @dfreilich)%0A* Fix timestamps (#672 by @dfreilich)%0A%0A### Library%0A%0A<details><summary>Changes that only affect `pack` as a library usage...</summary><p>%0A%0A#### Features%0A%0A* Move logger creation into PackCmd creation to allow for external use (#701 by @dfreilich)%0A* Move stack validation from data object (#677 by @dfreilich)%0A* Move project.toml parsing out of internal package (#660 by @dgageot)%0A%0A</p></details>
::set-output name=file::changelog.md
The file was saved!

```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No