### PR TITLE
Use CNB_PLATFORM_API to adjust what default process to show

### DIFF
--- a/inspect_image.go
+++ b/inspect_image.go
@@ -34,7 +34,12 @@ type layersMetadata struct {
 	Stack    lifecycle.StackMetadata    `json:"stack" toml:"stack"`
 }
 
-const PlatformAPIEnv = "CNB_PLATFORM_API"
+const (
+	PlatformAPIEnv      = "CNB_PLATFORM_API"
+	CNBProcessEnv       = "CNB_PROCESS_TYPE"
+	defaultProcess      = "web"
+	fallbackPlatformAPI = "0.3"
+)
 
 func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 	img, err := c.imageFetcher.Fetch(context.Background(), name, daemon, config.PullNever)
@@ -73,7 +78,7 @@ func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 	}
 
 	if platformAPI == "" {
-		platformAPI = "0.3"
+		platformAPI = fallbackPlatformAPI
 	}
 
 	platformAPIVersion, err := semver.NewVersion(platformAPI)
@@ -83,12 +88,12 @@ func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 
 	var defaultProcessType string
 	if platformAPIVersion.LessThan(semver.MustParse("0.4")) {
-		defaultProcessType, err = img.Env("CNB_PROCESS_TYPE")
+		defaultProcessType, err = img.Env(CNBProcessEnv)
 		if err != nil || defaultProcessType == "" {
-			defaultProcessType = "web"
+			defaultProcessType = defaultProcess
 		}
 	} else {
-		defaultProcessType = "web"
+		defaultProcessType = defaultProcess
 	}
 
 	var processDetails ProcessDetails

--- a/inspect_image.go
+++ b/inspect_image.go
@@ -36,12 +36,15 @@ type layersMetadata struct {
 }
 
 const (
-	PlatformAPIEnv      = "CNB_PLATFORM_API"
-	CNBProcessEnv       = "CNB_PROCESS_TYPE"
-	defaultProcess      = "web"
-	fallbackPlatformAPI = "0.3"
-	LauncherEntrypoint  = "/cnb/lifecycle/launcher"
-	BpEntrypointPrefix  = "/cnb/process/"
+	platformAPIEnv            = "CNB_PLATFORM_API"
+	cnbProcessEnv             = "CNB_PROCESS_TYPE"
+	launcherEntrypoint        = "/cnb/lifecycle/launcher"
+	windowsLauncherEntrypoint = `c:\cnb\lifecycle\launcher.exe`
+	entrypointPrefix          = "/cnb/process/"
+	windowsEntrypointPrefix   = `c:\cnb\process\`
+	defaultProcess            = "web"
+	fallbackPlatformAPI       = "0.3"
+	windowsPrefix             = "c:"
 )
 
 func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
@@ -75,7 +78,7 @@ func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 		return nil, err
 	}
 
-	platformAPI, err := img.Env(PlatformAPIEnv)
+	platformAPI, err := img.Env(platformAPIEnv)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading platform api")
 	}
@@ -91,7 +94,7 @@ func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 
 	var defaultProcessType string
 	if platformAPIVersion.LessThan(semver.MustParse("0.4")) {
-		defaultProcessType, err = img.Env(CNBProcessEnv)
+		defaultProcessType, err = img.Env(cnbProcessEnv)
 		if err != nil || defaultProcessType == "" {
 			defaultProcessType = defaultProcess
 		}
@@ -102,8 +105,15 @@ func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 		}
 
 		entrypoint := inspect.Config.Entrypoint
-		if len(entrypoint) > 0 && entrypoint[0] != LauncherEntrypoint {
-			process := strings.Replace(entrypoint[0], BpEntrypointPrefix, "", 1)
+		if len(entrypoint) > 0 && entrypoint[0] != launcherEntrypoint && entrypoint[0] != windowsLauncherEntrypoint {
+			process := entrypoint[0]
+			if strings.HasPrefix(process, windowsPrefix) {
+				process = strings.TrimPrefix(process, windowsEntrypointPrefix)
+				process = strings.TrimSuffix(process, ".exe") // Trim .exe for Windows support
+			} else {
+				process = strings.TrimPrefix(process, entrypointPrefix)
+			}
+
 			defaultProcessType = process
 		}
 	}

--- a/inspect_image.go
+++ b/inspect_image.go
@@ -2,6 +2,7 @@ package pack
 
 import (
 	"context"
+	"strings"
 
 	"github.com/buildpacks/pack/config"
 
@@ -39,6 +40,8 @@ const (
 	CNBProcessEnv       = "CNB_PROCESS_TYPE"
 	defaultProcess      = "web"
 	fallbackPlatformAPI = "0.3"
+	LauncherEntrypoint  = "/cnb/lifecycle/launcher"
+	BpEntrypointPrefix  = "/cnb/process/"
 )
 
 func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
@@ -93,7 +96,16 @@ func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 			defaultProcessType = defaultProcess
 		}
 	} else {
-		defaultProcessType = defaultProcess
+		inspect, _, err := c.docker.ImageInspectWithRaw(context.TODO(), name)
+		if err != nil {
+			return nil, errors.Wrap(err, "reading image")
+		}
+
+		entrypoint := inspect.Config.Entrypoint
+		if len(entrypoint) > 0 && entrypoint[0] != LauncherEntrypoint {
+			process := strings.Replace(entrypoint[0], BpEntrypointPrefix, "", 1)
+			defaultProcessType = process
+		}
 	}
 
 	var processDetails ProcessDetails

--- a/inspect_image.go
+++ b/inspect_image.go
@@ -34,6 +34,8 @@ type layersMetadata struct {
 	Stack    lifecycle.StackMetadata    `json:"stack" toml:"stack"`
 }
 
+const PlatformAPIEnv = "CNB_PLATFORM_API"
+
 func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 	img, err := c.imageFetcher.Fetch(context.Background(), name, daemon, config.PullNever)
 	if err != nil {
@@ -65,8 +67,27 @@ func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 		return nil, err
 	}
 
-	defaultProcessType, err := img.Env("CNB_PROCESS_TYPE")
-	if err != nil || defaultProcessType == "" {
+	platformAPI, err := img.Env(PlatformAPIEnv)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading platform api")
+	}
+
+	if platformAPI == "" {
+		platformAPI = "0.3"
+	}
+
+	platformAPIVersion, err := semver.NewVersion(platformAPI)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing platform api version")
+	}
+
+	var defaultProcessType string
+	if platformAPIVersion.LessThan(semver.MustParse("0.4")) {
+		defaultProcessType, err = img.Env("CNB_PROCESS_TYPE")
+		if err != nil || defaultProcessType == "" {
+			defaultProcessType = "web"
+		}
+	} else {
 		defaultProcessType = "web"
 	}
 

--- a/inspect_image_test.go
+++ b/inspect_image_test.go
@@ -296,6 +296,14 @@ func testInspectImage(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				when("Platform API >= 0.4", func() {
+					when("PlatformAPIEnv set to bad value", func() {
+						it("errors", func() {
+							h.AssertNil(t, fakeImage.SetEnv(PlatformAPIEnv, "not-semver"))
+							_, err := subject.InspectImage("some/image", useDaemon)
+							h.AssertError(t, err, "parsing platform api version")
+						})
+					})
+
 					when("CNB_PROCESS_TYPE is set", func() {
 						it.Before(func() {
 							h.AssertNil(t, fakeImage.SetEnv("CNB_PROCESS_TYPE", "other-process"))


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This is an attempt to change the default process type Pack displays for images created with a lifecycle implementing Platform API 0.4. 

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
Resolves #789