### PR TITLE
Add pull-policy flag to build/create-builder/package-buildpack/rebase commands

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -356,7 +356,7 @@ func testWithoutSpecificBuilderRequirement(
 				})
 			})
 
-			when("--pull-policy=never", func() {
+			when("--no-pull", func() {
 				it("should use local image", func() {
 					nestedPackage := packageBuildpackLocally(simplePackageConfigPath)
 					defer h.DockerRmi(dockerCli, nestedPackage)
@@ -367,8 +367,7 @@ func testWithoutSpecificBuilderRequirement(
 					pack.JustRunSuccessfully(
 						"package-buildpack", packageName,
 						"-c", aggregatePackageToml,
-						"--pull-policy",
-						"never",
+						"--no-pull",
 					)
 
 					_, _, err := dockerCli.ImageInspectWithRaw(context.Background(), packageName)
@@ -386,8 +385,7 @@ func testWithoutSpecificBuilderRequirement(
 					output, err := pack.Run(
 						"package-buildpack", packageName,
 						"-c", aggregatePackageToml,
-						"--pull-policy",
-						"never",
+						"--no-pull",
 					)
 					assert.NotNil(err)
 					assertions.NewOutputAssertionManager(t, output).ReportsImageNotExistingOnDaemon(nestedPackage)
@@ -1593,8 +1591,7 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 						"-p", filepath.Join("testdata", "mock_app"),
 						"--builder", builderName,
 						"--run-image", runBefore,
-						"--pull-policy",
-						"never",
+						"--no-pull",
 					)
 					origID = h.ImageID(t, repoName)
 					assertMockAppRunsWithOutput(t,
@@ -1632,8 +1629,7 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 							output := pack.RunSuccessfully(
 								"rebase", repoName,
 								"--run-image", runAfter,
-								"--pull-policy",
-								"never",
+								"--no-pull",
 							)
 
 							assert.Contains(output, fmt.Sprintf("Successfully rebased image '%s'", repoName))
@@ -1660,7 +1656,7 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 						})
 
 						it("prefers the local mirror", func() {
-							output := pack.RunSuccessfully("rebase", repoName, "--pull-policy", "never")
+							output := pack.RunSuccessfully("rebase", repoName, "--no-pull")
 
 							assertOutput := assertions.NewOutputAssertionManager(t, output)
 							assertOutput.ReportsSelectingRunImageMirrorFromLocalConfig(localRunImageMirror)
@@ -1683,7 +1679,7 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 						})
 
 						it("selects the best mirror", func() {
-							output := pack.RunSuccessfully("rebase", repoName, "--pull-policy", "never")
+							output := pack.RunSuccessfully("rebase", repoName, "--no-pull")
 
 							assertOutput := assertions.NewOutputAssertionManager(t, output)
 							assertOutput.ReportsSelectingRunImageMirror(runImageMirror)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -356,7 +356,7 @@ func testWithoutSpecificBuilderRequirement(
 				})
 			})
 
-			when("--no-pull", func() {
+			when("--pull-policy=never", func() {
 				it("should use local image", func() {
 					nestedPackage := packageBuildpackLocally(simplePackageConfigPath)
 					defer h.DockerRmi(dockerCli, nestedPackage)
@@ -367,7 +367,8 @@ func testWithoutSpecificBuilderRequirement(
 					pack.JustRunSuccessfully(
 						"package-buildpack", packageName,
 						"-c", aggregatePackageToml,
-						"--no-pull",
+						"--pull-policy",
+						"never",
 					)
 
 					_, _, err := dockerCli.ImageInspectWithRaw(context.Background(), packageName)
@@ -385,7 +386,8 @@ func testWithoutSpecificBuilderRequirement(
 					output, err := pack.Run(
 						"package-buildpack", packageName,
 						"-c", aggregatePackageToml,
-						"--no-pull",
+						"--pull-policy",
+						"never",
 					)
 					assert.NotNil(err)
 					assertions.NewOutputAssertionManager(t, output).ReportsImageNotExistingOnDaemon(nestedPackage)
@@ -1591,7 +1593,8 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 						"-p", filepath.Join("testdata", "mock_app"),
 						"--builder", builderName,
 						"--run-image", runBefore,
-						"--no-pull",
+						"--pull-policy",
+						"never",
 					)
 					origID = h.ImageID(t, repoName)
 					assertMockAppRunsWithOutput(t,
@@ -1629,7 +1632,8 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 							output := pack.RunSuccessfully(
 								"rebase", repoName,
 								"--run-image", runAfter,
-								"--no-pull",
+								"--pull-policy",
+								"never",
 							)
 
 							assert.Contains(output, fmt.Sprintf("Successfully rebased image '%s'", repoName))
@@ -1656,7 +1660,7 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 						})
 
 						it("prefers the local mirror", func() {
-							output := pack.RunSuccessfully("rebase", repoName, "--no-pull")
+							output := pack.RunSuccessfully("rebase", repoName, "--pull-policy", "never")
 
 							assertOutput := assertions.NewOutputAssertionManager(t, output)
 							assertOutput.ReportsSelectingRunImageMirrorFromLocalConfig(localRunImageMirror)
@@ -1679,7 +1683,7 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 						})
 
 						it("selects the best mirror", func() {
-							output := pack.RunSuccessfully("rebase", repoName, "--no-pull")
+							output := pack.RunSuccessfully("rebase", repoName, "--pull-policy", "never")
 
 							assertOutput := assertions.NewOutputAssertionManager(t, output)
 							assertOutput.ReportsSelectingRunImageMirror(runImageMirror)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -364,6 +364,7 @@ func testWithoutSpecificBuilderRequirement(
 
 					packageName := registryConfig.RepoName("test/package-" + h.RandString(10))
 					defer h.DockerRmi(dockerCli, packageName)
+					// TODO: Replace --no-pull with pull-policy never. See https://github.com/buildpacks/pack/issues/775
 					pack.JustRunSuccessfully(
 						"package-buildpack", packageName,
 						"-c", aggregatePackageToml,
@@ -382,6 +383,7 @@ func testWithoutSpecificBuilderRequirement(
 
 					packageName := registryConfig.RepoName("test/package-" + h.RandString(10))
 					defer h.DockerRmi(dockerCli, packageName)
+					// TODO: Replace --no-pull with pull-policy never. See https://github.com/buildpacks/pack/issues/775
 					output, err := pack.Run(
 						"package-buildpack", packageName,
 						"-c", aggregatePackageToml,
@@ -1586,6 +1588,7 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 												`, runImage, contents1, contents2))
 					}
 					buildRunImage(runBefore, "contents-before-1", "contents-before-2")
+					// TODO: Replace --no-pull with pull-policy never. See https://github.com/buildpacks/pack/issues/775
 					pack.RunSuccessfully(
 						"build", repoName,
 						"-p", filepath.Join("testdata", "mock_app"),
@@ -1626,6 +1629,7 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 						})
 
 						it("uses provided run image", func() {
+							// TODO: Replace --no-pull with pull-policy never. See https://github.com/buildpacks/pack/issues/775
 							output := pack.RunSuccessfully(
 								"rebase", repoName,
 								"--run-image", runAfter,
@@ -1656,6 +1660,7 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 						})
 
 						it("prefers the local mirror", func() {
+							// TODO: Replace --no-pull with pull-policy never. See https://github.com/buildpacks/pack/issues/775
 							output := pack.RunSuccessfully("rebase", repoName, "--no-pull")
 
 							assertOutput := assertions.NewOutputAssertionManager(t, output)
@@ -1679,6 +1684,7 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 						})
 
 						it("selects the best mirror", func() {
+							// TODO: Replace --no-pull with pull-policy never. See https://github.com/buildpacks/pack/issues/775
 							output := pack.RunSuccessfully("rebase", repoName, "--no-pull")
 
 							assertOutput := assertions.NewOutputAssertionManager(t, output)

--- a/build.go
+++ b/build.go
@@ -92,7 +92,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		return errors.Wrapf(err, "invalid builder '%s'", opts.Builder)
 	}
 
-	rawBuilderImage, err := c.imageFetcher.NewFetch(ctx, builderRef.Name(), true, opts.PullPolicy)
+	rawBuilderImage, err := c.imageFetcher.Fetch(ctx, builderRef.Name(), true, opts.PullPolicy)
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch builder image '%s'", builderRef.Name())
 	}
@@ -183,7 +183,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 	if !opts.TrustBuilder {
 		switch lifecycleImageSupported {
 		case true:
-			lifecycleImage, err := c.imageFetcher.NewFetch(
+			lifecycleImage, err := c.imageFetcher.Fetch(
 				ctx,
 				fmt.Sprintf("%s:%s", lifecycleImageRepo, lifecycleVersion.String()),
 				true,
@@ -254,7 +254,7 @@ func (c *Client) validateRunImage(context context.Context, name string, pullPoli
 	if name == "" {
 		return nil, errors.New("run image must be specified")
 	}
-	img, err := c.imageFetcher.NewFetch(context, name, !publish, pullPolicy)
+	img, err := c.imageFetcher.Fetch(context, name, !publish, pullPolicy)
 	if err != nil {
 		return nil, err
 	}

--- a/build_test.go
+++ b/build_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/Masterminds/semver"
 	"github.com/buildpacks/imgutil/fakes"
 	"github.com/buildpacks/lifecycle/api"
@@ -1503,44 +1505,44 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("NoPull option", func() {
-			when("true", func() {
+		when("PullPolicy", func() {
+			when("never", func() {
 				it("uses the local builder and run images without updating", func() {
 					h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
-						Image:   "some/app",
-						Builder: defaultBuilderName,
-						NoPull:  true,
+						Image:      "some/app",
+						Builder:    defaultBuilderName,
+						PullPolicy: config.PullNever,
 					}))
 
 					args := fakeImageFetcher.FetchCalls["default/run"]
 					h.AssertEq(t, args.Daemon, true)
-					h.AssertEq(t, args.Pull, false)
+					h.AssertEq(t, args.PullPolicy, config.PullNever)
 
 					args = fakeImageFetcher.FetchCalls[defaultBuilderName]
 					h.AssertEq(t, args.Daemon, true)
-					h.AssertEq(t, args.Pull, false)
+					h.AssertEq(t, args.PullPolicy, config.PullNever)
 
 					args = fakeImageFetcher.FetchCalls["buildpacksio/lifecycle:0.9.0"]
 					h.AssertEq(t, args.Daemon, true)
-					h.AssertEq(t, args.Pull, false)
+					h.AssertEq(t, args.PullPolicy, config.PullNever)
 				})
 			})
 
-			when("false", func() {
+			when("always", func() {
 				it("uses pulls the builder and run image before using them", func() {
 					h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
-						Image:   "some/app",
-						Builder: defaultBuilderName,
-						NoPull:  false,
+						Image:      "some/app",
+						Builder:    defaultBuilderName,
+						PullPolicy: config.PullAlways,
 					}))
 
 					args := fakeImageFetcher.FetchCalls["default/run"]
 					h.AssertEq(t, args.Daemon, true)
-					h.AssertEq(t, args.Pull, true)
+					h.AssertEq(t, args.PullPolicy, config.PullAlways)
 
 					args = fakeImageFetcher.FetchCalls[defaultBuilderName]
 					h.AssertEq(t, args.Daemon, true)
-					h.AssertEq(t, args.Pull, true)
+					h.AssertEq(t, args.PullPolicy, config.PullAlways)
 				})
 			})
 		})

--- a/build_test.go
+++ b/build_test.go
@@ -1357,7 +1357,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 
 							args := fakeImageFetcher.FetchCalls[fakeLifecycleImage.Name()]
 							h.AssertEq(t, args.Daemon, true)
-							h.AssertEq(t, args.Pull, true)
+							h.AssertEq(t, args.PullPolicy, config.PullAlways)
 						})
 					})
 
@@ -1419,11 +1419,11 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 
 					args := fakeImageFetcher.FetchCalls["default/run"]
 					h.AssertEq(t, args.Daemon, true)
-					h.AssertEq(t, args.Pull, true)
+					h.AssertEq(t, args.PullPolicy, config.PullAlways)
 
 					args = fakeImageFetcher.FetchCalls[defaultBuilderName]
 					h.AssertEq(t, args.Daemon, true)
-					h.AssertEq(t, args.Pull, true)
+					h.AssertEq(t, args.PullPolicy, config.PullAlways)
 				})
 
 				when("builder is untrusted", func() {
@@ -1440,7 +1440,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 
 							args := fakeImageFetcher.FetchCalls[fakeLifecycleImage.Name()]
 							h.AssertEq(t, args.Daemon, true)
-							h.AssertEq(t, args.Pull, true)
+							h.AssertEq(t, args.PullPolicy, config.PullAlways)
 						})
 
 						it("suggests that being untrusted may be the root of a failure", func() {

--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/pkg/errors"
 
+	pubcfg "github.com/buildpacks/pack/config"
 	"github.com/buildpacks/pack/internal/blob"
 	"github.com/buildpacks/pack/internal/build"
 	"github.com/buildpacks/pack/internal/config"
@@ -23,6 +24,7 @@ type ImageFetcher interface {
 	// If daemon is true, it will look return a `local.Image`. Pull, applicable only when daemon is true, will
 	// attempt to pull a remote image first.
 	Fetch(ctx context.Context, name string, daemon, pull bool) (imgutil.Image, error)
+	NewFetch(ctx context.Context, name string, daemon bool, pullPolicy pubcfg.PullPolicy) (imgutil.Image, error)
 }
 
 //go:generate mockgen -package testmocks -destination testmocks/mock_downloader.go github.com/buildpacks/pack Downloader

--- a/client.go
+++ b/client.go
@@ -23,8 +23,7 @@ type ImageFetcher interface {
 	// Fetch fetches an image by resolving it both remotely and locally depending on provided parameters.
 	// If daemon is true, it will look return a `local.Image`. Pull, applicable only when daemon is true, will
 	// attempt to pull a remote image first.
-	Fetch(ctx context.Context, name string, daemon, pull bool) (imgutil.Image, error)
-	NewFetch(ctx context.Context, name string, daemon bool, pullPolicy pubcfg.PullPolicy) (imgutil.Image, error)
+	Fetch(ctx context.Context, name string, daemon bool, pullPolicy pubcfg.PullPolicy) (imgutil.Image, error)
 }
 
 //go:generate mockgen -package testmocks -destination testmocks/mock_downloader.go github.com/buildpacks/pack Downloader

--- a/config/pull_policy.go
+++ b/config/pull_policy.go
@@ -1,6 +1,8 @@
 package config
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+)
 
 // PullPolicy defines a policy for how to manage images
 type PullPolicy int
@@ -14,18 +16,15 @@ const (
 	PullIfNotPresent
 )
 
+var nameMap = map[string]PullPolicy{"always": PullAlways, "never": PullNever, "if-not-present": PullIfNotPresent, "": PullAlways}
+
 // ParsePullPolicy from string
 func ParsePullPolicy(policy string) (PullPolicy, error) {
-	switch policy {
-	case "never":
-		return PullNever, nil
-	case "if-not-present":
-		return PullIfNotPresent, nil
-	case "always", "": //Default option
-		return PullAlways, nil
-	default:
-		return PullAlways, errors.Errorf("invalid pull policy %s", policy)
+	if val, ok := nameMap[policy]; ok {
+		return val, nil
 	}
+
+	return PullAlways, errors.Errorf("invalid pull policy %s", policy)
 }
 
 //ParsePolicyFromPull parses PullPolicy from boolean
@@ -35,4 +34,8 @@ func ParsePolicyFromPull(pull bool) PullPolicy {
 	}
 
 	return PullNever
+}
+
+func (p PullPolicy) String() string {
+	return [...]string{"always", "never", "if-not-present"}[p]
 }

--- a/config/pull_policy.go
+++ b/config/pull_policy.go
@@ -28,5 +28,14 @@ func ParsePullPolicy(policy string) (PullPolicy, error) {
 }
 
 func (p PullPolicy) String() string {
-	return [...]string{"always", "never", "if-not-present"}[p]
+	switch p {
+	case PullAlways:
+		return "always"
+	case PullNever:
+		return "never"
+	case PullIfNotPresent:
+		return "if-not-present"
+	}
+
+	return ""
 }

--- a/config/pull_policy.go
+++ b/config/pull_policy.go
@@ -27,15 +27,6 @@ func ParsePullPolicy(policy string) (PullPolicy, error) {
 	return PullAlways, errors.Errorf("invalid pull policy %s", policy)
 }
 
-//ParsePolicyFromPull parses PullPolicy from boolean
-func ParsePolicyFromPull(pull bool) PullPolicy {
-	if pull {
-		return PullAlways
-	}
-
-	return PullNever
-}
-
 func (p PullPolicy) String() string {
 	return [...]string{"always", "never", "if-not-present"}[p]
 }

--- a/config/pull_policy.go
+++ b/config/pull_policy.go
@@ -1,0 +1,38 @@
+package config
+
+import "github.com/pkg/errors"
+
+// PullPolicy defines a policy for how to manage images
+type PullPolicy int
+
+const (
+	// PullNever images, even if they are not present
+	PullNever PullPolicy = iota
+	// PullAlways images, even if they are present
+	PullAlways
+	// PullIfNotPresent pulls images if they aren't present
+	PullIfNotPresent
+)
+
+// ParsePullPolicy from string
+func ParsePullPolicy(policy string) (PullPolicy, error) {
+	switch policy {
+	case "never":
+		return PullNever, nil
+	case "if-not-present":
+		return PullIfNotPresent, nil
+	case "always", "": //Default option
+		return PullAlways, nil
+	default:
+		return PullAlways, errors.Errorf("invalid pull policy %s", policy)
+	}
+}
+
+//ParsePolicyFromPull parses PullPolicy from boolean
+func ParsePolicyFromPull(pull bool) PullPolicy {
+	if pull {
+		return PullAlways
+	}
+
+	return PullNever
+}

--- a/config/pull_policy.go
+++ b/config/pull_policy.go
@@ -6,10 +6,10 @@ import "github.com/pkg/errors"
 type PullPolicy int
 
 const (
-	// PullNever images, even if they are not present
-	PullNever PullPolicy = iota
 	// PullAlways images, even if they are present
-	PullAlways
+	PullAlways PullPolicy = iota
+	// PullNever images, even if they are not present
+	PullNever
 	// PullIfNotPresent pulls images if they aren't present
 	PullIfNotPresent
 )

--- a/config/pull_policy_test.go
+++ b/config/pull_policy_test.go
@@ -1,11 +1,13 @@
 package config_test
 
 import (
-	"github.com/buildpacks/pack/config"
-	h "github.com/buildpacks/pack/testhelpers"
+	"testing"
+
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
-	"testing"
+
+	"github.com/buildpacks/pack/config"
+	h "github.com/buildpacks/pack/testhelpers"
 )
 
 func TestPullPolicy(t *testing.T) {

--- a/config/pull_policy_test.go
+++ b/config/pull_policy_test.go
@@ -46,16 +46,6 @@ func testPullPolicy(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
-	when("#ParsePolicyFromPull", func() {
-		it("returns PullAlways if true", func() {
-			h.AssertEq(t, config.ParsePolicyFromPull(true), config.PullAlways)
-		})
-
-		it("returns PullNever if false", func() {
-			h.AssertEq(t, config.ParsePolicyFromPull(false), config.PullNever)
-		})
-	})
-
 	when("#String", func() {
 		it("returns the right String value", func() {
 			h.AssertEq(t, config.PullAlways.String(), "always")

--- a/config/pull_policy_test.go
+++ b/config/pull_policy_test.go
@@ -1,0 +1,56 @@
+package config_test
+
+import (
+	"github.com/buildpacks/pack/config"
+	h "github.com/buildpacks/pack/testhelpers"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"testing"
+)
+
+func TestPullPolicy(t *testing.T) {
+	spec.Run(t, "PullPolicy", testPullPolicy, spec.Report(report.Terminal{}))
+}
+
+func testPullPolicy(t *testing.T, when spec.G, it spec.S) {
+	when("#ParsePullPolicy", func() {
+		it("returns PullNever for never", func() {
+			policy, err := config.ParsePullPolicy("never")
+			h.AssertNil(t, err)
+			h.AssertEq(t, policy, config.PullNever)
+		})
+
+		it("returns PullAlways for always", func() {
+			policy, err := config.ParsePullPolicy("always")
+			h.AssertNil(t, err)
+			h.AssertEq(t, policy, config.PullAlways)
+		})
+
+		it("returns PullIfNotPresent for if-not-present", func() {
+			policy, err := config.ParsePullPolicy("if-not-present")
+			h.AssertNil(t, err)
+			h.AssertEq(t, policy, config.PullIfNotPresent)
+		})
+
+		it("defaults to PullAlways, if empty string", func() {
+			policy, err := config.ParsePullPolicy("")
+			h.AssertNil(t, err)
+			h.AssertEq(t, policy, config.PullAlways)
+		})
+
+		it("returns error for unknown string", func() {
+			_, err := config.ParsePullPolicy("fake-policy-here")
+			h.AssertError(t, err, "invalid pull policy")
+		})
+	})
+
+	when("#ParsePolicyFromPull", func() {
+		it("returns PullAlways if true", func() {
+			h.AssertEq(t, config.ParsePolicyFromPull(true), config.PullAlways)
+		})
+
+		it("returns PullNever if false", func() {
+			h.AssertEq(t, config.ParsePolicyFromPull(false), config.PullNever)
+		})
+	})
+}

--- a/config/pull_policy_test.go
+++ b/config/pull_policy_test.go
@@ -55,4 +55,12 @@ func testPullPolicy(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, config.ParsePolicyFromPull(false), config.PullNever)
 		})
 	})
+
+	when("#String", func() {
+		it("returns the right String value", func() {
+			h.AssertEq(t, config.PullAlways.String(), "always")
+			h.AssertEq(t, config.PullNever.String(), "never")
+			h.AssertEq(t, config.PullIfNotPresent.String(), "if-not-present")
+		})
+	})
 }

--- a/create_builder.go
+++ b/create_builder.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/Masterminds/semver"
 	"github.com/buildpacks/imgutil"
 	"github.com/pkg/errors"
@@ -25,6 +27,7 @@ type CreateBuilderOptions struct {
 	Publish     bool
 	NoPull      bool
 	Registry    string
+	PullPolicy  config.PullPolicy
 }
 
 // CreateBuilder creates a builder
@@ -202,7 +205,7 @@ func (c *Client) addBuildpacksToBuilder(ctx context.Context, opts CreateBuilderO
 		case buildpack.PackageLocator:
 			c.logger.Debugf("Downloading buildpack from image: %s", style.Symbol(b.ImageName))
 
-			mainBP, depBPs, err = extractPackagedBuildpacks(ctx, b.ImageName, c.imageFetcher, opts.Publish, opts.NoPull)
+			mainBP, depBPs, err = extractPackagedBuildpacks(ctx, b.ImageName, c.imageFetcher, opts.Publish, opts.PullPolicy)
 			if err != nil {
 				return err
 			}
@@ -219,7 +222,7 @@ func (c *Client) addBuildpacksToBuilder(ctx context.Context, opts CreateBuilderO
 				return errors.Wrapf(err, "locating in registry %s", style.Symbol(b.URI))
 			}
 
-			mainBP, depBPs, err = extractPackagedBuildpacks(ctx, registryBp.Address, c.imageFetcher, opts.Publish, opts.NoPull)
+			mainBP, depBPs, err = extractPackagedBuildpacks(ctx, registryBp.Address, c.imageFetcher, opts.Publish, opts.PullPolicy)
 			if err != nil {
 				return errors.Wrapf(err, "extracting from registry %s", style.Symbol(b.URI))
 			}

--- a/create_builder.go
+++ b/create_builder.go
@@ -25,7 +25,6 @@ type CreateBuilderOptions struct {
 	BuilderName string
 	Config      pubbldr.Config
 	Publish     bool
-	NoPull      bool
 	Registry    string
 	PullPolicy  config.PullPolicy
 }
@@ -67,7 +66,7 @@ func (c *Client) validateRunImageConfig(ctx context.Context, opts CreateBuilderO
 	var runImages []imgutil.Image
 	for _, i := range append([]string{opts.Config.Stack.RunImage}, opts.Config.Stack.RunImageMirrors...) {
 		if !opts.Publish {
-			img, err := c.imageFetcher.Fetch(ctx, i, true, false)
+			img, err := c.imageFetcher.NewFetch(ctx, i, true, opts.PullPolicy)
 			if err != nil {
 				if errors.Cause(err) != image.ErrNotFound {
 					return errors.Wrap(err, "failed to fetch image")
@@ -78,7 +77,7 @@ func (c *Client) validateRunImageConfig(ctx context.Context, opts CreateBuilderO
 			}
 		}
 
-		img, err := c.imageFetcher.Fetch(ctx, i, false, false)
+		img, err := c.imageFetcher.NewFetch(ctx, i, false, opts.PullPolicy)
 		if err != nil {
 			if errors.Cause(err) != image.ErrNotFound {
 				return errors.Wrap(err, "failed to fetch image")
@@ -109,7 +108,7 @@ func (c *Client) validateRunImageConfig(ctx context.Context, opts CreateBuilderO
 }
 
 func (c *Client) createBaseBuilder(ctx context.Context, opts CreateBuilderOptions) (*builder.Builder, error) {
-	baseImage, err := c.imageFetcher.Fetch(ctx, opts.Config.Stack.BuildImage, !opts.Publish, !opts.NoPull)
+	baseImage, err := c.imageFetcher.NewFetch(ctx, opts.Config.Stack.BuildImage, !opts.Publish, opts.PullPolicy)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch build image")
 	}

--- a/create_builder.go
+++ b/create_builder.go
@@ -66,7 +66,7 @@ func (c *Client) validateRunImageConfig(ctx context.Context, opts CreateBuilderO
 	var runImages []imgutil.Image
 	for _, i := range append([]string{opts.Config.Stack.RunImage}, opts.Config.Stack.RunImageMirrors...) {
 		if !opts.Publish {
-			img, err := c.imageFetcher.NewFetch(ctx, i, true, opts.PullPolicy)
+			img, err := c.imageFetcher.Fetch(ctx, i, true, opts.PullPolicy)
 			if err != nil {
 				if errors.Cause(err) != image.ErrNotFound {
 					return errors.Wrap(err, "failed to fetch image")
@@ -77,7 +77,7 @@ func (c *Client) validateRunImageConfig(ctx context.Context, opts CreateBuilderO
 			}
 		}
 
-		img, err := c.imageFetcher.NewFetch(ctx, i, false, opts.PullPolicy)
+		img, err := c.imageFetcher.Fetch(ctx, i, false, opts.PullPolicy)
 		if err != nil {
 			if errors.Cause(err) != image.ErrNotFound {
 				return errors.Wrap(err, "failed to fetch image")
@@ -108,7 +108,7 @@ func (c *Client) validateRunImageConfig(ctx context.Context, opts CreateBuilderO
 }
 
 func (c *Client) createBaseBuilder(ctx context.Context, opts CreateBuilderOptions) (*builder.Builder, error) {
-	baseImage, err := c.imageFetcher.NewFetch(ctx, opts.Config.Stack.BuildImage, !opts.Publish, opts.PullPolicy)
+	baseImage, err := c.imageFetcher.Fetch(ctx, opts.Config.Stack.BuildImage, !opts.Publish, opts.PullPolicy)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch build image")
 	}

--- a/create_builder_test.go
+++ b/create_builder_test.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/buildpacks/imgutil/fakes"
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/golang/mock/gomock"
@@ -666,7 +668,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 					opts.Config.Buildpacks[0].URI = "urn:cnb:registry:example/foo@1.1.0"
 
 					packageImage := fakes.NewImage("example.com/some/package@sha256:74eb48882e835d8767f62940d453eb96ed2737de3a16573881dcea7dea769df7", "", nil)
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), true, true).Return(nil, errors.New("failed to pull"))
+					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), packageImage.Name(), true, config.PullAlways).Return(nil, errors.New("failed to pull"))
 
 					err := subject.CreateBuilder(context.TODO(), opts)
 					h.AssertError(t, err,
@@ -740,8 +742,8 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				return url
 			}
 
-			shouldFetchPackageImageWith := func(demon, pull bool) {
-				mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), demon, pull).Return(packageImage, nil)
+			shouldFetchPackageImageWith := func(demon bool, pull config.PullPolicy) {
+				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), packageImage.Name(), demon, pull).Return(packageImage, nil)
 			}
 
 			when("package image lives in cnb registry", func() {
@@ -795,6 +797,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 
 						opts.Publish = false
 						opts.NoPull = false
+						opts.PullPolicy = config.PullAlways
 						opts.Registry = registryFixture
 						opts.Config.Buildpacks = append(
 							opts.Config.Buildpacks,
@@ -807,7 +810,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 							},
 						)
 
-						shouldFetchPackageImageWith(true, true)
+						shouldFetchPackageImageWith(true, config.PullAlways)
 						h.AssertNil(t, subject.CreateBuilder(context.TODO(), opts))
 					})
 				})
@@ -829,12 +832,13 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 						Config: pubbldpkg.Config{
 							Buildpack: dist.BuildpackURI{URI: createBuildpack(bpd)},
 						},
-						Publish: true,
+						Publish:    true,
+						PullPolicy: config.PullAlways,
 					}))
 				})
 
 				prepareFetcherWithMissingPackageImage := func() {
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), gomock.Any(), gomock.Any()).Return(nil, image.ErrNotFound)
+					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), packageImage.Name(), gomock.Any(), gomock.Any()).Return(nil, image.ErrNotFound)
 				}
 
 				when("publish=false and no-pull=false", func() {
@@ -845,6 +849,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 
 						opts.Publish = false
 						opts.NoPull = false
+						opts.PullPolicy = config.PullAlways
 						opts.Config.Buildpacks = append(
 							opts.Config.Buildpacks,
 							pubbldr.BuildpackConfig{
@@ -854,7 +859,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 							},
 						)
 
-						shouldFetchPackageImageWith(true, true)
+						shouldFetchPackageImageWith(true, config.PullAlways)
 						h.AssertNil(t, subject.CreateBuilder(context.TODO(), opts))
 					})
 				})
@@ -867,6 +872,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 
 						opts.Publish = true
 						opts.NoPull = false
+						opts.PullPolicy = config.PullAlways
 						opts.Config.Buildpacks = append(
 							opts.Config.Buildpacks,
 							pubbldr.BuildpackConfig{
@@ -876,12 +882,12 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 							},
 						)
 
-						shouldFetchPackageImageWith(false, true)
+						shouldFetchPackageImageWith(false, config.PullAlways)
 						h.AssertNil(t, subject.CreateBuilder(context.TODO(), opts))
 					})
 				})
 
-				when("publish=true and no-pull=true", func() {
+				when("publish=true and pull-policy=never", func() {
 					it("should push to registry and not pull package image", func() {
 						prepareFetcherWithBuildImage()
 						prepareFetcherWithRunImages()
@@ -889,6 +895,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 
 						opts.Publish = true
 						opts.NoPull = true
+						opts.PullPolicy = config.PullNever
 						opts.Config.Buildpacks = append(
 							opts.Config.Buildpacks,
 							pubbldr.BuildpackConfig{
@@ -898,12 +905,12 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 							},
 						)
 
-						shouldFetchPackageImageWith(false, false)
+						shouldFetchPackageImageWith(false, config.PullNever)
 						h.AssertNil(t, subject.CreateBuilder(context.TODO(), opts))
 					})
 				})
 
-				when("publish=false no-pull=true and there is no local package image", func() {
+				when("publish=false pull-policy=never and there is no local package image", func() {
 					it("should fail without trying to retrieve package image from registry", func() {
 						prepareFetcherWithBuildImage()
 						prepareFetcherWithRunImages()
@@ -911,6 +918,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 
 						opts.Publish = false
 						opts.NoPull = true
+						opts.PullPolicy = config.PullNever
 						opts.Config.Buildpacks = append(
 							opts.Config.Buildpacks,
 							pubbldr.BuildpackConfig{
@@ -943,7 +951,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 						},
 					)
 
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), notPackageImage.Name(), gomock.Any(), gomock.Any()).Return(notPackageImage, nil)
+					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), notPackageImage.Name(), gomock.Any(), gomock.Any()).Return(notPackageImage, nil)
 					h.AssertNil(t, notPackageImage.SetLabel("io.buildpacks.buildpack.layers", ""))
 
 					h.AssertError(t, subject.CreateBuilder(context.TODO(), opts), "extracting buildpacks from 'not/package': could not find label 'io.buildpacks.buildpackage.metadata'")

--- a/create_builder_test.go
+++ b/create_builder_test.go
@@ -117,7 +117,8 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 					},
 					Lifecycle: pubbldr.LifecycleConfig{URI: "file:///some-lifecycle"},
 				},
-				Publish: false,
+				Publish:    false,
+				PullPolicy: config.PullAlways,
 			}
 
 			tmpDir, err = ioutil.TempDir("", "create-builder-test")

--- a/create_builder_test.go
+++ b/create_builder_test.go
@@ -131,12 +131,12 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		var prepareFetcherWithRunImages = func() {
-			mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/run-image", gomock.Any(), gomock.Any()).Return(fakeRunImage, nil).AnyTimes()
-			mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "localhost:5000/some/run-image", gomock.Any(), gomock.Any()).Return(fakeRunImageMirror, nil).AnyTimes()
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", gomock.Any(), gomock.Any()).Return(fakeRunImage, nil).AnyTimes()
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "localhost:5000/some/run-image", gomock.Any(), gomock.Any()).Return(fakeRunImageMirror, nil).AnyTimes()
 		}
 
 		var prepareFetcherWithBuildImage = func() {
-			mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/build-image", gomock.Any(), gomock.Any()).Return(fakeBuildImage, nil)
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", gomock.Any(), gomock.Any()).Return(fakeBuildImage, nil)
 		}
 
 		var successfullyCreateBuilder = func() *builder.Builder {
@@ -162,7 +162,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("should fail when the stack ID from the builder config does not match the stack ID from the build image", func() {
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(fakeBuildImage, nil)
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(fakeBuildImage, nil)
 				h.AssertNil(t, fakeBuildImage.SetLabel("io.buildpacks.stack.id", "other.stack.id"))
 				prepareFetcherWithRunImages()
 
@@ -250,13 +250,13 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("should warn when the run image cannot be found", func() {
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(fakeBuildImage, nil)
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(fakeBuildImage, nil)
 
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/run-image", false, config.PullAlways).Return(nil, errors.Wrap(image.ErrNotFound, "yikes"))
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/run-image", true, config.PullAlways).Return(nil, errors.Wrap(image.ErrNotFound, "yikes"))
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", false, config.PullAlways).Return(nil, errors.Wrap(image.ErrNotFound, "yikes"))
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", true, config.PullAlways).Return(nil, errors.Wrap(image.ErrNotFound, "yikes"))
 
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "localhost:5000/some/run-image", false, config.PullAlways).Return(nil, errors.Wrap(image.ErrNotFound, "yikes"))
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "localhost:5000/some/run-image", true, config.PullAlways).Return(nil, errors.Wrap(image.ErrNotFound, "yikes"))
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "localhost:5000/some/run-image", false, config.PullAlways).Return(nil, errors.Wrap(image.ErrNotFound, "yikes"))
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "localhost:5000/some/run-image", true, config.PullAlways).Return(nil, errors.Wrap(image.ErrNotFound, "yikes"))
 
 				err := subject.CreateBuilder(context.TODO(), opts)
 				h.AssertNil(t, err)
@@ -265,14 +265,14 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("should fail when not publish and the run image cannot be fetched", func() {
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/run-image", true, config.PullAlways).Return(nil, errors.New("yikes"))
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", true, config.PullAlways).Return(nil, errors.New("yikes"))
 
 				err := subject.CreateBuilder(context.TODO(), opts)
 				h.AssertError(t, err, "failed to fetch image: yikes")
 			})
 
 			it("should fail when publish and the run image cannot be fetched", func() {
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/run-image", false, config.PullAlways).Return(nil, errors.New("yikes"))
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", false, config.PullAlways).Return(nil, errors.New("yikes"))
 
 				opts.Publish = true
 				err := subject.CreateBuilder(context.TODO(), opts)
@@ -282,8 +282,8 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 			it("should fail when the run image isn't a valid image", func() {
 				fakeImage := fakeBadImageStruct{}
 
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/run-image", gomock.Any(), gomock.Any()).Return(fakeImage, nil).AnyTimes()
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "localhost:5000/some/run-image", gomock.Any(), gomock.Any()).Return(fakeImage, nil).AnyTimes()
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", gomock.Any(), gomock.Any()).Return(fakeImage, nil).AnyTimes()
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "localhost:5000/some/run-image", gomock.Any(), gomock.Any()).Return(fakeImage, nil).AnyTimes()
 
 				err := subject.CreateBuilder(context.TODO(), opts)
 				h.AssertError(t, err, "failed to label image")
@@ -291,13 +291,13 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 
 			when("publish is true", func() {
 				it("should only try to validate the remote run image", func() {
-					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/build-image", true, gomock.Any()).Times(0)
-					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/run-image", true, gomock.Any()).Times(0)
-					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "localhost:5000/some/run-image", true, gomock.Any()).Times(0)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", true, gomock.Any()).Times(0)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", true, gomock.Any()).Times(0)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "localhost:5000/some/run-image", true, gomock.Any()).Times(0)
 
-					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/build-image", false, gomock.Any()).Return(fakeBuildImage, nil)
-					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/run-image", false, gomock.Any()).Return(fakeRunImage, nil)
-					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "localhost:5000/some/run-image", false, gomock.Any()).Return(fakeRunImageMirror, nil)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", false, gomock.Any()).Return(fakeBuildImage, nil)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", false, gomock.Any()).Return(fakeRunImage, nil)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "localhost:5000/some/run-image", false, gomock.Any()).Return(fakeRunImageMirror, nil)
 
 					opts.Publish = true
 
@@ -311,7 +311,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 			when("build image not found", func() {
 				it("should fail", func() {
 					prepareFetcherWithRunImages()
-					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(nil, image.ErrNotFound)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(nil, image.ErrNotFound)
 
 					err := subject.CreateBuilder(context.TODO(), opts)
 					h.AssertError(t, err, "fetch build image: not found")
@@ -323,7 +323,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 					fakeImage := fakeBadImageStruct{}
 
 					prepareFetcherWithRunImages()
-					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(fakeImage, nil)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(fakeImage, nil)
 
 					err := subject.CreateBuilder(context.TODO(), opts)
 					h.AssertError(t, err, "failed to create builder: invalid build-image")
@@ -345,7 +345,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 						prepareFetcherWithRunImages()
 
 						fakeBuildImage.SetPlatform("windows", "0123", "amd64")
-						mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(fakeBuildImage, nil)
+						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(fakeBuildImage, nil)
 
 						err = packClientWithExperimental.CreateBuilder(context.TODO(), opts)
 						h.AssertNil(t, err)
@@ -357,7 +357,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 						prepareFetcherWithRunImages()
 
 						fakeBuildImage.SetPlatform("windows", "0123", "amd64")
-						mockImageFetcher.EXPECT().NewFetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(fakeBuildImage, nil)
+						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(fakeBuildImage, nil)
 
 						err := subject.CreateBuilder(context.TODO(), opts)
 						h.AssertError(t, err, "failed to create builder: Windows containers support is currently experimental.")
@@ -668,7 +668,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 					opts.Config.Buildpacks[0].URI = "urn:cnb:registry:example/foo@1.1.0"
 
 					packageImage := fakes.NewImage("example.com/some/package@sha256:74eb48882e835d8767f62940d453eb96ed2737de3a16573881dcea7dea769df7", "", nil)
-					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), packageImage.Name(), true, config.PullAlways).Return(nil, errors.New("failed to pull"))
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), true, config.PullAlways).Return(nil, errors.New("failed to pull"))
 
 					err := subject.CreateBuilder(context.TODO(), opts)
 					h.AssertError(t, err,
@@ -743,7 +743,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			shouldFetchPackageImageWith := func(demon bool, pull config.PullPolicy) {
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), packageImage.Name(), demon, pull).Return(packageImage, nil)
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), demon, pull).Return(packageImage, nil)
 			}
 
 			when("package image lives in cnb registry", func() {
@@ -837,7 +837,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				prepareFetcherWithMissingPackageImage := func() {
-					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), packageImage.Name(), gomock.Any(), gomock.Any()).Return(nil, image.ErrNotFound)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), gomock.Any(), gomock.Any()).Return(nil, image.ErrNotFound)
 				}
 
 				when("publish=false and pull-policy=always", func() {
@@ -946,7 +946,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 						},
 					)
 
-					mockImageFetcher.EXPECT().NewFetch(gomock.Any(), notPackageImage.Name(), gomock.Any(), gomock.Any()).Return(notPackageImage, nil)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), notPackageImage.Name(), gomock.Any(), gomock.Any()).Return(notPackageImage, nil)
 					h.AssertNil(t, notPackageImage.SetLabel("io.buildpacks.buildpack.layers", ""))
 
 					h.AssertError(t, subject.CreateBuilder(context.TODO(), opts), "extracting buildpacks from 'not/package': could not find label 'io.buildpacks.buildpackage.metadata'")

--- a/inspect_builder.go
+++ b/inspect_builder.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/buildpacks/pack/config"
 	"github.com/buildpacks/pack/internal/builder"
 	"github.com/buildpacks/pack/internal/dist"
 	"github.com/buildpacks/pack/internal/image"
@@ -25,7 +26,7 @@ type BuilderInfo struct {
 }
 
 func (c *Client) InspectBuilder(name string, daemon bool) (*BuilderInfo, error) {
-	img, err := c.imageFetcher.Fetch(context.Background(), name, daemon, false)
+	img, err := c.imageFetcher.Fetch(context.Background(), name, daemon, config.PullNever)
 	if err != nil {
 		if errors.Cause(err) == image.ErrNotFound {
 			return nil, nil

--- a/inspect_builder_test.go
+++ b/inspect_builder_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/buildpacks/imgutil/fakes"
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/golang/mock/gomock"
@@ -66,9 +68,9 @@ func testInspectBuilder(t *testing.T, when spec.G, it spec.S) {
 			when(fmt.Sprintf("daemon is %t", useDaemon), func() {
 				it.Before(func() {
 					if useDaemon {
-						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", true, false).Return(builderImage, nil)
+						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", true, config.PullNever).Return(builderImage, nil)
 					} else {
-						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", false, false).Return(builderImage, nil)
+						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", false, config.PullNever).Return(builderImage, nil)
 					}
 				})
 
@@ -209,7 +211,7 @@ func testInspectBuilder(t *testing.T, when spec.G, it spec.S) {
 
 	when("fetcher fails to fetch the image", func() {
 		it.Before(func() {
-			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", false, false).Return(nil, errors.New("some-error"))
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", false, config.PullNever).Return(nil, errors.New("some-error"))
 		})
 
 		it("returns an error", func() {
@@ -222,7 +224,7 @@ func testInspectBuilder(t *testing.T, when spec.G, it spec.S) {
 		it.Before(func() {
 			notFoundImage := fakes.NewImage("", "", nil)
 			notFoundImage.Delete()
-			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", true, false).Return(nil, errors.Wrap(image.ErrNotFound, "some-error"))
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", true, config.PullNever).Return(nil, errors.Wrap(image.ErrNotFound, "some-error"))
 		})
 
 		it("return nil metadata", func() {

--- a/inspect_image.go
+++ b/inspect_image.go
@@ -3,6 +3,8 @@ package pack
 import (
 	"context"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/Masterminds/semver"
 	"github.com/buildpacks/lifecycle"
 	"github.com/buildpacks/lifecycle/launch"
@@ -33,7 +35,7 @@ type layersMetadata struct {
 }
 
 func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
-	img, err := c.imageFetcher.Fetch(context.Background(), name, daemon, false)
+	img, err := c.imageFetcher.Fetch(context.Background(), name, daemon, config.PullNever)
 	if err != nil {
 		if errors.Cause(err) == image.ErrNotFound {
 			return nil, nil

--- a/inspect_image_test.go
+++ b/inspect_image_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/buildpacks/imgutil/fakes"
 	"github.com/buildpacks/lifecycle"
 	"github.com/buildpacks/lifecycle/launch"
@@ -114,9 +116,9 @@ func testInspectImage(t *testing.T, when spec.G, it spec.S) {
 			when(fmt.Sprintf("daemon is %t", useDaemon), func() {
 				it.Before(func() {
 					if useDaemon {
-						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/image", true, false).Return(fakeImage, nil)
+						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/image", true, config.PullNever).Return(fakeImage, nil)
 					} else {
-						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/image", false, false).Return(fakeImage, nil)
+						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/image", false, config.PullNever).Return(fakeImage, nil)
 					}
 				})
 
@@ -296,7 +298,7 @@ func testInspectImage(t *testing.T, when spec.G, it spec.S) {
 
 	when("the image doesn't exist", func() {
 		it("returns nil", func() {
-			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "not/some-image", true, false).Return(nil, image.ErrNotFound)
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "not/some-image", true, config.PullNever).Return(nil, image.ErrNotFound)
 
 			info, err := subject.InspectImage("not/some-image", true)
 			h.AssertNil(t, err)
@@ -306,7 +308,7 @@ func testInspectImage(t *testing.T, when spec.G, it spec.S) {
 
 	when("there is an error fetching the image", func() {
 		it("returns the error", func() {
-			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "not/some-image", true, false).Return(nil, errors.New("some-error"))
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "not/some-image", true, config.PullNever).Return(nil, errors.New("some-error"))
 
 			_, err := subject.InspectImage("not/some-image", true)
 			h.AssertError(t, err, "some-error")
@@ -316,7 +318,7 @@ func testInspectImage(t *testing.T, when spec.G, it spec.S) {
 	when("the image is missing labels", func() {
 		it("returns empty data", func() {
 			mockImageFetcher.EXPECT().
-				Fetch(gomock.Any(), "missing/labels", true, false).
+				Fetch(gomock.Any(), "missing/labels", true, config.PullNever).
 				Return(fakes.NewImage("missing/labels", "", nil), nil)
 			info, err := subject.InspectImage("missing/labels", true)
 			h.AssertNil(t, err)
@@ -330,7 +332,7 @@ func testInspectImage(t *testing.T, when spec.G, it spec.S) {
 		it.Before(func() {
 			badImage = fakes.NewImage("bad/image", "", nil)
 			mockImageFetcher.EXPECT().
-				Fetch(gomock.Any(), "bad/image", true, false).
+				Fetch(gomock.Any(), "bad/image", true, config.PullNever).
 				Return(badImage, nil)
 		})
 
@@ -350,7 +352,7 @@ func testInspectImage(t *testing.T, when spec.G, it spec.S) {
 	when("lifecycle version is 0.4.x or earlier", func() {
 		it("includes an empty base image reference", func() {
 			oldImage := fakes.NewImage("old/image", "", nil)
-			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "old/image", true, false).Return(oldImage, nil)
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "old/image", true, config.PullNever).Return(oldImage, nil)
 
 			h.AssertNil(t, oldImage.SetLabel(
 				"io.buildpacks.lifecycle.metadata",

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -160,6 +160,7 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringArrayVar(&buildFlags.Volumes, "volume", nil, "Mount host volume into the build container, in the form '<host path>:<target path>[:<mode>]'."+multiValueHelp("volume"))
 	cmd.Flags().StringVarP(&buildFlags.DefaultProcessType, "default-process", "D", "", "Set the default process type")
 	cmd.Flags().StringVar(&buildFlags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
+	// TODO: Remove --no-pull flag after v0.13.0 released. See https://github.com/buildpacks/pack/issues/775
 	cmd.Flags().BoolVar(&buildFlags.NoPull, "no-pull", false, "Skip pulling builder and run images before use")
 	cmd.Flags().MarkHidden("no-pull")
 }

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	config2 "github.com/buildpacks/pack/config"
+	pubcfg "github.com/buildpacks/pack/config"
 
 	"github.com/pkg/errors"
 	ignore "github.com/sabhiram/go-gitignore"
@@ -105,9 +105,9 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				logger.Warn("Using untrusted builder with volume mounts. If there is sensitive data in the volumes, this may present a security vulnerability.")
 			}
 
-			pullPolicy, err := config2.ParsePullPolicy(flags.Policy)
+			pullPolicy, err := pubcfg.ParsePullPolicy(flags.Policy)
 			if err != nil {
-				return errors.Wrapf(err, "parse pull policy %s", flags.Policy)
+				return errors.Wrapf(err, "parsing pull policy %s", flags.Policy)
 			}
 
 			if err := packClient.Build(cmd.Context(), pack.BuildOptions{
@@ -181,7 +181,7 @@ func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackCli
 		if flags.Policy != "" {
 			logger.Warn("Flag --no-pull ignored in favor of --pull-policy")
 		} else {
-			flags.Policy = config2.PullNever.String()
+			flags.Policy = pubcfg.PullNever.String()
 		}
 	}
 

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -49,7 +49,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 		Args:  cobra.ExactArgs(1),
 		Short: "Generate app image from source code",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			if err := validateBuildFlags(flags, logger, cfg, packClient); err != nil {
+			if err := validateBuildFlags(&flags, cfg, packClient, logger); err != nil {
 				return err
 			}
 
@@ -105,16 +105,6 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				logger.Warn("Using untrusted builder with volume mounts. If there is sensitive data in the volumes, this may present a security vulnerability.")
 			}
 
-			if flags.NoPull {
-				logger.Warn("Flag --no-pull has been deprecated")
-
-				if flags.Policy != "" {
-					logger.Warn("Flag --no-pull ignored in favor of --pull-policy")
-				} else {
-					flags.Policy = config2.PullNever.String()
-				}
-			}
-
 			pullPolicy, err := config2.ParsePullPolicy(flags.Policy)
 			if err != nil {
 				return errors.Wrapf(err, "parse pull policy %s", flags.Policy)
@@ -162,7 +152,6 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringVar(&buildFlags.RunImage, "run-image", "", "Run image (defaults to default stack's run image)")
 	cmd.Flags().StringArrayVarP(&buildFlags.Env, "env", "e", []string{}, "Build-time environment variable, in the form 'VAR=VALUE' or 'VAR'.\nWhen using latter value-less form, value will be taken from current\n  environment at the time this command is executed.\nThis flag may be specified multiple times and will override\n  individual values defined by --env-file.")
 	cmd.Flags().StringArrayVar(&buildFlags.EnvFiles, "env-file", []string{}, "Build-time environment variables file\nOne variable per line, of the form 'VAR=VALUE' or 'VAR'\nWhen using latter value-less form, value will be taken from current\n  environment at the time this command is executed")
-	cmd.Flags().BoolVar(&buildFlags.NoPull, "no-pull", false, "Skip pulling builder and run images before use")
 	cmd.Flags().BoolVar(&buildFlags.ClearCache, "clear-cache", false, "Clear image's associated cache before building")
 	cmd.Flags().BoolVar(&buildFlags.TrustBuilder, "trust-builder", false, "Trust the provided builder\nAll lifecycle phases will be run in a single container (if supported by the lifecycle).")
 	cmd.Flags().StringSliceVarP(&buildFlags.Buildpacks, "buildpack", "b", nil, "Buildpack reference in the form of '<buildpack>@<version>',\n  path to a buildpack directory (not supported on Windows),\n  path/URL to a buildpack .tar or .tgz file, or\n  the name of a packaged buildpack image"+multiValueHelp("buildpack"))
@@ -170,10 +159,12 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringVarP(&buildFlags.DescriptorPath, "descriptor", "d", "", "Path to the project descriptor file")
 	cmd.Flags().StringArrayVar(&buildFlags.Volumes, "volume", nil, "Mount host volume into the build container, in the form '<host path>:<target path>[:<mode>]'."+multiValueHelp("volume"))
 	cmd.Flags().StringVarP(&buildFlags.DefaultProcessType, "default-process", "D", "", "Set the default process type")
-	cmd.Flags().StringVar(&buildFlags.Policy, "pull-policy", "", "pull policy to use")
+	cmd.Flags().StringVar(&buildFlags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
+	cmd.Flags().BoolVar(&buildFlags.NoPull, "no-pull", false, "Skip pulling builder and run images before use")
+	cmd.Flags().MarkHidden("no-pull")
 }
 
-func validateBuildFlags(flags BuildFlags, logger logging.Logger, cfg config.Config, packClient PackClient) error {
+func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackClient, logger logging.Logger) error {
 	if flags.Builder == "" {
 		suggestSettingBuilder(logger, packClient)
 		return pack.NewSoftError()
@@ -181,6 +172,16 @@ func validateBuildFlags(flags BuildFlags, logger logging.Logger, cfg config.Conf
 
 	if flags.Registry != "" && !cfg.Experimental {
 		return pack.NewExperimentError("Support for buildpack registries is currently experimental.")
+	}
+
+	if flags.NoPull {
+		logger.Warn("Flag --no-pull has been deprecated")
+
+		if flags.Policy != "" {
+			logger.Warn("Flag --no-pull ignored in favor of --pull-policy")
+		} else {
+			flags.Policy = config2.PullNever.String()
+		}
 	}
 
 	return nil

--- a/internal/commands/create_builder.go
+++ b/internal/commands/create_builder.go
@@ -77,6 +77,7 @@ func CreateBuilder(logger logging.Logger, cfg config.Config, client PackClient) 
 	cmd.Flags().StringVarP(&flags.BuilderTomlPath, "config", "c", "", "Path to builder TOML file (required)")
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, "Publish to registry")
 	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
+	// TODO: Remove --no-pull flag after v0.13.0 released. See https://github.com/buildpacks/pack/issues/775
 	cmd.Flags().BoolVar(&flags.NoPull, "no-pull", false, "Skip pulling build image before use")
 	cmd.Flags().MarkHidden("no-pull")
 

--- a/internal/commands/create_builder.go
+++ b/internal/commands/create_builder.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"fmt"
 
-	config2 "github.com/buildpacks/pack/config"
+	pubcfg "github.com/buildpacks/pack/config"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -41,7 +41,7 @@ func CreateBuilder(logger logging.Logger, cfg config.Config, client PackClient) 
 				logger.Warn("Flag --builder-config has been deprecated, please use --config instead")
 			}
 
-			pullPolicy, err := config2.ParsePullPolicy(flags.Policy)
+			pullPolicy, err := pubcfg.ParsePullPolicy(flags.Policy)
 			if err != nil {
 				return errors.Wrapf(err, "parsing pull policy %s", flags.Policy)
 			}
@@ -86,7 +86,7 @@ func CreateBuilder(logger logging.Logger, cfg config.Config, client PackClient) 
 }
 
 func validateCreateBuilderFlags(flags *CreateBuilderFlags, cfg config.Config, logger logging.Logger) error {
-	if flags.Publish && flags.Policy == config2.PullNever.String() {
+	if flags.Publish && flags.Policy == pubcfg.PullNever.String() {
 		return errors.Errorf("--publish and --pull-policy never cannot be used together. The --publish flag requires the use of remote images.")
 	}
 
@@ -108,7 +108,7 @@ func validateCreateBuilderFlags(flags *CreateBuilderFlags, cfg config.Config, lo
 		if flags.Policy != "" {
 			logger.Warn("Flag --no-pull ignored in favor of --pull-policy")
 		} else {
-			flags.Policy = config2.PullNever.String()
+			flags.Policy = pubcfg.PullNever.String()
 		}
 	}
 

--- a/internal/commands/create_builder.go
+++ b/internal/commands/create_builder.go
@@ -47,7 +47,7 @@ func CreateBuilder(logger logging.Logger, cfg config.Config, client PackClient) 
 				if cmd.Flags().Changed("pull-policy") {
 					logger.Warn("Flag --no-pull ignored in favor of --pull-policy")
 				} else {
-					policy = "never"
+					policy = config2.PullNever.String()
 				}
 			}
 

--- a/internal/commands/create_builder.go
+++ b/internal/commands/create_builder.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"fmt"
 
+	config2 "github.com/buildpacks/pack/config"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -24,17 +26,34 @@ type CreateBuilderFlags struct {
 // CreateBuilder creates a builder image, based on a builder config
 func CreateBuilder(logger logging.Logger, cfg config.Config, client PackClient) *cobra.Command {
 	var flags CreateBuilderFlags
+	var policy string
+
 	cmd := &cobra.Command{
 		Use:   "create-builder <image-name> --config <builder-config-path>",
 		Args:  cobra.ExactArgs(1),
 		Short: "Create builder image",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			if err := validateCreateBuilderFlags(flags, cfg); err != nil {
+			if err := validateCreateBuilderFlags(flags, cfg, policy); err != nil {
 				return err
 			}
 
 			if cmd.Flags().Changed("builder-config") {
 				logger.Warn("Flag --builder-config has been deprecated, please use --config instead")
+			}
+
+			if cmd.Flags().Changed("no-pull") {
+				logger.Warn("Flag --no-pull has been deprecated, please use `--pull-policy never` instead")
+
+				if cmd.Flags().Changed("pull-policy") {
+					logger.Warn("Flag --no-pull ignored in favor of --pull-policy")
+				} else {
+					policy = "never"
+				}
+			}
+
+			pullPolicy, err := config2.ParsePullPolicy(policy)
+			if err != nil {
+				return errors.Wrapf(err, "parsing pull policy %s", policy)
 			}
 
 			builderConfig, warns, err := builder.ReadConfig(flags.BuilderTomlPath)
@@ -50,8 +69,8 @@ func CreateBuilder(logger logging.Logger, cfg config.Config, client PackClient) 
 				BuilderName: imageName,
 				Config:      builderConfig,
 				Publish:     flags.Publish,
-				NoPull:      flags.NoPull,
 				Registry:    flags.Registry,
+				PullPolicy:  pullPolicy,
 			}); err != nil {
 				return err
 			}
@@ -69,11 +88,17 @@ func CreateBuilder(logger logging.Logger, cfg config.Config, client PackClient) 
 	cmd.Flags().StringVarP(&flags.BuilderTomlPath, "config", "c", "", "Path to builder TOML file (required)")
 
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, "Publish to registry")
+	cmd.Flags().StringVar(&policy, "pull-policy", "", "pull policy to use")
+
 	AddHelpFlag(cmd, "create-builder")
 	return cmd
 }
 
-func validateCreateBuilderFlags(flags CreateBuilderFlags, cfg config.Config) error {
+func validateCreateBuilderFlags(flags CreateBuilderFlags, cfg config.Config, policy string) error {
+	if flags.Publish && policy == "never" {
+		return errors.Errorf("--publish and --pull-policy never cannot be used together. The --publish flag requires the use of remote images.")
+	}
+
 	if flags.Publish && flags.NoPull {
 		return errors.Errorf("The --publish and --no-pull flags cannot be used together. The --publish flag requires the use of remote images.")
 	}

--- a/internal/commands/create_builder_test.go
+++ b/internal/commands/create_builder_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/buildpacks/pack"
 	"github.com/buildpacks/pack/builder"
-	config2 "github.com/buildpacks/pack/config"
+	pubcfg "github.com/buildpacks/pack/config"
 	"github.com/buildpacks/pack/internal/dist"
 
 	"github.com/golang/mock/gomock"
@@ -114,7 +114,7 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 				opts := pack.CreateBuilderOptions{
 					BuilderName: "some/builder",
 					Config:      validConfigStruct,
-					PullPolicy:  config2.PullNever,
+					PullPolicy:  pubcfg.PullNever,
 				}
 				mockClient.EXPECT().CreateBuilder(gomock.Any(), opts).Return(nil)
 
@@ -131,7 +131,7 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 				opts := pack.CreateBuilderOptions{
 					BuilderName: "some/builder",
 					Config:      validConfigStruct,
-					PullPolicy:  config2.PullAlways,
+					PullPolicy:  pubcfg.PullAlways,
 				}
 				mockClient.EXPECT().CreateBuilder(gomock.Any(), opts).Return(nil)
 
@@ -146,6 +146,17 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 				output := outBuf.String()
 				h.AssertContains(t, output, "Warning: Flag --no-pull has been deprecated")
 				h.AssertContains(t, output, "Warning: Flag --no-pull ignored in favor of --pull-policy")
+			})
+		})
+
+		when("--pull-policy", func() {
+			it("returns error for unknown policy", func() {
+				command.SetArgs([]string{
+					"some/builder",
+					"--config", builderConfigPath,
+					"--pull-policy", "unknown-policy",
+				})
+				h.AssertError(t, command.Execute(), "parsing pull policy")
 			})
 		})
 

--- a/internal/commands/create_builder_test.go
+++ b/internal/commands/create_builder_test.go
@@ -6,6 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/buildpacks/pack"
+	"github.com/buildpacks/pack/builder"
+	config2 "github.com/buildpacks/pack/config"
+	"github.com/buildpacks/pack/internal/dist"
+
 	"github.com/golang/mock/gomock"
 	"github.com/heroku/color"
 	"github.com/sclevine/spec"
@@ -19,6 +24,21 @@ import (
 	"github.com/buildpacks/pack/logging"
 	h "github.com/buildpacks/pack/testhelpers"
 )
+
+const validConfig = `
+[[buildpacks]]
+  id = "some.buildpack"
+
+[[order]]
+	[[order.group]]
+		id = "some.buildpack"
+
+`
+
+var validConfigStruct = builder.Config{
+	Buildpacks: []builder.BuildpackConfig{{BuildpackInfo: dist.BuildpackInfo{ID: "some.buildpack"}}},
+	Order:      dist.Order{{Group: []dist.BuildpackRef{{BuildpackInfo: dist.BuildpackInfo{ID: "some.buildpack"}}}}},
+}
 
 func TestCreateBuilderCommand(t *testing.T) {
 	color.Disable(true)
@@ -70,6 +90,65 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("both --publish and pull-policy=never flags are specified", func() {
+			it("errors with a descriptive message", func() {
+				command.SetArgs([]string{
+					"some/builder",
+					"--config", "some-config-path",
+					"--publish",
+					"--pull-policy",
+					"never",
+				})
+				err := command.Execute()
+				h.AssertNotNil(t, err)
+				h.AssertError(t, err, "--publish and --pull-policy never cannot be used together. The --publish flag requires the use of remote images.")
+			})
+		})
+
+		when("no-pull flag is specified", func() {
+			it.Before(func() {
+				h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(validConfig), 0666))
+			})
+
+			it("works and logs warning", func() {
+				opts := pack.CreateBuilderOptions{
+					BuilderName: "some/builder",
+					Config:      validConfigStruct,
+					PullPolicy:  config2.PullNever,
+				}
+				mockClient.EXPECT().CreateBuilder(gomock.Any(), opts).Return(nil)
+
+				command.SetArgs([]string{
+					"some/builder",
+					"--config", builderConfigPath,
+					"--no-pull",
+				})
+				h.AssertNil(t, command.Execute())
+				h.AssertContains(t, outBuf.String(), "Warning: Flag --no-pull has been deprecated")
+			})
+
+			it("disregards no-pull if used with pull-policy always and logs warning", func() {
+				opts := pack.CreateBuilderOptions{
+					BuilderName: "some/builder",
+					Config:      validConfigStruct,
+					PullPolicy:  config2.PullAlways,
+				}
+				mockClient.EXPECT().CreateBuilder(gomock.Any(), opts).Return(nil)
+
+				command.SetArgs([]string{
+					"some/builder",
+					"--config", builderConfigPath,
+					"--no-pull",
+					"--pull-policy",
+					"always",
+				})
+				h.AssertNil(t, command.Execute())
+				output := outBuf.String()
+				h.AssertContains(t, output, "Warning: Flag --no-pull has been deprecated")
+				h.AssertContains(t, output, "Warning: Flag --no-pull ignored in favor of --pull-policy")
+			})
+		})
+
 		when("--buildpack-registry flag is specified but experimental isn't set in the config", func() {
 			it("errors with a descriptive message", func() {
 				command.SetArgs([]string{
@@ -106,15 +185,7 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 		when("uses --builder-config", func() {
 			it.Before(func() {
-				h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`
-[[buildpacks]]
-  id = "some.buildpack"
-
-[[order]]
-	[[order.group]]
-		id = "some.buildpack"
-
-`), 0666))
+				h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(validConfig), 0666))
 			})
 
 			it("errors with a descriptive message", func() {

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -113,7 +113,7 @@ func validateFlags(logger logging.Logger, p PackageBuildpackFlags, policy *strin
 		if *policy != "" {
 			logger.Warn("Flag --no-pull ignored in favor of --pull-policy")
 		} else {
-			*policy = "never"
+			*policy = config.PullNever.String()
 		}
 	}
 

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -42,14 +42,14 @@ func PackageBuildpack(logger logging.Logger, client BuildpackPackager, packageCo
 		Short: "Package buildpack in OCI format.",
 		Args:  cobra.ExactValidArgs(1),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			if err := validateFlags(&flags, logger); err != nil {
+			if err := validatePackageBuildpackFlags(&flags, logger); err != nil {
 				return err
 			}
 
 			var err error
 			pullPolicy, err := config.ParsePullPolicy(flags.Policy)
 			if err != nil {
-				return errors.Wrap(err, "parse pull policy")
+				return errors.Wrap(err, "parsing pull policy")
 			}
 
 			if cmd.Flags().Changed("package-config") {
@@ -94,7 +94,7 @@ func PackageBuildpack(logger logging.Logger, client BuildpackPackager, packageCo
 	return cmd
 }
 
-func validateFlags(p *PackageBuildpackFlags, logger logging.Logger) error {
+func validatePackageBuildpackFlags(p *PackageBuildpackFlags, logger logging.Logger) error {
 	if p.Publish && p.Policy == config.PullNever.String() {
 		return errors.Errorf("--publish and --pull-policy never cannot be used together. The --publish flag requires the use of remote images.")
 	}

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"context"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -18,6 +20,7 @@ type PackageBuildpackFlags struct {
 	Format          string
 	Publish         bool
 	NoPull          bool
+	Policy          config.PullPolicy
 }
 
 // BuildpackPackager packages buildpacks
@@ -30,16 +33,24 @@ type PackageConfigReader interface {
 	Read(path string) (pubbldpkg.Config, error)
 }
 
-// PackageBuildpack packages (a) buildpack(s) into OCI format, baed on a package config
+// PackageBuildpack packages (a) buildpack(s) into OCI format, based on a package config
 func PackageBuildpack(logger logging.Logger, client BuildpackPackager, packageConfigReader PackageConfigReader) *cobra.Command {
 	var flags PackageBuildpackFlags
+	var policy string
+
 	cmd := &cobra.Command{
 		Use:   `package-buildpack <name> --config <package-config-path>`,
 		Short: "Package buildpack in OCI format.",
 		Args:  cobra.ExactValidArgs(1),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			if err := flags.validate(); err != nil {
+			if err := validateFlags(logger, flags, &policy); err != nil {
 				return err
+			}
+
+			var err error
+			flags.Policy, err = config.ParsePullPolicy(policy)
+			if err != nil {
+				return errors.Wrap(err, "parse pull policy")
 			}
 
 			if cmd.Flags().Changed("package-config") {
@@ -53,11 +64,11 @@ func PackageBuildpack(logger logging.Logger, client BuildpackPackager, packageCo
 
 			name := args[0]
 			if err := client.PackageBuildpack(cmd.Context(), pack.PackageBuildpackOptions{
-				Name:    name,
-				Format:  flags.Format,
-				Config:  config,
-				Publish: flags.Publish,
-				NoPull:  flags.NoPull,
+				Name:       name,
+				Format:     flags.Format,
+				Config:     config,
+				Publish:    flags.Publish,
+				PullPolicy: flags.Policy,
 			}); err != nil {
 				return err
 			}
@@ -75,13 +86,19 @@ func PackageBuildpack(logger logging.Logger, client BuildpackPackager, packageCo
 
 	cmd.Flags().StringVarP(&flags.Format, "format", "f", "", `Format to save package as ("image" or "file")`)
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, `Publish to registry (applies to "--image" only)`)
+	cmd.Flags().StringVar(&policy, "pull-policy", "", "pull policy to use")
 	cmd.Flags().BoolVar(&flags.NoPull, "no-pull", false, "Skip pulling packages before use")
-	AddHelpFlag(cmd, "package-buildpack")
+	cmd.Flags().MarkHidden("no-pull")
 
+	AddHelpFlag(cmd, "package-buildpack")
 	return cmd
 }
 
-func (p PackageBuildpackFlags) validate() error {
+func validateFlags(logger logging.Logger, p PackageBuildpackFlags, policy *string) error {
+	if p.Publish && *policy == "never" {
+		return errors.Errorf("--publish and --pull-policy never cannot be used together. The --publish flag requires the use of remote images.")
+	}
+
 	if p.Publish && p.NoPull {
 		return errors.Errorf("The --publish and --no-pull flags cannot be used together. The --publish flag requires the use of remote images.")
 	}
@@ -89,5 +106,16 @@ func (p PackageBuildpackFlags) validate() error {
 	if p.PackageTomlPath == "" {
 		return errors.Errorf("Please provide a package config path, using --config")
 	}
+
+	if p.NoPull {
+		logger.Warn("Flag --no-pull has been deprecated, please use `--pull-policy never` instead")
+
+		if *policy != "" {
+			logger.Warn("Flag --no-pull ignored in favor of --pull-policy")
+		} else {
+			*policy = "never"
+		}
+	}
+
 	return nil
 }

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -86,6 +86,7 @@ func PackageBuildpack(logger logging.Logger, client BuildpackPackager, packageCo
 	cmd.Flags().StringVarP(&flags.Format, "format", "f", "", `Format to save package as ("image" or "file")`)
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, `Publish to registry (applies to "--image" only)`)
 	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
+	// TODO: Remove --no-pull flag after v0.13.0 released. See https://github.com/buildpacks/pack/issues/775
 	cmd.Flags().BoolVar(&flags.NoPull, "no-pull", false, "Skip pulling packages before use")
 	cmd.Flags().MarkHidden("no-pull")
 

--- a/internal/commands/package_buildpack_test.go
+++ b/internal/commands/package_buildpack_test.go
@@ -303,7 +303,7 @@ func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 					"unknown-policy",
 				})
 
-				h.AssertError(t, command.Execute(), "parse pull policy")
+				h.AssertError(t, command.Execute(), "parsing pull policy")
 			})
 		})
 	})

--- a/internal/commands/package_buildpack_test.go
+++ b/internal/commands/package_buildpack_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/heroku/color"
 	"github.com/pkg/errors"
 	"github.com/sclevine/spec"
@@ -22,11 +24,174 @@ import (
 func TestPackageBuildpackCommand(t *testing.T) {
 	color.Disable(true)
 	defer color.Disable(false)
-	spec.Run(t, "Commands", testPackageBuildpackCommand, spec.Parallel(), spec.Report(report.Terminal{}))
+	spec.Run(t, "PackageBuildpackCommand", testPackageBuildpackCommand, spec.Parallel(), spec.Report(report.Terminal{}))
 }
 
 func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 	when("PackageBuildpack#Execute", func() {
+		when("valid package config", func() {
+			it("reads package config from the configured path", func() {
+				fakePackageConfigReader := fakes.NewFakePackageConfigReader()
+				expectedConfigPath := "/path/to/some/file"
+
+				packageBuildpackCommand := packageBuildpackCommand(
+					withConfigReader(fakePackageConfigReader),
+					withConfigPath(expectedConfigPath),
+				)
+
+				err := packageBuildpackCommand.Execute()
+				h.AssertNil(t, err)
+
+				h.AssertEq(t, fakePackageConfigReader.ReadCalledWithArg, expectedConfigPath)
+			})
+
+			it("creates package with correct image name", func() {
+				fakeBuildpackPackager := &fakes.FakeBuildpackPackager{}
+
+				packageBuildpackCommand := packageBuildpackCommand(
+					withImageName("my-specific-image"),
+					withBuildpackPackager(fakeBuildpackPackager),
+				)
+
+				err := packageBuildpackCommand.Execute()
+				h.AssertNil(t, err)
+
+				receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+
+				h.AssertEq(t, receivedOptions.Name, "my-specific-image")
+			})
+
+			it("creates package with config returned by the reader", func() {
+				fakeBuildpackPackager := &fakes.FakeBuildpackPackager{}
+
+				myConfig := pubbldpkg.Config{
+					Buildpack: dist.BuildpackURI{URI: "test"},
+				}
+
+				packageBuildpackCommand := packageBuildpackCommand(
+					withBuildpackPackager(fakeBuildpackPackager),
+					withConfigReader(fakes.NewFakePackageConfigReader(whereReadReturns(myConfig, nil))),
+				)
+
+				err := packageBuildpackCommand.Execute()
+				h.AssertNil(t, err)
+
+				receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+
+				h.AssertEq(t, receivedOptions.Config, myConfig)
+			})
+
+			when("--no-pull", func() {
+				var (
+					outBuf                bytes.Buffer
+					cmd                   *cobra.Command
+					args                  []string
+					fakeBuildpackPackager *fakes.FakeBuildpackPackager
+				)
+
+				it.Before(func() {
+					logger := logging.NewLogWithWriters(&outBuf, &outBuf)
+					fakeBuildpackPackager = &fakes.FakeBuildpackPackager{}
+
+					cmd = packageBuildpackCommand(withLogger(logger), withBuildpackPackager(fakeBuildpackPackager))
+					args = []string{
+						"some-image-name",
+						"--config", "/path/to/some/file",
+					}
+				})
+
+				it("logs warning and works", func() {
+					args = append(args, "--no-pull")
+					cmd.SetArgs(args)
+
+					err := cmd.Execute()
+					h.AssertContains(t, outBuf.String(), "Warning: Flag --no-pull has been deprecated")
+					h.AssertNil(t, err)
+
+					receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+					h.AssertEq(t, receivedOptions.PullPolicy, config.PullNever)
+				})
+
+				when("used together with --pull-policy always", func() {
+					it("logs warning and disregards --no-pull", func() {
+						args = append(args, "--no-pull", "--pull-policy", "always")
+						cmd.SetArgs(args)
+
+						err := cmd.Execute()
+						h.AssertNil(t, err)
+
+						output := outBuf.String()
+						h.AssertContains(t, outBuf.String(), "Warning: Flag --no-pull has been deprecated")
+						h.AssertContains(t, output, "Flag --no-pull ignored in favor of --pull-policy")
+
+						receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+						h.AssertEq(t, receivedOptions.PullPolicy, config.PullAlways)
+					})
+				})
+
+				when("used together with --pull-policy never", func() {
+					it("logs warning and disregards --no-pull", func() {
+						args = append(args, "--no-pull", "--pull-policy", "never")
+						cmd.SetArgs(args)
+
+						err := cmd.Execute()
+						h.AssertNil(t, err)
+
+						output := outBuf.String()
+						h.AssertContains(t, outBuf.String(), "Warning: Flag --no-pull has been deprecated")
+						h.AssertContains(t, output, "Flag --no-pull ignored in favor of --pull-policy")
+
+						receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+						h.AssertEq(t, receivedOptions.PullPolicy, config.PullNever)
+					})
+				})
+			})
+
+			when("pull-policy", func() {
+				var (
+					outBuf                bytes.Buffer
+					cmd                   *cobra.Command
+					args                  []string
+					fakeBuildpackPackager *fakes.FakeBuildpackPackager
+				)
+
+				it.Before(func() {
+					logger := logging.NewLogWithWriters(&outBuf, &outBuf)
+					fakeBuildpackPackager = &fakes.FakeBuildpackPackager{}
+
+					cmd = packageBuildpackCommand(withLogger(logger), withBuildpackPackager(fakeBuildpackPackager))
+					args = []string{
+						"some-image-name",
+						"--config", "/path/to/some/file",
+					}
+				})
+
+				it("pull-policy=never sets policy", func() {
+					args = append(args, "--pull-policy", "never")
+					cmd.SetArgs(args)
+
+					err := cmd.Execute()
+					h.AssertNil(t, err)
+
+					receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+					h.AssertEq(t, receivedOptions.PullPolicy, config.PullNever)
+				})
+
+				it("pull-policy=always sets policy", func() {
+					args = append(args, "--pull-policy", "always")
+					cmd.SetArgs(args)
+
+					err := cmd.Execute()
+					h.AssertNil(t, err)
+
+					receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+					h.AssertEq(t, receivedOptions.PullPolicy, config.PullAlways)
+				})
+			})
+		})
+	})
+
+	when("invalid flags", func() {
 		when("both --publish and --no-pull flags are specified", func() {
 			it("errors with a descriptive message", func() {
 				logger := logging.NewLogWithWriters(&bytes.Buffer{}, &bytes.Buffer{})
@@ -47,19 +212,25 @@ func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		it("reads package config from the configured path", func() {
-			fakePackageConfigReader := fakes.NewFakePackageConfigReader()
-			expectedConfigPath := "/path/to/some/file"
+		when("both --publish and --pull-policy never flags are specified", func() {
+			it("errors with a descriptive message", func() {
+				logger := logging.NewLogWithWriters(&bytes.Buffer{}, &bytes.Buffer{})
+				configReader := fakes.NewFakePackageConfigReader()
+				buildpackPackager := &fakes.FakeBuildpackPackager{}
 
-			packageBuildpackCommand := packageBuildpackCommand(
-				withConfigReader(fakePackageConfigReader),
-				withConfigPath(expectedConfigPath),
-			)
+				command := commands.PackageBuildpack(logger, buildpackPackager, configReader)
+				command.SetArgs([]string{
+					"some-image-name",
+					"--config", "/path/to/some/file",
+					"--publish",
+					"--pull-policy",
+					"never",
+				})
 
-			err := packageBuildpackCommand.Execute()
-			h.AssertNil(t, err)
-
-			h.AssertEq(t, fakePackageConfigReader.ReadCalledWithArg, expectedConfigPath)
+				err := command.Execute()
+				h.AssertNotNil(t, err)
+				h.AssertError(t, err, "--publish and --pull-policy never cannot be used together. The --publish flag requires the use of remote images.")
+			})
 		})
 
 		it("logs an error and exits when package toml is invalid", func() {
@@ -77,42 +248,6 @@ func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNotNil(t, err)
 
 			h.AssertContains(t, outBuf.String(), fmt.Sprintf("ERROR: reading config: %s", expectedErr))
-		})
-
-		it("creates package with correct image name", func() {
-			fakeBuildpackPackager := &fakes.FakeBuildpackPackager{}
-
-			packageBuildpackCommand := packageBuildpackCommand(
-				withImageName("my-specific-image"),
-				withBuildpackPackager(fakeBuildpackPackager),
-			)
-
-			err := packageBuildpackCommand.Execute()
-			h.AssertNil(t, err)
-
-			receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
-
-			h.AssertEq(t, receivedOptions.Name, "my-specific-image")
-		})
-
-		it("creates package with config returned by the reader", func() {
-			fakeBuildpackPackager := &fakes.FakeBuildpackPackager{}
-
-			myConfig := pubbldpkg.Config{
-				Buildpack: dist.BuildpackURI{URI: "test"},
-			}
-
-			packageBuildpackCommand := packageBuildpackCommand(
-				withBuildpackPackager(fakeBuildpackPackager),
-				withConfigReader(fakes.NewFakePackageConfigReader(whereReadReturns(myConfig, nil))),
-			)
-
-			err := packageBuildpackCommand.Execute()
-			h.AssertNil(t, err)
-
-			receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
-
-			h.AssertEq(t, receivedOptions.Config, myConfig)
 		})
 
 		when("package-config is specified", func() {
@@ -151,6 +286,24 @@ func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 
 				err := cmd.Execute()
 				h.AssertError(t, err, "Please provide a package config path")
+			})
+		})
+
+		when("--pull-policy unknown-policy", func() {
+			it("fails to run", func() {
+				logger := logging.NewLogWithWriters(&bytes.Buffer{}, &bytes.Buffer{})
+				configReader := fakes.NewFakePackageConfigReader()
+				buildpackPackager := &fakes.FakeBuildpackPackager{}
+
+				command := commands.PackageBuildpack(logger, buildpackPackager, configReader)
+				command.SetArgs([]string{
+					"some-image-name",
+					"--config", "/path/to/some/file",
+					"--pull-policy",
+					"unknown-policy",
+				})
+
+				h.AssertError(t, command.Execute(), "parse pull policy")
 			})
 		})
 	})

--- a/internal/commands/rebase.go
+++ b/internal/commands/rebase.go
@@ -52,6 +52,7 @@ func Rebase(logger logging.Logger, cfg config.Config, client PackClient) *cobra.
 	cmd.Flags().BoolVar(&opts.Publish, "publish", false, "Publish to registry")
 	cmd.Flags().StringVar(&opts.RunImage, "run-image", "", "Run image to use for rebasing")
 	cmd.Flags().StringVar(&policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
+	// TODO: Remove --no-pull flag after v0.13.0 released. See https://github.com/buildpacks/pack/issues/775
 	cmd.Flags().BoolVar(&noPull, "no-pull", false, "Skip pulling app and run images before use")
 	cmd.Flags().MarkHidden("no-pull")
 

--- a/internal/commands/rebase.go
+++ b/internal/commands/rebase.go
@@ -50,12 +50,11 @@ func Rebase(logger logging.Logger, cfg config.Config, client PackClient) *cobra.
 	}
 
 	cmd.Flags().BoolVar(&opts.Publish, "publish", false, "Publish to registry")
-	cmd.Flags().StringVar(&policy, "pull-policy", "", "pull policy to use")
 	cmd.Flags().StringVar(&opts.RunImage, "run-image", "", "Run image to use for rebasing")
-	AddHelpFlag(cmd, "rebase")
-
+	cmd.Flags().StringVar(&policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
 	cmd.Flags().BoolVar(&noPull, "no-pull", false, "Skip pulling app and run images before use")
 	cmd.Flags().MarkHidden("no-pull")
 
+	AddHelpFlag(cmd, "rebase")
 	return cmd
 }

--- a/internal/commands/rebase.go
+++ b/internal/commands/rebase.go
@@ -31,7 +31,7 @@ func Rebase(logger logging.Logger, cfg config.Config, client PackClient) *cobra.
 				if cmd.Flags().Changed("pull-policy") {
 					logger.Warn("Flag --no-pull ignored in favor of --pull-policy")
 				} else if noPull {
-					policy = "never"
+					policy = pubcfg.PullNever.String()
 				}
 			}
 

--- a/internal/commands/rebase.go
+++ b/internal/commands/rebase.go
@@ -38,7 +38,7 @@ func Rebase(logger logging.Logger, cfg config.Config, client PackClient) *cobra.
 			var err error
 			opts.PullPolicy, err = pubcfg.ParsePullPolicy(policy)
 			if err != nil {
-				return errors.Wrapf(err, "parse pull policy %s", policy)
+				return errors.Wrapf(err, "parsing pull policy %s", policy)
 			}
 
 			if err := client.Rebase(cmd.Context(), opts); err != nil {

--- a/internal/commands/rebase_test.go
+++ b/internal/commands/rebase_test.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/heroku/color"
+
+	config2 "github.com/buildpacks/pack/config"
+
 	"github.com/golang/mock/gomock"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
@@ -19,6 +23,9 @@ import (
 )
 
 func TestRebaseCommand(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+
 	spec.Run(t, "Commands", testRebaseCommand, spec.Parallel(), spec.Report(report.Terminal{}))
 }
 
@@ -51,40 +58,102 @@ func testRebaseCommand(t *testing.T, when spec.G, it spec.S) {
 
 		when("image name is provided", func() {
 			var (
-				runImage    string
-				testMirror1 string
-				testMirror2 string
+				repoName string
+				opts     pack.RebaseOptions
 			)
 			it.Before(func() {
-				runImage = "test/image"
-				testMirror1 = "example.com/some/run1"
-				testMirror2 = "example.com/some/run2"
+				runImage := "test/image"
+				testMirror1 := "example.com/some/run1"
+				testMirror2 := "example.com/some/run2"
 
 				cfg.RunImages = []config.RunImage{{
 					Image:   runImage,
 					Mirrors: []string{testMirror1, testMirror2},
 				}}
 				command = commands.Rebase(logger, cfg, mockClient)
-			})
 
-			it("works", func() {
-				repoName := "test/repo-image"
-				opts := pack.RebaseOptions{
-					RepoName: repoName,
-					Publish:  false,
-					SkipPull: false,
-					RunImage: "",
+				repoName = "test/repo-image"
+				opts = pack.RebaseOptions{
+					RepoName:   repoName,
+					Publish:    false,
+					PullPolicy: config2.PullAlways,
+					RunImage:   "",
 					AdditionalMirrors: map[string][]string{
 						runImage: {testMirror1, testMirror2},
 					},
 				}
+			})
 
+			it("works", func() {
 				mockClient.EXPECT().
 					Rebase(gomock.Any(), opts).
 					Return(nil)
 
 				command.SetArgs([]string{repoName})
 				h.AssertNil(t, command.Execute())
+			})
+
+			when("--no-pull", func() {
+				it("logs warning and works", func() {
+					opts.PullPolicy = config2.PullNever
+					mockClient.EXPECT().
+						Rebase(gomock.Any(), opts).
+						Return(nil)
+
+					command.SetArgs([]string{repoName, "--no-pull"})
+					h.AssertNil(t, command.Execute())
+					h.AssertContains(t, outBuf.String(), "Warning: Flag --no-pull has been deprecated")
+				})
+
+				when("used together with --pull-policy always", func() {
+					it("logs warning and disregards --no-pull", func() {
+						opts.PullPolicy = config2.PullAlways
+						mockClient.EXPECT().
+							Rebase(gomock.Any(), opts).
+							Return(nil)
+
+						command.SetArgs([]string{repoName, "--no-pull", "--pull-policy", "always"})
+						h.AssertNil(t, command.Execute())
+						output := outBuf.String()
+						h.AssertContains(t, output, "Warning: Flag --no-pull has been deprecated")
+						h.AssertContains(t, output, "Flag --no-pull ignored in favor of --pull-policy")
+					})
+				})
+
+				when("used together with --pull-policy never", func() {
+					it("logs warning and disregards --no-pull", func() {
+						opts.PullPolicy = config2.PullNever
+						mockClient.EXPECT().
+							Rebase(gomock.Any(), opts).
+							Return(nil)
+
+						command.SetArgs([]string{repoName, "--no-pull", "--pull-policy", "never"})
+						h.AssertNil(t, command.Execute())
+
+						output := outBuf.String()
+						h.AssertContains(t, output, "Warning: Flag --no-pull has been deprecated")
+						h.AssertContains(t, output, "Flag --no-pull ignored in favor of --pull-policy")
+					})
+				})
+			})
+
+			when("--pull-policy never", func() {
+				it("works", func() {
+					opts.PullPolicy = config2.PullNever
+					mockClient.EXPECT().
+						Rebase(gomock.Any(), opts).
+						Return(nil)
+
+					command.SetArgs([]string{repoName, "--pull-policy", "never"})
+					h.AssertNil(t, command.Execute())
+				})
+			})
+
+			when("--pull-policy unknown-policy", func() {
+				it("fails to run", func() {
+					command.SetArgs([]string{repoName, "--pull-policy", "unknown-policy"})
+					h.AssertError(t, command.Execute(), "parse pull policy")
+				})
 			})
 		})
 	})

--- a/internal/commands/rebase_test.go
+++ b/internal/commands/rebase_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/heroku/color"
 
-	config2 "github.com/buildpacks/pack/config"
+	pubcfg "github.com/buildpacks/pack/config"
 
 	"github.com/golang/mock/gomock"
 	"github.com/sclevine/spec"
@@ -76,7 +76,7 @@ func testRebaseCommand(t *testing.T, when spec.G, it spec.S) {
 				opts = pack.RebaseOptions{
 					RepoName:   repoName,
 					Publish:    false,
-					PullPolicy: config2.PullAlways,
+					PullPolicy: pubcfg.PullAlways,
 					RunImage:   "",
 					AdditionalMirrors: map[string][]string{
 						runImage: {testMirror1, testMirror2},
@@ -95,7 +95,7 @@ func testRebaseCommand(t *testing.T, when spec.G, it spec.S) {
 
 			when("--no-pull", func() {
 				it("logs warning and works", func() {
-					opts.PullPolicy = config2.PullNever
+					opts.PullPolicy = pubcfg.PullNever
 					mockClient.EXPECT().
 						Rebase(gomock.Any(), opts).
 						Return(nil)
@@ -107,7 +107,7 @@ func testRebaseCommand(t *testing.T, when spec.G, it spec.S) {
 
 				when("used together with --pull-policy always", func() {
 					it("logs warning and disregards --no-pull", func() {
-						opts.PullPolicy = config2.PullAlways
+						opts.PullPolicy = pubcfg.PullAlways
 						mockClient.EXPECT().
 							Rebase(gomock.Any(), opts).
 							Return(nil)
@@ -122,7 +122,7 @@ func testRebaseCommand(t *testing.T, when spec.G, it spec.S) {
 
 				when("used together with --pull-policy never", func() {
 					it("logs warning and disregards --no-pull", func() {
-						opts.PullPolicy = config2.PullNever
+						opts.PullPolicy = pubcfg.PullNever
 						mockClient.EXPECT().
 							Rebase(gomock.Any(), opts).
 							Return(nil)
@@ -139,7 +139,7 @@ func testRebaseCommand(t *testing.T, when spec.G, it spec.S) {
 
 			when("--pull-policy never", func() {
 				it("works", func() {
-					opts.PullPolicy = config2.PullNever
+					opts.PullPolicy = pubcfg.PullNever
 					mockClient.EXPECT().
 						Rebase(gomock.Any(), opts).
 						Return(nil)
@@ -152,7 +152,7 @@ func testRebaseCommand(t *testing.T, when spec.G, it spec.S) {
 			when("--pull-policy unknown-policy", func() {
 				it("fails to run", func() {
 					command.SetArgs([]string{repoName, "--pull-policy", "unknown-policy"})
-					h.AssertError(t, command.Execute(), "parse pull policy")
+					h.AssertError(t, command.Execute(), "parsing pull policy")
 				})
 			})
 		})

--- a/internal/fakes/fake_image_fetcher.go
+++ b/internal/fakes/fake_image_fetcher.go
@@ -31,11 +31,7 @@ func NewFakeImageFetcher() *FakeImageFetcher {
 	}
 }
 
-func (f *FakeImageFetcher) Fetch(ctx context.Context, name string, daemon, pull bool) (imgutil.Image, error) {
-	return f.NewFetch(ctx, name, daemon, config.ParsePolicyFromPull(pull))
-}
-
-func (f *FakeImageFetcher) NewFetch(ctx context.Context, name string, daemon bool, policy config.PullPolicy) (imgutil.Image, error) {
+func (f *FakeImageFetcher) Fetch(ctx context.Context, name string, daemon bool, policy config.PullPolicy) (imgutil.Image, error) {
 	f.FetchCalls[name] = &FetchArgs{Daemon: daemon, Pull: boolFromPolicy(policy), PullPolicy: policy}
 
 	ri, remoteFound := f.RemoteImages[name]

--- a/internal/image/fetcher.go
+++ b/internal/image/fetcher.go
@@ -38,11 +38,7 @@ func NewFetcher(logger logging.Logger, docker client.CommonAPIClient) *Fetcher {
 
 var ErrNotFound = errors.New("not found")
 
-func (f *Fetcher) Fetch(ctx context.Context, name string, daemon, pull bool) (imgutil.Image, error) {
-	return f.NewFetch(ctx, name, daemon, config.ParsePolicyFromPull(pull))
-}
-
-func (f *Fetcher) NewFetch(ctx context.Context, name string, daemon bool, pullPolicy config.PullPolicy) (imgutil.Image, error) {
+func (f *Fetcher) Fetch(ctx context.Context, name string, daemon bool, pullPolicy config.PullPolicy) (imgutil.Image, error) {
 	if daemon && pullPolicy == config.PullNever {
 		return f.fetchDaemonImage(name)
 	}

--- a/internal/image/fetcher_test.go
+++ b/internal/image/fetcher_test.go
@@ -70,22 +70,14 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("returns the remote image", func() {
-					// TODO: Remove Fetch tests
-					_, err := fetcher.Fetch(context.TODO(), repoName, false, false)
-					h.AssertNil(t, err)
-
-					_, err = fetcher.NewFetch(context.TODO(), repoName, false, pubcfg.PullAlways)
+					_, err := fetcher.Fetch(context.TODO(), repoName, false, pubcfg.PullAlways)
 					h.AssertNil(t, err)
 				})
 			})
 
 			when("there is no remote image", func() {
 				it("returns an error", func() {
-					// TODO: Remove Fetch tests
-					_, err := fetcher.Fetch(context.TODO(), repoName, false, false)
-					h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist in registry", repoName))
-
-					_, err = fetcher.NewFetch(context.TODO(), repoName, false, pubcfg.PullAlways)
+					_, err := fetcher.Fetch(context.TODO(), repoName, false, pubcfg.PullAlways)
 					h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist in registry", repoName))
 				})
 			})
@@ -111,22 +103,14 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it("returns the local image", func() {
-						// TODO: Remove Fetch tests
-						_, err := fetcher.Fetch(context.TODO(), repoName, true, false)
-						h.AssertNil(t, err)
-
-						_, err = fetcher.NewFetch(context.TODO(), repoName, true, pubcfg.PullNever)
+						_, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullNever)
 						h.AssertNil(t, err)
 					})
 				})
 
 				when("there is no local image", func() {
 					it("returns an error", func() {
-						// TODO: Remove Fetch tests
-						_, err := fetcher.Fetch(context.TODO(), repoName, true, false)
-						h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist on the daemon", repoName))
-
-						_, err = fetcher.NewFetch(context.TODO(), repoName, true, pubcfg.PullNever)
+						_, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullNever)
 						h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist on the daemon", repoName))
 					})
 				})
@@ -152,11 +136,7 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it("pull the image and return the local copy", func() {
-						// TODO: Remove Fetch tests
-						_, err := fetcher.Fetch(context.TODO(), repoName, true, true)
-						h.AssertNil(t, err)
-
-						_, err = fetcher.NewFetch(context.TODO(), repoName, true, pubcfg.PullAlways)
+						_, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullAlways)
 						h.AssertNil(t, err)
 					})
 				})
@@ -175,22 +155,14 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 						})
 
 						it("returns the local image", func() {
-							// TODO: Remove Fetch tests
-							_, err := fetcher.Fetch(context.TODO(), repoName, true, true)
-							h.AssertNil(t, err)
-
-							_, err = fetcher.NewFetch(context.TODO(), repoName, true, pubcfg.PullAlways)
+							_, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullAlways)
 							h.AssertNil(t, err)
 						})
 					})
 
 					when("there is no local image", func() {
 						it("returns an error", func() {
-							// TODO: Remove Fetch tests
-							_, err := fetcher.Fetch(context.TODO(), repoName, true, true)
-							h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist on the daemon", repoName))
-
-							_, err = fetcher.NewFetch(context.TODO(), repoName, true, pubcfg.PullAlways)
+							_, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullAlways)
 							h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist on the daemon", repoName))
 						})
 					})

--- a/internal/image/fetcher_test.go
+++ b/internal/image/fetcher_test.go
@@ -110,7 +110,7 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("daemon is true", func() {
-			when("pullPolicy is PullNever", func() {
+			when("PullNever", func() {
 				when("there is a local image", func() {
 					it.Before(func() {
 						// Make sure the repoName is not a valid remote repo.
@@ -142,7 +142,7 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 
-			when("pullPolicy is PullAlways", func() {
+			when("PullAlways", func() {
 				when("there is a remote image", func() {
 					it.Before(func() {
 						// Instantiate a pull-able local image
@@ -195,7 +195,7 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 
-			when("pullPolicy is PullIfNotPresent", func() {
+			when("PullIfNotPresent", func() {
 				when("there is a remote image", func() {
 					var (
 						label          = "label"

--- a/internal/image/fetcher_test.go
+++ b/internal/image/fetcher_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
+	pubcfg "github.com/buildpacks/pack/config"
 	"github.com/buildpacks/pack/internal/image"
 	"github.com/buildpacks/pack/internal/logging"
 	h "github.com/buildpacks/pack/testhelpers"
@@ -69,14 +70,22 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("returns the remote image", func() {
+					// TODO: Remove Fetch tests
 					_, err := fetcher.Fetch(context.TODO(), repoName, false, false)
+					h.AssertNil(t, err)
+
+					_, err = fetcher.NewFetch(context.TODO(), repoName, false, pubcfg.PullAlways)
 					h.AssertNil(t, err)
 				})
 			})
 
 			when("there is no remote image", func() {
 				it("returns an error", func() {
+					// TODO: Remove Fetch tests
 					_, err := fetcher.Fetch(context.TODO(), repoName, false, false)
+					h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist in registry", repoName))
+
+					_, err = fetcher.NewFetch(context.TODO(), repoName, false, pubcfg.PullAlways)
 					h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist in registry", repoName))
 				})
 			})
@@ -102,14 +111,22 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it("returns the local image", func() {
+						// TODO: Remove Fetch tests
 						_, err := fetcher.Fetch(context.TODO(), repoName, true, false)
+						h.AssertNil(t, err)
+
+						_, err = fetcher.NewFetch(context.TODO(), repoName, true, pubcfg.PullNever)
 						h.AssertNil(t, err)
 					})
 				})
 
 				when("there is no local image", func() {
 					it("returns an error", func() {
+						// TODO: Remove Fetch tests
 						_, err := fetcher.Fetch(context.TODO(), repoName, true, false)
+						h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist on the daemon", repoName))
+
+						_, err = fetcher.NewFetch(context.TODO(), repoName, true, pubcfg.PullNever)
 						h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist on the daemon", repoName))
 					})
 				})
@@ -135,7 +152,11 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it("pull the image and return the local copy", func() {
+						// TODO: Remove Fetch tests
 						_, err := fetcher.Fetch(context.TODO(), repoName, true, true)
+						h.AssertNil(t, err)
+
+						_, err = fetcher.NewFetch(context.TODO(), repoName, true, pubcfg.PullAlways)
 						h.AssertNil(t, err)
 					})
 				})
@@ -154,14 +175,22 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 						})
 
 						it("returns the local image", func() {
+							// TODO: Remove Fetch tests
 							_, err := fetcher.Fetch(context.TODO(), repoName, true, true)
+							h.AssertNil(t, err)
+
+							_, err = fetcher.NewFetch(context.TODO(), repoName, true, pubcfg.PullAlways)
 							h.AssertNil(t, err)
 						})
 					})
 
 					when("there is no local image", func() {
 						it("returns an error", func() {
+							// TODO: Remove Fetch tests
 							_, err := fetcher.Fetch(context.TODO(), repoName, true, true)
+							h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist on the daemon", repoName))
+
+							_, err = fetcher.NewFetch(context.TODO(), repoName, true, pubcfg.PullAlways)
 							h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist on the daemon", repoName))
 						})
 					})

--- a/pack.go
+++ b/pack.go
@@ -18,7 +18,7 @@ var (
 )
 
 func extractPackagedBuildpacks(ctx context.Context, pkgImageRef string, fetcher ImageFetcher, publish bool, pullPolicy config.PullPolicy) (mainBP dist.Buildpack, depBPs []dist.Buildpack, err error) {
-	pkgImage, err := fetcher.NewFetch(ctx, pkgImageRef, !publish, pullPolicy)
+	pkgImage, err := fetcher.Fetch(ctx, pkgImageRef, !publish, pullPolicy)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "fetching image")
 	}

--- a/pack.go
+++ b/pack.go
@@ -3,6 +3,8 @@ package pack
 import (
 	"context"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/pkg/errors"
 
 	"github.com/buildpacks/pack/internal/buildpackage"
@@ -15,8 +17,8 @@ var (
 	Version = "0.0.0"
 )
 
-func extractPackagedBuildpacks(ctx context.Context, pkgImageRef string, fetcher ImageFetcher, publish, noPull bool) (mainBP dist.Buildpack, depBPs []dist.Buildpack, err error) {
-	pkgImage, err := fetcher.Fetch(ctx, pkgImageRef, !publish, !noPull)
+func extractPackagedBuildpacks(ctx context.Context, pkgImageRef string, fetcher ImageFetcher, publish bool, pullPolicy config.PullPolicy) (mainBP dist.Buildpack, depBPs []dist.Buildpack, err error) {
+	pkgImage, err := fetcher.NewFetch(ctx, pkgImageRef, !publish, pullPolicy)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "fetching image")
 	}

--- a/package_buildpack.go
+++ b/package_buildpack.go
@@ -3,6 +3,8 @@ package pack
 import (
 	"context"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/pkg/errors"
 
 	pubbldpkg "github.com/buildpacks/pack/buildpackage"
@@ -19,11 +21,11 @@ const (
 
 // PackageBuildpackOptions are configuration options and metadata you can pass into PackageBuildpack
 type PackageBuildpackOptions struct {
-	Name    string
-	Format  string
-	Config  pubbldpkg.Config
-	Publish bool
-	NoPull  bool
+	Name       string
+	Format     string
+	Config     pubbldpkg.Config
+	Publish    bool
+	PullPolicy config.PullPolicy
 }
 
 // PackageBuildpack packages buildpack(s) into an image or file
@@ -80,7 +82,7 @@ func (c *Client) PackageBuildpack(ctx context.Context, opts PackageBuildpackOpti
 				depBPs = []dist.Buildpack{depBP}
 			}
 		} else if dep.ImageName != "" {
-			mainBP, deps, err := extractPackagedBuildpacks(ctx, dep.ImageName, c.imageFetcher, opts.Publish, opts.NoPull)
+			mainBP, deps, err := extractPackagedBuildpacks(ctx, dep.ImageName, c.imageFetcher, opts.Publish, opts.PullPolicy)
 			if err != nil {
 				return err
 			}

--- a/package_buildpack_test.go
+++ b/package_buildpack_test.go
@@ -178,11 +178,11 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			shouldFetchNestedPackage := func(demon bool, pull config.PullPolicy) {
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), nestedPackage.Name(), demon, pull).Return(nestedPackage, nil)
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), demon, pull).Return(nestedPackage, nil)
 			}
 
 			shouldNotFindNestedPackageWhenCallingImageFetcherWith := func(demon bool, pull config.PullPolicy) {
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), nestedPackage.Name(), demon, pull).Return(nil, image.ErrNotFound)
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), demon, pull).Return(nil, image.ErrNotFound)
 			}
 
 			shouldCreateLocalPackage := func() imgutil.Image {
@@ -299,7 +299,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 		when("nested package is not a valid package", func() {
 			it("should error", func() {
 				notPackageImage := fakes.NewImage("not/package", "", nil)
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), notPackageImage.Name(), true, config.PullAlways).Return(notPackageImage, nil)
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), notPackageImage.Name(), true, config.PullAlways).Return(notPackageImage, nil)
 
 				h.AssertError(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 					Name: "some/package",
@@ -367,7 +367,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					PullPolicy: config.PullAlways,
 				}))
 
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), nestedPackage.Name(), true, config.PullAlways).Return(nestedPackage, nil)
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), true, config.PullAlways).Return(nestedPackage, nil)
 			})
 
 			it("should pull and use local nested package image", func() {
@@ -477,7 +477,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					PullPolicy: config.PullAlways,
 				}))
 
-				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), nestedPackage.Name(), true, config.PullAlways).Return(nestedPackage, nil)
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), true, config.PullAlways).Return(nestedPackage, nil)
 			})
 
 			it("should include both of them", func() {

--- a/package_buildpack_test.go
+++ b/package_buildpack_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/imgutil/fakes"
 	"github.com/buildpacks/lifecycle/api"
@@ -144,8 +146,8 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 						Buildpack:    dist.BuildpackURI{URI: createBuildpack(packageDescriptor)},
 						Dependencies: []dist.ImageOrURI{{BuildpackURI: dist.BuildpackURI{URI: dependencyPath}}},
 					},
-					Publish: false,
-					NoPull:  false,
+					Publish:    false,
+					PullPolicy: config.PullAlways,
 				})
 
 				h.AssertError(t, err, "inspecting buildpack blob")
@@ -170,16 +172,17 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 							Stacks: []dist.Stack{{ID: "some.stack.id"}},
 						})},
 					},
-					Publish: true,
+					Publish:    true,
+					PullPolicy: config.PullAlways,
 				}))
 			})
 
-			shouldFetchNestedPackage := func(demon, pull bool) {
-				mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), demon, pull).Return(nestedPackage, nil)
+			shouldFetchNestedPackage := func(demon bool, pull config.PullPolicy) {
+				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), nestedPackage.Name(), demon, pull).Return(nestedPackage, nil)
 			}
 
-			shouldNotFindNestedPackageWhenCallingImageFetcherWith := func(demon, pull bool) {
-				mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), demon, pull).Return(nil, image.ErrNotFound)
+			shouldNotFindNestedPackageWhenCallingImageFetcherWith := func(demon bool, pull config.PullPolicy) {
+				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), nestedPackage.Name(), demon, pull).Return(nil, image.ErrNotFound)
 			}
 
 			shouldCreateLocalPackage := func() imgutil.Image {
@@ -196,7 +199,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 
 			when("publish=false and no-pull=false", func() {
 				it("should pull and use local nested package image", func() {
-					shouldFetchNestedPackage(true, true)
+					shouldFetchNestedPackage(true, config.PullAlways)
 					packageImage := shouldCreateLocalPackage()
 
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
@@ -214,15 +217,15 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 							})},
 							Dependencies: []dist.ImageOrURI{{ImageRef: dist.ImageRef{ImageName: nestedPackage.Name()}}},
 						},
-						Publish: false,
-						NoPull:  false,
+						Publish:    false,
+						PullPolicy: config.PullAlways,
 					}))
 				})
 			})
 
 			when("publish=true and no-pull=false", func() {
 				it("should use remote nested package image", func() {
-					shouldFetchNestedPackage(false, true)
+					shouldFetchNestedPackage(false, config.PullAlways)
 					packageImage := shouldCreateRemotePackage()
 
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
@@ -240,15 +243,15 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 							})},
 							Dependencies: []dist.ImageOrURI{{ImageRef: dist.ImageRef{ImageName: nestedPackage.Name()}}},
 						},
-						Publish: true,
-						NoPull:  false,
+						Publish:    true,
+						PullPolicy: config.PullAlways,
 					}))
 				})
 			})
 
-			when("publish=true and no-pull=true", func() {
+			when("publish=true and pull-policy=never", func() {
 				it("should push to registry and not pull nested package image", func() {
-					shouldFetchNestedPackage(false, false)
+					shouldFetchNestedPackage(false, config.PullNever)
 					packageImage := shouldCreateRemotePackage()
 
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
@@ -266,15 +269,15 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 							})},
 							Dependencies: []dist.ImageOrURI{{ImageRef: dist.ImageRef{ImageName: nestedPackage.Name()}}},
 						},
-						Publish: true,
-						NoPull:  true,
+						Publish:    true,
+						PullPolicy: config.PullNever,
 					}))
 				})
 			})
 
-			when("publish=false no-pull=true and there is no local image", func() {
+			when("publish=false pull-policy=never and there is no local image", func() {
 				it("should fail without trying to retrieve nested image from registry", func() {
-					shouldNotFindNestedPackageWhenCallingImageFetcherWith(true, false)
+					shouldNotFindNestedPackageWhenCallingImageFetcherWith(true, config.PullNever)
 
 					h.AssertError(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: "some/package",
@@ -286,8 +289,8 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 							})},
 							Dependencies: []dist.ImageOrURI{{ImageRef: dist.ImageRef{ImageName: nestedPackage.Name()}}},
 						},
-						Publish: false,
-						NoPull:  true,
+						Publish:    false,
+						PullPolicy: config.PullNever,
 					}), "not found")
 				})
 			})
@@ -296,7 +299,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 		when("nested package is not a valid package", func() {
 			it("should error", func() {
 				notPackageImage := fakes.NewImage("not/package", "", nil)
-				mockImageFetcher.EXPECT().Fetch(gomock.Any(), notPackageImage.Name(), true, true).Return(notPackageImage, nil)
+				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), notPackageImage.Name(), true, config.PullAlways).Return(notPackageImage, nil)
 
 				h.AssertError(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 					Name: "some/package",
@@ -308,8 +311,8 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 						})},
 						Dependencies: []dist.ImageOrURI{{ImageRef: dist.ImageRef{ImageName: notPackageImage.Name()}}},
 					},
-					Publish: false,
-					NoPull:  false,
+					Publish:    false,
+					PullPolicy: config.PullAlways,
 				}), "extracting buildpacks from 'not/package': could not find label 'io.buildpacks.buildpackage.metadata'")
 			})
 		})
@@ -360,10 +363,11 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					Config: pubbldpkg.Config{
 						Buildpack: dist.BuildpackURI{URI: createBuildpack(childDescriptor)},
 					},
-					Publish: true,
+					Publish:    true,
+					PullPolicy: config.PullAlways,
 				}))
 
-				mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), true, true).Return(nestedPackage, nil)
+				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), nestedPackage.Name(), true, config.PullAlways).Return(nestedPackage, nil)
 			})
 
 			it("should pull and use local nested package image", func() {
@@ -375,9 +379,9 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 						Buildpack:    dist.BuildpackURI{URI: createBuildpack(packageDescriptor)},
 						Dependencies: []dist.ImageOrURI{{ImageRef: dist.ImageRef{ImageName: nestedPackage.Name()}}},
 					},
-					Publish: false,
-					NoPull:  false,
-					Format:  pack.FormatFile,
+					Publish:    false,
+					PullPolicy: config.PullAlways,
+					Format:     pack.FormatFile,
 				}))
 
 				assertPackageBPFileHasBuildpacks(t, packagePath, []dist.BuildpackDescriptor{packageDescriptor, childDescriptor})
@@ -394,9 +398,9 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 						Buildpack:    dist.BuildpackURI{URI: createBuildpack(packageDescriptor)},
 						Dependencies: []dist.ImageOrURI{{BuildpackURI: dist.BuildpackURI{URI: createBuildpack(childDescriptor)}}},
 					},
-					Publish: false,
-					NoPull:  false,
-					Format:  pack.FormatFile,
+					Publish:    false,
+					PullPolicy: config.PullAlways,
+					Format:     pack.FormatFile,
 				}))
 
 				assertPackageBPFileHasBuildpacks(t, packagePath, []dist.BuildpackDescriptor{packageDescriptor, childDescriptor})
@@ -415,9 +419,9 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 							Buildpack:    dist.BuildpackURI{URI: createBuildpack(packageDescriptor)},
 							Dependencies: []dist.ImageOrURI{{BuildpackURI: dist.BuildpackURI{URI: bpURL}}},
 						},
-						Publish: false,
-						NoPull:  false,
-						Format:  pack.FormatFile,
+						Publish:    false,
+						PullPolicy: config.PullAlways,
+						Format:     pack.FormatFile,
 					})
 					h.AssertError(t, err, "downloading buildpack")
 				})
@@ -437,9 +441,9 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 							Buildpack:    dist.BuildpackURI{URI: createBuildpack(packageDescriptor)},
 							Dependencies: []dist.ImageOrURI{{BuildpackURI: dist.BuildpackURI{URI: bpURL}}},
 						},
-						Publish: false,
-						NoPull:  false,
-						Format:  pack.FormatFile,
+						Publish:    false,
+						PullPolicy: config.PullAlways,
+						Format:     pack.FormatFile,
 					})
 					h.AssertError(t, err, "creating buildpack")
 				})
@@ -469,10 +473,11 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					Config: pubbldpkg.Config{
 						Buildpack: dist.BuildpackURI{URI: createBuildpack(childDescriptor)},
 					},
-					Publish: true,
+					Publish:    true,
+					PullPolicy: config.PullAlways,
 				}))
 
-				mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), true, true).Return(nestedPackage, nil)
+				mockImageFetcher.EXPECT().NewFetch(gomock.Any(), nestedPackage.Name(), true, config.PullAlways).Return(nestedPackage, nil)
 			})
 
 			it("should include both of them", func() {
@@ -485,9 +490,9 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 						Dependencies: []dist.ImageOrURI{{ImageRef: dist.ImageRef{ImageName: nestedPackage.Name()}},
 							{BuildpackURI: dist.BuildpackURI{URI: createBuildpack(secondChildDescriptor)}}},
 					},
-					Publish: false,
-					NoPull:  false,
-					Format:  pack.FormatFile,
+					Publish:    false,
+					PullPolicy: config.PullAlways,
+					Format:     pack.FormatFile,
 				}))
 
 				assertPackageBPFileHasBuildpacks(t, packagePath, []dist.BuildpackDescriptor{packageDescriptor, childDescriptor, secondChildDescriptor})
@@ -506,7 +511,8 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					Config: pubbldpkg.Config{
 						Buildpack: dist.BuildpackURI{URI: createBuildpack(childDescriptor)},
 					},
-					Format: pack.FormatFile,
+					PullPolicy: config.PullAlways,
+					Format:     pack.FormatFile,
 				}))
 
 				mockDownloader.EXPECT().Download(gomock.Any(), dependencyPackagePath).Return(blob.NewBlob(dependencyPackagePath), nil).AnyTimes()
@@ -521,9 +527,9 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 						Buildpack:    dist.BuildpackURI{URI: createBuildpack(packageDescriptor)},
 						Dependencies: []dist.ImageOrURI{{BuildpackURI: dist.BuildpackURI{URI: dependencyPackagePath}}},
 					},
-					Publish: false,
-					NoPull:  false,
-					Format:  pack.FormatFile,
+					Publish:    false,
+					PullPolicy: config.PullAlways,
+					Format:     pack.FormatFile,
 				}))
 
 				assertPackageBPFileHasBuildpacks(t, packagePath, []dist.BuildpackDescriptor{packageDescriptor, childDescriptor})
@@ -543,8 +549,8 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 						Stacks: []dist.Stack{{ID: "some.stack.id"}},
 					})},
 				},
-				Publish: false,
-				NoPull:  false,
+				Publish:    false,
+				PullPolicy: config.PullAlways,
 			})
 			h.AssertError(t, err, "unknown format: 'invalid-format'")
 		})

--- a/rebase.go
+++ b/rebase.go
@@ -27,7 +27,7 @@ func (c *Client) Rebase(ctx context.Context, opts RebaseOptions) error {
 		return errors.Wrapf(err, "invalid image name '%s'", opts.RepoName)
 	}
 
-	appImage, err := c.imageFetcher.NewFetch(ctx, opts.RepoName, !opts.Publish, opts.PullPolicy)
+	appImage, err := c.imageFetcher.Fetch(ctx, opts.RepoName, !opts.Publish, opts.PullPolicy)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (c *Client) Rebase(ctx context.Context, opts RebaseOptions) error {
 		return errors.New("run image must be specified")
 	}
 
-	baseImage, err := c.imageFetcher.NewFetch(ctx, runImageName, !opts.Publish, opts.PullPolicy)
+	baseImage, err := c.imageFetcher.Fetch(ctx, runImageName, !opts.Publish, opts.PullPolicy)
 	if err != nil {
 		return err
 	}

--- a/rebase.go
+++ b/rebase.go
@@ -3,6 +3,8 @@ package pack
 import (
 	"context"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/buildpacks/lifecycle"
 	"github.com/pkg/errors"
 
@@ -14,7 +16,7 @@ import (
 type RebaseOptions struct {
 	RepoName          string
 	Publish           bool
-	SkipPull          bool
+	PullPolicy        config.PullPolicy
 	RunImage          string
 	AdditionalMirrors map[string][]string
 }
@@ -25,7 +27,7 @@ func (c *Client) Rebase(ctx context.Context, opts RebaseOptions) error {
 		return errors.Wrapf(err, "invalid image name '%s'", opts.RepoName)
 	}
 
-	appImage, err := c.imageFetcher.Fetch(ctx, opts.RepoName, !opts.Publish, !opts.SkipPull)
+	appImage, err := c.imageFetcher.NewFetch(ctx, opts.RepoName, !opts.Publish, opts.PullPolicy)
 	if err != nil {
 		return err
 	}
@@ -54,7 +56,7 @@ func (c *Client) Rebase(ctx context.Context, opts RebaseOptions) error {
 		return errors.New("run image must be specified")
 	}
 
-	baseImage, err := c.imageFetcher.Fetch(ctx, runImageName, !opts.Publish, !opts.SkipPull)
+	baseImage, err := c.imageFetcher.NewFetch(ctx, runImageName, !opts.Publish, opts.PullPolicy)
 	if err != nil {
 		return err
 	}

--- a/rebase_test.go
+++ b/rebase_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/buildpacks/imgutil/fakes"
 	"github.com/heroku/color"
 	"github.com/sclevine/spec"
@@ -174,11 +176,11 @@ func testRebase(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				when("is false", func() {
-					when("skip pull is false", func() {
+					when("pull policy is always", func() {
 						it("updates the local image", func() {
 							h.AssertNil(t, subject.Rebase(context.TODO(), RebaseOptions{
-								RepoName: "some/app",
-								SkipPull: false,
+								RepoName:   "some/app",
+								PullPolicy: config.PullAlways,
 							}))
 							h.AssertEq(t, fakeAppImage.Base(), "some/run")
 							lbl, _ := fakeAppImage.Label("io.buildpacks.lifecycle.metadata")
@@ -186,11 +188,11 @@ func testRebase(t *testing.T, when spec.G, it spec.S) {
 						})
 					})
 
-					when("skip pull is true", func() {
+					when("pull policy is never", func() {
 						it("uses local image", func() {
 							h.AssertNil(t, subject.Rebase(context.TODO(), RebaseOptions{
-								RepoName: "some/app",
-								SkipPull: true,
+								RepoName:   "some/app",
+								PullPolicy: config.PullNever,
 							}))
 							h.AssertEq(t, fakeAppImage.Base(), "some/run")
 							lbl, _ := fakeAppImage.Label("io.buildpacks.lifecycle.metadata")

--- a/register_buildpack.go
+++ b/register_buildpack.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/buildpacks/pack/config"
+
 	"github.com/buildpacks/pack/internal/buildpackage"
 	"github.com/buildpacks/pack/internal/dist"
 	"github.com/buildpacks/pack/internal/registry"
@@ -19,7 +21,7 @@ type RegisterBuildpackOptions struct {
 }
 
 func (c *Client) RegisterBuildpack(ctx context.Context, opts RegisterBuildpackOptions) error {
-	appImage, err := c.imageFetcher.Fetch(ctx, opts.ImageName, false, true)
+	appImage, err := c.imageFetcher.Fetch(ctx, opts.ImageName, false, config.PullAlways)
 	if err != nil {
 		return err
 	}

--- a/testmocks/mock_image_fetcher.go
+++ b/testmocks/mock_image_fetcher.go
@@ -38,7 +38,7 @@ func (m *MockImageFetcher) EXPECT() *MockImageFetcherMockRecorder {
 }
 
 // Fetch mocks base method
-func (m *MockImageFetcher) Fetch(arg0 context.Context, arg1 string, arg2, arg3 bool) (imgutil.Image, error) {
+func (m *MockImageFetcher) Fetch(arg0 context.Context, arg1 string, arg2 bool, arg3 config.PullPolicy) (imgutil.Image, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Fetch", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(imgutil.Image)
@@ -50,19 +50,4 @@ func (m *MockImageFetcher) Fetch(arg0 context.Context, arg1 string, arg2, arg3 b
 func (mr *MockImageFetcherMockRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockImageFetcher)(nil).Fetch), arg0, arg1, arg2, arg3)
-}
-
-// NewFetch mocks base method
-func (m *MockImageFetcher) NewFetch(arg0 context.Context, arg1 string, arg2 bool, arg3 config.PullPolicy) (imgutil.Image, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewFetch", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(imgutil.Image)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// NewFetch indicates an expected call of NewFetch
-func (mr *MockImageFetcherMockRecorder) NewFetch(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewFetch", reflect.TypeOf((*MockImageFetcher)(nil).NewFetch), arg0, arg1, arg2, arg3)
 }

--- a/testmocks/mock_image_fetcher.go
+++ b/testmocks/mock_image_fetcher.go
@@ -10,6 +10,8 @@ import (
 
 	imgutil "github.com/buildpacks/imgutil"
 	gomock "github.com/golang/mock/gomock"
+
+	config "github.com/buildpacks/pack/config"
 )
 
 // MockImageFetcher is a mock of ImageFetcher interface
@@ -48,4 +50,19 @@ func (m *MockImageFetcher) Fetch(arg0 context.Context, arg1 string, arg2, arg3 b
 func (mr *MockImageFetcherMockRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockImageFetcher)(nil).Fetch), arg0, arg1, arg2, arg3)
+}
+
+// NewFetch mocks base method
+func (m *MockImageFetcher) NewFetch(arg0 context.Context, arg1 string, arg2 bool, arg3 config.PullPolicy) (imgutil.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewFetch", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(imgutil.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewFetch indicates an expected call of NewFetch
+func (mr *MockImageFetcherMockRecorder) NewFetch(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewFetch", reflect.TypeOf((*MockImageFetcher)(nil).NewFetch), arg0, arg1, arg2, arg3)
 }


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
This deprecates the `--no-pull` flag, in favor of `--pull-policy`, which as three options at the moment:
* `always` &rarr; Always pulls the images necessary (the default behavior of pack)
* `never` &rarr; Never pulls the images necessary (equivalent to `--no-pull`)
* `if-not-present` &rarr; Pulls the image only if it is not present

It also adds the possibility for future policies to be added, by centralizing the `PullPolicy`s. 

## Output
<!-- If applicable, please provide examples of the output changes. -->
### `$ pack build`
#### Before
![Screen Shot 2020-08-05 at 9 06 42 AM](https://user-images.githubusercontent.com/7035673/89417110-3f47e380-d6fc-11ea-8f50-8ed8eed73c5e.png)

#### After
![Screen Shot 2020-08-05 at 9 12 23 AM](https://user-images.githubusercontent.com/7035673/89417127-440c9780-d6fc-11ea-9c49-96d64533ee9b.png)

### `$ pack create-builder`
#### Before
![Screen Shot 2020-08-05 at 9 02 12 AM](https://user-images.githubusercontent.com/7035673/89416105-c6945780-d6fa-11ea-97c2-998c69e3ec93.png)

#### After
![Screen Shot 2020-08-05 at 9 04 40 AM](https://user-images.githubusercontent.com/7035673/89416120-cb590b80-d6fa-11ea-999c-8ef9a58caaa7.png)

### `$ pack package-buildpack`
#### Before
![image](https://user-images.githubusercontent.com/7035673/89418136-a87c2680-d6fd-11ea-9409-59351a583266.png)

#### After
![image](https://user-images.githubusercontent.com/7035673/89418153-ab771700-d6fd-11ea-9c17-306783d9a6ce.png)

### `$ pack rebase`
#### Before
![Screen Shot 2020-08-05 at 9 20 24 AM](https://user-images.githubusercontent.com/7035673/89417739-196f0e80-d6fd-11ea-9919-1fb9d3a46251.png)

#### After
![image](https://user-images.githubusercontent.com/7035673/89417746-1bd16880-d6fd-11ea-94ee-02b5c0679a03.png)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, and it will be automatically through the generated pack documentation

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #686 
Implements https://github.com/buildpacks/rfcs/pull/80
