### PR TITLE
Remove deprecated flags

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -268,7 +268,7 @@ func testWithoutSpecificBuilderRequirement(
 		packageBuildpackLocally := func(absConfigPath string) string {
 			t.Helper()
 			packageName := "test/package-" + h.RandString(10)
-			output, err := pack.Run("package-buildpack", packageName, "-p", absConfigPath)
+			output, err := pack.Run("package-buildpack", packageName, "-c", absConfigPath)
 			h.AssertNil(t, err)
 			h.AssertContains(t, output, fmt.Sprintf("Successfully created package '%s'", packageName))
 			return packageName
@@ -277,7 +277,7 @@ func testWithoutSpecificBuilderRequirement(
 		packageBuildpackRemotely := func(absConfigPath string) string {
 			t.Helper()
 			packageName := registryConfig.RepoName("test/package-" + h.RandString(10))
-			output, err := pack.Run("package-buildpack", packageName, "-p", absConfigPath, "--publish")
+			output, err := pack.Run("package-buildpack", packageName, "-c", absConfigPath, "--publish")
 			h.AssertNil(t, err)
 			h.AssertContains(t, output, fmt.Sprintf("Successfully published package '%s'", packageName))
 			return packageName
@@ -312,7 +312,7 @@ func testWithoutSpecificBuilderRequirement(
 		when("no --format is provided", func() {
 			it("creates the package as image", func() {
 				packageName := "test/package-" + h.RandString(10)
-				output := pack.RunSuccessfully("package-buildpack", packageName, "-p", simplePackageConfigPath)
+				output := pack.RunSuccessfully("package-buildpack", packageName, "-c", simplePackageConfigPath)
 				h.AssertContains(t, output, fmt.Sprintf("Successfully created package '%s'", packageName))
 				defer h.DockerRmi(dockerCli, packageName)
 
@@ -344,7 +344,7 @@ func testWithoutSpecificBuilderRequirement(
 					defer h.DockerRmi(dockerCli, packageName)
 					output := pack.RunSuccessfully(
 						"package-buildpack", packageName,
-						"-p", aggregatePackageToml,
+						"-c", aggregatePackageToml,
 						"--publish",
 					)
 					h.AssertContains(t, output, fmt.Sprintf("Successfully published package '%s'", packageName))
@@ -369,7 +369,7 @@ func testWithoutSpecificBuilderRequirement(
 					defer h.DockerRmi(dockerCli, packageName)
 					pack.JustRunSuccessfully(
 						"package-buildpack", packageName,
-						"-p", aggregatePackageToml,
+						"-c", aggregatePackageToml,
 						"--no-pull",
 					)
 
@@ -387,7 +387,7 @@ func testWithoutSpecificBuilderRequirement(
 					defer h.DockerRmi(dockerCli, packageName)
 					output, err := pack.Run(
 						"package-buildpack", packageName,
-						"-p", aggregatePackageToml,
+						"-c", aggregatePackageToml,
 						"--no-pull",
 					)
 					h.AssertNotNil(t, err)
@@ -409,7 +409,7 @@ func testWithoutSpecificBuilderRequirement(
 				output, err := pack.Run(
 					"package-buildpack", outputFile,
 					"--format", "file",
-					"-p", simplePackageConfigPath,
+					"-c", simplePackageConfigPath,
 				)
 				h.AssertNil(t, err)
 				h.AssertContains(t, output, fmt.Sprintf("Successfully created package '%s'", outputFile))
@@ -421,7 +421,7 @@ func testWithoutSpecificBuilderRequirement(
 			it("displays an error", func() {
 				output, err := pack.Run(
 					"package-buildpack", "some-package",
-					"-p", pack.FixtureManager().FixtureLocation("invalid_package.toml"),
+					"-c", pack.FixtureManager().FixtureLocation("invalid_package.toml"),
 				)
 				h.AssertNotNil(t, err)
 				h.AssertContains(t, output, "reading config")
@@ -606,7 +606,7 @@ func testAcceptance(
 
 					output, err := pack.Run(
 						"create-builder", "some-builder:build",
-						"--builder-config", builderConfigPath,
+						"--config", builderConfigPath,
 					)
 					h.AssertNotNil(t, err)
 					h.AssertContains(t, output, "invalid builder toml")
@@ -1709,7 +1709,7 @@ func createBuilder(t *testing.T, pack *invoke.PackInvoker, runImageMirror, lifec
 	// CREATE BUILDER
 	output, err := pack.Run(
 		"create-builder", bldr,
-		"-b", builderConfigFile.Name(),
+		"-c", builderConfigFile.Name(),
 		"--no-color",
 	)
 	if err != nil {
@@ -1784,7 +1784,7 @@ func packageBuildpack(t *testing.T, pack *invoke.PackInvoker, configLocation, tm
 		append([]string{
 			outputName,
 			"--no-color",
-			"-p", packageConfig,
+			"-c", packageConfig,
 		}, additionalArgs...)...,
 	)
 

--- a/internal/commands/create_builder.go
+++ b/internal/commands/create_builder.go
@@ -66,12 +66,7 @@ func CreateBuilder(logger logging.Logger, cfg config.Config, client PackClient) 
 		cmd.Flags().MarkHidden("buildpack-registry")
 	}
 
-	cmd.Flags().StringVarP(&flags.BuilderTomlPath, "builder-config", "b", "", "Path to builder TOML file (required)")
 	cmd.Flags().StringVarP(&flags.BuilderTomlPath, "config", "c", "", "Path to builder TOML file (required)")
-
-	// TODO: Mark config required and remove builder-config after release of pack v0.12: https://github.com/buildpacks/pack/issues/694
-	// cmd.MarkFlagRequired("config")
-	cmd.Flags().MarkHidden("builder-config")
 
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, "Publish to registry")
 	AddHelpFlag(cmd, "create-builder")

--- a/internal/commands/create_builder_test.go
+++ b/internal/commands/create_builder_test.go
@@ -117,16 +117,12 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 `), 0666))
 			})
 
-			it("logs warning and works", func() {
-				mockClient.EXPECT().CreateBuilder(gomock.Any(), gomock.Any()).Return(nil)
-
+			it("errors with a descriptive message", func() {
 				command.SetArgs([]string{
 					"some/builder",
 					"--builder-config", builderConfigPath,
 				})
-				h.AssertNil(t, command.Execute())
-
-				h.AssertContains(t, outBuf.String(), "Warning: Flag --builder-config has been deprecated, please use --config instead")
+				h.AssertError(t, command.Execute(), "unknown flag: --builder-config")
 			})
 		})
 

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -71,12 +71,7 @@ func PackageBuildpack(logger logging.Logger, client BuildpackPackager, packageCo
 			return nil
 		}),
 	}
-	cmd.Flags().StringVarP(&flags.PackageTomlPath, "package-config", "p", "", "Path to package TOML config (required)")
 	cmd.Flags().StringVarP(&flags.PackageTomlPath, "config", "c", "", "Path to package TOML config (required)")
-
-	// TODO: Mark config required and remove package-config after release of pack v0.12: https://github.com/buildpacks/pack/issues/694
-	// cmd.MarkFlagRequired("config")
-	cmd.Flags().MarkHidden("package-config")
 
 	cmd.Flags().StringVarP(&flags.Format, "format", "f", "", `Format to save package as ("image" or "file")`)
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, `Publish to registry (applies to "--image" only)`)

--- a/internal/commands/package_buildpack_test.go
+++ b/internal/commands/package_buildpack_test.go
@@ -116,7 +116,7 @@ func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("package-config is specified", func() {
-			it("logs warning and works", func() {
+			it("errors with a descriptive message", func() {
 				outBuf := &bytes.Buffer{}
 
 				config := &packageCommandConfig{
@@ -132,8 +132,7 @@ func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 				cmd.SetArgs([]string{config.imageName, "--package-config", config.configPath})
 
 				err := cmd.Execute()
-				h.AssertNil(t, err)
-				h.AssertContains(t, outBuf.String(), "Flag --package-config has been deprecated, please use --config instead")
+				h.AssertError(t, err, "unknown flag: --package-config")
 			})
 		})
 


### PR DESCRIPTION
* In #691, we deprecated builder-config and package-config flags in favor of --config. This removes those deprecated flags

Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
![Screen Shot 2020-07-23 at 12 24 18 PM](https://user-images.githubusercontent.com/7035673/88311945-8a66fd00-ccdf-11ea-8f21-9e67924477eb.png)


#### After
![image](https://user-images.githubusercontent.com/7035673/88311887-76bb9680-ccdf-11ea-9b9f-c6ea8cd8ef27.png)

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #694 
