### PR TITLE
remove md from register buildpack issue body

### DIFF
--- a/internal/registry/buildpack.go
+++ b/internal/registry/buildpack.go
@@ -17,7 +17,7 @@ type Buildpack struct {
 }
 
 // Validate that a buildpack reference contains required information
-func (b *Buildpack) Validate() error {
+func Validate(b Buildpack) error {
 	if b.Address == "" {
 		return errors.New("invalid entry: address is a required field")
 	}

--- a/internal/registry/buildpack_test.go
+++ b/internal/registry/buildpack_test.go
@@ -21,7 +21,7 @@ func testRegistryBuildpack(t *testing.T, when spec.G, it spec.S) {
 				Address: "",
 			}
 
-			h.AssertNotNil(t, b.Validate())
+			h.AssertNotNil(t, registry.Validate(b))
 		})
 
 		it("errors when not a digest", func() {
@@ -29,7 +29,7 @@ func testRegistryBuildpack(t *testing.T, when spec.G, it spec.S) {
 				Address: "example.com/some/package:18",
 			}
 
-			h.AssertNotNil(t, b.Validate())
+			h.AssertNotNil(t, registry.Validate(b))
 		})
 
 		it("succeeds when address is a digest", func() {
@@ -37,7 +37,7 @@ func testRegistryBuildpack(t *testing.T, when spec.G, it spec.S) {
 				Address: "example.com/some/package@sha256:8c27fe111c11b722081701dfed3bd55e039b9ce92865473cf4cdfa918071c566",
 			}
 
-			h.AssertNil(t, b.Validate())
+			h.AssertNil(t, registry.Validate(b))
 		})
 	})
 }

--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -31,13 +31,10 @@ type Cache struct {
 
 const GithubIssueTitleTemplate = "{{ if .Yanked }}YANK{{else}}ADD{{end}} {{.Namespace}}/{{.Name}}@{{.Version}}"
 const GithubIssueBodyTemplate = `
-### Data
-
-` + "```toml" + `
 id = "{{.Namespace}}/{{.Name}}"
 version = "{{.Version}}"
 {{ if .Yanked }}{{else}}addr = "{{.Address}}"{{end}}
-` + "```"
+`
 
 // Entry is a list of buildpacks stored in a registry
 type Entry struct {
@@ -98,12 +95,12 @@ func (r *Cache) LocateBuildpack(bp string) (Buildpack, error) {
 					}
 				}
 			}
-			return highestVersion, highestVersion.Validate()
+			return highestVersion, Validate(highestVersion)
 		}
 
 		for _, bpIndex := range entry.Buildpacks {
 			if bpIndex.Version == version {
-				return bpIndex, bpIndex.Validate()
+				return bpIndex, Validate(bpIndex)
 			}
 		}
 		return Buildpack{}, fmt.Errorf("could not find version for buildpack: %s", bp)


### PR DESCRIPTION
## Summary
This PR removes unnecessary md formatting for something that is intended to be machine parse-able.   The only requirement is that it's TOML.  Also added a small clean-up.

## Output
id = "projectriff/java-function"
version = "0.4.2"
addr = "gcr.io/projectriff/java-function@sha256:aeab8d5b5cfa4d06fa0a099a1ebf26ad953c146d79a845f9283dac3986e8cf1e"

#### Before
### Data

```toml
id = "projectriff/node-function"
version = "0.6.2"
addr = "gcr.io/projectriff/node-function@sha256:9d88250dfd77dbf5a535f1358c6a05dc2c0d3a22defbdcd72bb8f5e24b84e21d"
```

#### After
id = "projectriff/java-function"
version = "0.4.2"
addr = "gcr.io/projectriff/java-function@sha256:aeab8d5b5cfa4d06fa0a099a1ebf26ad953c146d79a845f9283dac3986e8cf1e"

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
