### PR TITLE
Sanitize pack report

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -453,7 +453,7 @@ func testWithoutSpecificBuilderRequirement(
 			it("explicit mode doesn't redact", func() {
 				pack.RunSuccessfully("set-default-builder", "paketobuildpacks/builder:base")
 
-				output := pack.RunSuccessfully("report", "-e")
+				output := pack.RunSuccessfully("report", "--explicit")
 
 				version := pack.Version()
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -431,10 +431,29 @@ func testWithoutSpecificBuilderRequirement(
 		})
 
 		when("default builder is set", func() {
-			it("outputs information", func() {
+			it("redacts default builder", func() {
 				pack.RunSuccessfully("set-default-builder", "paketobuildpacks/builder:base")
 
 				output := pack.RunSuccessfully("report")
+
+				version := pack.Version()
+
+				expectedOutput := pack.FixtureManager().TemplateFixture(
+					"report_output.txt",
+					map[string]interface{}{
+						"DefaultBuilder": "[REDACTED]",
+						"Version":        version,
+						"OS":             runtime.GOOS,
+						"Arch":           runtime.GOARCH,
+					},
+				)
+				assert.Equal(output, expectedOutput)
+			})
+
+			it("explicit mode doesn't redact", func() {
+				pack.RunSuccessfully("set-default-builder", "paketobuildpacks/builder:base")
+
+				output := pack.RunSuccessfully("report", "-e")
 
 				version := pack.Version()
 

--- a/internal/commands/report_test.go
+++ b/internal/commands/report_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestReportCommand(t *testing.T) {
-	spec.Run(t, "Commands", testReportCommand, spec.Random(), spec.Report(report.Terminal{}))
+	spec.Run(t, "ReportCommand", testReportCommand, spec.Random(), spec.Report(report.Terminal{}))
 }
 
 func testReportCommand(t *testing.T, when spec.G, it spec.S) {
@@ -68,9 +68,21 @@ experimental = true
 
 			it("presents output", func() {
 				h.AssertNil(t, command.Execute())
+				h.AssertContains(t, outBuf.String(), `default-builder-image = "[REDACTED]"`)
+				h.AssertContains(t, outBuf.String(), `experimental = true`)
+				h.AssertContains(t, outBuf.String(), `Version:  `+testVersion)
+
+				h.AssertNotContains(t, outBuf.String(), `default-builder-image = "some/image"`)
+			})
+
+			it("doesn't sanitize output if explicit", func() {
+				command.SetArgs([]string{"-e"})
+				h.AssertNil(t, command.Execute())
 				h.AssertContains(t, outBuf.String(), `default-builder-image = "some/image"`)
 				h.AssertContains(t, outBuf.String(), `experimental = true`)
 				h.AssertContains(t, outBuf.String(), `Version:  `+testVersion)
+
+				h.AssertNotContains(t, outBuf.String(), `default-builder-image = "[REDACTED]"`)
 			})
 		})
 


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This sanitizes sensitive information from the `~/.pack/config.toml`. At the present it only sanitizes default builder, but if additional material is desired, we can add that as well. It adds a `-e` flag to `pack report`, to allow for reporting sensitive information. 

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
![image](https://user-images.githubusercontent.com/7035673/89917526-e75f2000-dbc6-11ea-849b-b5029b075e3c.png)

#### After
![image](https://user-images.githubusercontent.com/7035673/89917548-ec23d400-dbc6-11ea-8a8d-b1f06435ded9.png)

![image](https://user-images.githubusercontent.com/7035673/89917646-09f13900-dbc7-11ea-8741-0d6e3a41582d.png)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, and it will be automatically with the pack documentation

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #624