### PR TITLE
460 remove symlink

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -32,13 +32,12 @@ const (
 
 	cnbDir = "/cnb"
 
-	orderPath          = "/cnb/order.toml"
-	stackPath          = "/cnb/stack.toml"
-	platformDir        = "/platform"
-	lifecycleDir       = "/cnb/lifecycle"
-	compatLifecycleDir = "/lifecycle"
-	workspaceDir       = "/workspace"
-	layersDir          = "/layers"
+	orderPath    = "/cnb/order.toml"
+	stackPath    = "/cnb/stack.toml"
+	platformDir  = "/platform"
+	lifecycleDir = "/cnb/lifecycle"
+	workspaceDir = "/workspace"
+	layersDir    = "/layers"
 
 	metadataLabel = "io.buildpacks.builder.metadata"
 	stackLabel    = "io.buildpacks.stack.id"
@@ -702,7 +701,6 @@ func (b *Builder) lifecycleLayer(dest string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "embedding lifecycle tar")
 	}
-
 
 	return fh.Name(), nil
 }

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -703,15 +703,6 @@ func (b *Builder) lifecycleLayer(dest string) (string, error) {
 		return "", errors.Wrap(err, "embedding lifecycle tar")
 	}
 
-	if err := lw.WriteHeader(&tar.Header{
-		Name:     compatLifecycleDir,
-		Linkname: lifecycleDir,
-		Typeflag: tar.TypeSymlink,
-		Mode:     0644,
-		ModTime:  archive.NormalizedDateTime,
-	}); err != nil {
-		return "", errors.Wrapf(err, "creating %s symlink", style.Symbol(compatLifecycleDir))
-	}
 
 	return fh.Name(), nil
 }

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -589,14 +589,16 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 					h.HasFileMode(0755),
 					h.HasModTime(archive.NormalizedDateTime),
 				)
+			})
 
-				it("should add lifecycle symlink", func() {
-					h.AssertOnTarEntry(t, layerTar, "/lifecycle",
-						h.SymlinksTo("/cnb/lifecycle"),
-						h.HasFileMode(0644),
-						h.HasModTime(archive.NormalizedDateTime),
-					)
-				})
+			it("should add lifecycle symlink", func() {
+				layerTar, err := baseImage.FindLayerWithPath("/cnb/lifecycle")
+				h.AssertNil(t, err)
+				h.AssertOnTarEntry(t, layerTar, "/lifecycle",
+					h.SymlinksTo("/cnb/lifecycle"),
+					h.HasFileMode(0644),
+					h.HasModTime(archive.NormalizedDateTime),
+				)
 			})
 
 			it("sets the lifecycle version on the metadata", func() {

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -591,16 +591,6 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 				)
 			})
 
-			it("should add lifecycle symlink", func() {
-				layerTar, err := baseImage.FindLayerWithPath("/cnb/lifecycle")
-				h.AssertNil(t, err)
-				h.AssertOnTarEntry(t, layerTar, "/lifecycle",
-					h.SymlinksTo("/cnb/lifecycle"),
-					h.HasFileMode(0644),
-					h.HasModTime(archive.NormalizedDateTime),
-				)
-			})
-
 			it("sets the lifecycle version on the metadata", func() {
 				label, err := baseImage.Label("io.buildpacks.builder.metadata")
 				h.AssertNil(t, err)

--- a/internal/commands/set_run_image_mirrors_test.go
+++ b/internal/commands/set_run_image_mirrors_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestSetRunImageMirrorsCommand(t *testing.T) {
-	spec.Run(t, "Commands", testSetRunImageMirrorsCommand, spec.Parallel(), spec.Report(report.Terminal{}))
+	spec.Run(t, "Commands", testSetRunImageMirrorsCommand, spec.Sequential(), spec.Report(report.Terminal{}))
 }
 
 func testSetRunImageMirrorsCommand(t *testing.T, when spec.G, it spec.S) {


### PR DESCRIPTION
## Summary
- Remove code to create obsolete `/lifecycle` symlink in builders

- Small fix to run image mirror tests to disable parallel test execution. 

#### Before
Directory structure of builders:
```
/
├── bin
├── ...
├── cnb
├── ...
└── lifecycle
```
#### After
Directory structure of builders:
```
/
├── bin
├── ...
├── cnb
└── ...
```

## Documentation
No documentation needed

## Related
Resolves #460 
