### PR TITLE
Support default windows lifecycle uri

### DIFF
--- a/acceptance/testdata/pack_fixtures/report_output.txt
+++ b/acceptance/testdata/pack_fixtures/report_output.txt
@@ -2,7 +2,7 @@ Pack:
   Version:  {{ .Version }}
   OS/Arch:  {{ .OS }}/{{ .Arch }}
 
-Default Lifecycle Version:  0.8.0
+Default Lifecycle Version:  0.9.0
 
 Config:
   default-builder-image = "{{ .DefaultBuilder }}"

--- a/build_test.go
+++ b/build_test.go
@@ -1495,7 +1495,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.Pull, false)
 
-					args = fakeImageFetcher.FetchCalls["buildpacksio/lifecycle:0.8.0"]
+					args = fakeImageFetcher.FetchCalls["buildpacksio/lifecycle:0.9.0"]
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.Pull, false)
 				})

--- a/create_builder.go
+++ b/create_builder.go
@@ -136,7 +136,7 @@ func (c *Client) createBaseBuilder(ctx context.Context, opts CreateBuilderOption
 		)
 	}
 
-	lifecycle, err := c.fetchLifecycle(ctx, opts.Config.Lifecycle)
+	lifecycle, err := c.fetchLifecycle(ctx, opts.Config.Lifecycle, os)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch lifecycle")
 	}
@@ -146,7 +146,7 @@ func (c *Client) createBaseBuilder(ctx context.Context, opts CreateBuilderOption
 	return bldr, nil
 }
 
-func (c *Client) fetchLifecycle(ctx context.Context, config pubbldr.LifecycleConfig) (builder.Lifecycle, error) {
+func (c *Client) fetchLifecycle(ctx context.Context, config pubbldr.LifecycleConfig, os string) (builder.Lifecycle, error) {
 	if config.Version != "" && config.URI != "" {
 		return nil, errors.Errorf(
 			"%s can only declare %s or %s, not both",
@@ -162,11 +162,11 @@ func (c *Client) fetchLifecycle(ctx context.Context, config pubbldr.LifecycleCon
 			return nil, errors.Wrapf(err, "%s must be a valid semver", style.Symbol("lifecycle.version"))
 		}
 
-		uri = uriFromLifecycleVersion(*v)
+		uri = uriFromLifecycleVersion(*v, os)
 	case config.URI != "":
 		uri = config.URI
 	default:
-		uri = uriFromLifecycleVersion(*semver.MustParse(builder.DefaultLifecycleVersion))
+		uri = uriFromLifecycleVersion(*semver.MustParse(builder.DefaultLifecycleVersion), os)
 	}
 
 	b, err := c.downloader.Download(ctx, uri)
@@ -296,6 +296,10 @@ func validateBuildpack(bp dist.Buildpack, source, expectedID, expectedBPVersion 
 	return nil
 }
 
-func uriFromLifecycleVersion(version semver.Version) string {
+func uriFromLifecycleVersion(version semver.Version, os string) string {
+	if os == "windows" {
+		return fmt.Sprintf("https://github.com/buildpacks/lifecycle/releases/download/v%s/lifecycle-v%s+windows.x86-64.tgz", version.String(), version.String())
+	}
+
 	return fmt.Sprintf("https://github.com/buildpacks/lifecycle/releases/download/v%s/lifecycle-v%s+linux.x86-64.tgz", version.String(), version.String())
 }

--- a/internal/builder/lifecycle.go
+++ b/internal/builder/lifecycle.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DefaultLifecycleVersion    = "0.8.0"
+	DefaultLifecycleVersion    = "0.9.0"
 	DefaultBuildpackAPIVersion = "0.2"
 )
 
@@ -116,7 +116,10 @@ func (l *lifecycle) validateBinaries() error {
 	for _, p := range l.binaries() {
 		_, found := headers[p]
 		if !found {
-			return fmt.Errorf("did not find '%s' in tar", p)
+			_, found = headers[p+".exe"]
+			if !found {
+				return fmt.Errorf("did not find '%s' in tar", p)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: Anthony Emengo <anthonyemengojr@gmail.com>

## Summary

Allow pack to construct the correct lifecycle url when creating a _windows_ builder.

## Output

#### Before

```
Creating builder debug/builder from build-image pack-test/build
Using cached version of https://github.com/buildpacks/lifecycle/releases/download/v0.8.0/lifecycle-v0.8.0+linux.x86-64.tgz
...
```

#### After

```
Creating builder debug/builder from build-image pack-test/build
Using cached version of https://github.com/buildpacks/lifecycle/releases/download/v0.8.0/lifecycle-v0.8.0+windows.x86-64.tgz
...
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No

@ameyer-pivotal 
@micahyoung 
