### PR TITLE
Add Milestones to Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,8 @@ This repository adheres to the following project policies:
 Aside from the policies above, you may find [DEVELOPMENT.md](DEVELOPMENT.md) to provide specific helpful detail
 to assist you while developing in this repository.
 
+We welcome any and all contributions! The issues we are prioritizing are visible in the repository [milestones](https://github.com/buildpacks/pack/milestones), and we especially welcome contributions to that. One good place to start contributing is in our [documentation](https://github.com/buildpacks/docs/issues), though you are welcome to start in this repository!
+
 #### Preparing for a Pull Request
 
 After making all the changes but before creating a [Pull Request][pull-request-process], you should run


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
As we are now using Milestones to track/prioritize work, I added it to our Contributing doc. 

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No
