### PR TITLE
Ignore a number of non-code files when triggering workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,16 @@ name: build
 
 on:
   push:
+    paths-ignore: &ignore-paths
+      - '**.md'
+      - 'resources/**'
+      - 'CODEOWNERS'
+      - 'LICENSE'
     branches:
       - main
       - 'release/**'
   pull_request:
+    "<<": *ignore-paths
     branches:
       - main
       - 'release/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   push:
-    paths-ignore: &ignore-paths
+    paths-ignore:
       - '**.md'
       - 'resources/**'
       - 'CODEOWNERS'
@@ -11,7 +11,11 @@ on:
       - main
       - 'release/**'
   pull_request:
-    "<<": *ignore-paths
+    paths-ignore:
+      - '**.md'
+      - 'resources/**'
+      - 'CODEOWNERS'
+      - 'LICENSE'
     branches:
       - main
       - 'release/**'

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -2,10 +2,16 @@ name: compatibility
 
 on:
   push:
+    paths-ignore: &ignore-paths
+      - '**.md'
+      - 'resources/**'
+      - 'CODEOWNERS'
+      - 'LICENSE'
     branches:
       - main
       - 'release/**'
   pull_request:
+    "<<": *ignore-paths
     branches:
       - main
       - 'release/**'

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -2,7 +2,7 @@ name: compatibility
 
 on:
   push:
-    paths-ignore: &ignore-paths
+    paths-ignore:
       - '**.md'
       - 'resources/**'
       - 'CODEOWNERS'
@@ -11,7 +11,11 @@ on:
       - main
       - 'release/**'
   pull_request:
-    "<<": *ignore-paths
+    paths-ignore:
+      - '**.md'
+      - 'resources/**'
+      - 'CODEOWNERS'
+      - 'LICENSE'
     branches:
       - main
       - 'release/**'


### PR DESCRIPTION
Signed-off-by: Simon Jones <simonjones@vmware.com>

## Summary
All docs files, CODEOWNERS & LICENSE files do not require testing, or building, as they're repo related assets rather than product related

## Output

#### Before
Commits to PRs which only change docs would trigger our test suites

#### After
Any PR with non code changes should not trigger test suites.

All PRs that do change code files in any way should continue to trigger our full suite of tests

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No
