### PR TITLE
Defer to builder run image mirror if not publishing (daemon case)

### DIFF
--- a/build.go
+++ b/build.go
@@ -101,7 +101,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		return errors.Wrapf(err, "invalid builder '%s'", opts.Builder)
 	}
 
-	runImageName := c.resolveRunImage(opts.RunImage, imageRef.Context().RegistryStr(), bldr.Stack(), opts.AdditionalMirrors)
+	runImageName := c.resolveRunImage(opts.RunImage, imageRef.Context().RegistryStr(), builderRef.Context().RegistryStr(), bldr.Stack(), opts.AdditionalMirrors, opts.Publish)
 	runImage, err := c.validateRunImage(ctx, runImageName, opts.NoPull, opts.Publish, bldr.StackID)
 	if err != nil {
 		return errors.Wrapf(err, "invalid run-image '%s'", runImageName)

--- a/build_test.go
+++ b/build_test.go
@@ -407,28 +407,46 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 
 			when("run image is not supplied", func() {
 				when("there are no locally configured mirrors", func() {
-					it("chooses the best mirror from the builder", func() {
-						h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
-							Image:   "some/app",
-							Builder: defaultBuilderName,
-						}))
-						h.AssertEq(t, fakeLifecycle.Opts.RunImage, "default/run")
+					when("Publish is true", func() {
+						it("chooses the run image mirror matching the local image", func() {
+							fakeImageFetcher.RemoteImages[fakeDefaultRunImage.Name()] = fakeDefaultRunImage
+
+							h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+								Image:   "some/app",
+								Builder: defaultBuilderName,
+								Publish: true,
+							}))
+							h.AssertEq(t, fakeLifecycle.Opts.RunImage, "default/run")
+						})
+
+						for _, registry := range []string{"registry1.example.com", "registry2.example.com"} {
+							testRegistry := registry
+							it("chooses the run image mirror matching the built image", func() {
+								runImg := testRegistry + "/run/mirror"
+								fakeImageFetcher.RemoteImages[runImg] = fakeDefaultRunImage
+								h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+									Image:   testRegistry + "/some/app",
+									Builder: defaultBuilderName,
+									Publish: true,
+								}))
+								h.AssertEq(t, fakeLifecycle.Opts.RunImage, runImg)
+							})
+						}
 					})
 
-					it("chooses the best mirror from the builder", func() {
-						h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
-							Image:   "registry1.example.com/some/app",
-							Builder: defaultBuilderName,
-						}))
-						h.AssertEq(t, fakeLifecycle.Opts.RunImage, "registry1.example.com/run/mirror")
-					})
-
-					it("chooses the best mirror from the builder", func() {
-						h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
-							Image:   "registry2.example.com/some/app",
-							Builder: defaultBuilderName,
-						}))
-						h.AssertEq(t, fakeLifecycle.Opts.RunImage, "registry2.example.com/run/mirror")
+					when("Publish is false", func() {
+						for _, img := range []string{"some/app",
+							"registry1.example.com/some/app",
+							"registry2.example.com/some/app"} {
+							testImg := img
+							it("chooses a mirror on the builder registry", func() {
+								h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+									Image:   testImg,
+									Builder: defaultBuilderName,
+								}))
+								h.AssertEq(t, fakeLifecycle.Opts.RunImage, "default/run")
+							})
+						}
 					})
 				})
 
@@ -436,6 +454,9 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					var (
 						fakeLocalMirror  *fakes.Image
 						fakeLocalMirror1 *fakes.Image
+						mirrors          = map[string][]string{
+							"default/run": {"local/mirror", "registry1.example.com/local/mirror"},
+						}
 					)
 
 					it.Before(func() {
@@ -457,39 +478,39 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 						fakeLocalMirror1.Cleanup()
 					})
 
-					it("prefers user provided mirrors", func() {
-						h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
-							Image:   "some/app",
-							Builder: defaultBuilderName,
-							AdditionalMirrors: map[string][]string{
-								"default/run": {"local/mirror", "registry1.example.com/local/mirror"},
-							},
-						}))
-						h.AssertEq(t, fakeLifecycle.Opts.RunImage, "local/mirror")
+					when("Publish is true", func() {
+						for _, registry := range []string{"", "registry1.example.com"} {
+							testRegistry := registry
+							it("prefers user provided mirrors for registry "+testRegistry, func() {
+								if testRegistry != "" {
+									testRegistry += "/"
+								}
+								runImg := testRegistry + "local/mirror"
+								fakeImageFetcher.RemoteImages[runImg] = fakeDefaultRunImage
+
+								h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+									Image:             testRegistry + "some/app",
+									Builder:           defaultBuilderName,
+									AdditionalMirrors: mirrors,
+									Publish:           true,
+								}))
+								h.AssertEq(t, fakeLifecycle.Opts.RunImage, runImg)
+							})
+						}
 					})
 
-					it("choose the correct user provided mirror for the registry", func() {
-						h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
-							Image:   "registry1.example.com/some/app",
-							Builder: defaultBuilderName,
-							AdditionalMirrors: map[string][]string{
-								"default/run": {"local/mirror", "registry1.example.com/local/mirror"},
-							},
-						}))
-						h.AssertEq(t, fakeLifecycle.Opts.RunImage, "registry1.example.com/local/mirror")
-					})
-
-					when("there is no user provided mirror for the registry", func() {
-						it("chooses from builder mirrors", func() {
-							h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
-								Image:   "registry2.example.com/some/app",
-								Builder: defaultBuilderName,
-								AdditionalMirrors: map[string][]string{
-									"default/run": {"local/mirror", "registry1.example.com/local/mirror"},
-								},
-							}))
-							h.AssertEq(t, fakeLifecycle.Opts.RunImage, "registry2.example.com/run/mirror")
-						})
+					when("Publish is false", func() {
+						for _, registry := range []string{"", "registry1.example.com", "registry2.example.com"} {
+							testRegistry := registry
+							it("prefers user provided mirrors", func() {
+								h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+									Image:             testRegistry + "some/app",
+									Builder:           defaultBuilderName,
+									AdditionalMirrors: mirrors,
+								}))
+								h.AssertEq(t, fakeLifecycle.Opts.RunImage, "local/mirror")
+							})
+						}
 					})
 				})
 			})

--- a/common.go
+++ b/common.go
@@ -28,13 +28,19 @@ func (c *Client) parseTagReference(imageName string) (name.Reference, error) {
 	return ref, nil
 }
 
-func (c *Client) resolveRunImage(runImage, targetRegistry string, stackInfo builder.StackMetadata, additionalMirrors map[string][]string) string {
+func (c *Client) resolveRunImage(runImage, imgRegistry, bldrRegistry string, stackInfo builder.StackMetadata, additionalMirrors map[string][]string, publish bool) string {
 	if runImage != "" {
 		c.logger.Debugf("Using provided run-image %s", style.Symbol(runImage))
 		return runImage
 	}
+
+	preferredRegistry := bldrRegistry
+	if publish || bldrRegistry == "" {
+		preferredRegistry = imgRegistry
+	}
+
 	runImageName := getBestRunMirror(
-		targetRegistry,
+		preferredRegistry,
 		stackInfo.RunImage.Image,
 		stackInfo.RunImage.Mirrors,
 		additionalMirrors[stackInfo.RunImage.Image],

--- a/common_test.go
+++ b/common_test.go
@@ -1,0 +1,119 @@
+package pack
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpacks/pack/internal/builder"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestCommon(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "build", testCommon, spec.Report(report.Terminal{}))
+}
+
+func testCommon(t *testing.T, when spec.G, it spec.S) {
+	when("#resolveRunImage", func() {
+		var (
+			subject         *Client
+			outBuf          bytes.Buffer
+			logger          logging.Logger
+			runImageName    string
+			defaultRegistry string
+			defaultMirror   string
+			gcrRegistry     string
+			gcrRunMirror    string
+			stackInfo       builder.StackMetadata
+		)
+
+		it.Before(func() {
+			logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+
+			var err error
+			subject, err = NewClient(WithLogger(logger))
+			h.AssertNil(t, err)
+
+			defaultRegistry = "default.registry.io"
+			runImageName = "stack/run"
+			defaultMirror = defaultRegistry + "/" + runImageName
+			gcrRegistry = "gcr.io"
+			gcrRunMirror = gcrRegistry + "/" + runImageName
+			stackInfo = builder.StackMetadata{
+				RunImage: builder.RunImageMetadata{
+					Image: runImageName,
+					Mirrors: []string{
+						defaultMirror, gcrRunMirror,
+					},
+				},
+			}
+		})
+
+		when("passed specific run image", func() {
+			it("selects that run image", func() {
+				runImgFlag := "flag/passed-run-image"
+				runImageName := subject.resolveRunImage(runImgFlag, defaultRegistry, "", stackInfo, nil, false)
+				h.AssertEq(t, runImageName, runImgFlag)
+			})
+		})
+
+		when("publish is true", func() {
+			it("defaults to run-image in registry publishing to", func() {
+				runImageName := subject.resolveRunImage("", gcrRegistry, defaultRegistry, stackInfo, nil, true)
+				h.AssertEq(t, runImageName, gcrRunMirror)
+			})
+
+			it("prefers config defined run image mirror to stack defined run image mirror", func() {
+				configMirrors := map[string][]string{
+					runImageName: []string{defaultRegistry + "/unique-run-img"},
+				}
+				runImageName := subject.resolveRunImage("", defaultRegistry, "", stackInfo, configMirrors, true)
+				h.AssertNotEq(t, runImageName, defaultMirror)
+				h.AssertEq(t, runImageName, defaultRegistry+"/unique-run-img")
+			})
+
+			it("returns a config mirror if no match to target registry", func() {
+				configMirrors := map[string][]string{
+					runImageName: []string{defaultRegistry + "/unique-run-img"},
+				}
+				runImageName := subject.resolveRunImage("", "test.registry.io", "", stackInfo, configMirrors, true)
+				h.AssertNotEq(t, runImageName, defaultMirror)
+				h.AssertEq(t, runImageName, defaultRegistry+"/unique-run-img")
+			})
+		})
+
+		// If publish is false, we are using the local daemon, and want to match to the builder registry
+		when("publish is false", func() {
+			it("defaults to run-image in registry publishing to", func() {
+				runImageName := subject.resolveRunImage("", gcrRegistry, defaultRegistry, stackInfo, nil, false)
+				h.AssertEq(t, runImageName, defaultMirror)
+				h.AssertNotEq(t, runImageName, gcrRunMirror)
+			})
+
+			it("prefers config defined run image mirror to stack defined run image mirror", func() {
+				configMirrors := map[string][]string{
+					runImageName: []string{defaultRegistry + "/unique-run-img"},
+				}
+				runImageName := subject.resolveRunImage("", gcrRegistry, defaultRegistry, stackInfo, configMirrors, false)
+				h.AssertNotEq(t, runImageName, defaultMirror)
+				h.AssertEq(t, runImageName, defaultRegistry+"/unique-run-img")
+			})
+
+			it("returns a config mirror if no match to target registry", func() {
+				configMirrors := map[string][]string{
+					runImageName: []string{defaultRegistry + "/unique-run-img"},
+				}
+				runImageName := subject.resolveRunImage("", defaultRegistry, "test.registry.io", stackInfo, configMirrors, false)
+				h.AssertNotEq(t, runImageName, defaultMirror)
+				h.AssertEq(t, runImageName, defaultRegistry+"/unique-run-img")
+			})
+		})
+	})
+}

--- a/rebase.go
+++ b/rebase.go
@@ -40,13 +40,15 @@ func (c *Client) Rebase(ctx context.Context, opts RebaseOptions) error {
 	runImageName := c.resolveRunImage(
 		opts.RunImage,
 		imageRef.Context().RegistryStr(),
+		"",
 		builder.StackMetadata{
 			RunImage: builder.RunImageMetadata{
 				Image:   md.Stack.RunImage.Image,
 				Mirrors: md.Stack.RunImage.Mirrors,
 			},
 		},
-		opts.AdditionalMirrors)
+		opts.AdditionalMirrors,
+		opts.Publish)
 
 	if runImageName == "" {
 		return errors.New("run image must be specified")


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This work attempts to make the selection of `run-image-mirrors` more intuitive. Previously, our selection of a run image mirror looked like this:
1. run image provided with `pack build --run-image`
2. run image mirror in the same registry as the app you are trying to build (so, for instance, `pack build test-app` will look for a run image mirror in `dockerhub`, while `pack build gcr.io/test-app` will look for a run image mirror in `gcr.io`)
3. run image mirrors configured using `pack set-run-image-mirror`
4. run image mirrors defined on the builder/stack

In practice, this was confusing to users (see #712, and a conversation on slack [here](https://buildpacks.slack.com/archives/CJ6B92ZSB/p1596819380003400)). While the above priorities made sense when thinking about publishing images (if you are publishing, we want to minimize the number of bits you have to stream, so using a run image mirror in that registry would be optimal), they were suboptimal when users were doing local development, where users would have expected the run image to be in the same registry as the builder. 

As such, this PR addresses changes priority (2) above, adjusting between selecting a run image mirror:
* in the same registry as the **app**, if you are **publishing** (running `pack build --publish`, referred to as a non-`daemon` case)
* in the same registry as the **builder**, if you are doing local development (running `pack build`, referred to as the `daemon` case)


## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
##### `$ pack build`
![pack build](https://user-images.githubusercontent.com/7035673/89739695-ec01c800-da50-11ea-85da-ab55a07cfcb1.png)

##### `$ pack build --publish`
![pack build --publish](https://user-images.githubusercontent.com/7035673/89739731-266b6500-da51-11ea-902d-4a9f790791f1.png)

#### After
##### `$ pack build`
![pack build](https://user-images.githubusercontent.com/7035673/89739696-ef954f00-da50-11ea-83df-12efe322bdf8.png)

##### `$ pack build --publish`
![pack build --publish](https://user-images.githubusercontent.com/7035673/89739701-f4f29980-da50-11ea-849e-0d1593f09898.png)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, in the release notes

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
Resolves #712 
