### PR TITLE
Add default process=web to acceptance tests

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -751,7 +751,7 @@ func testAcceptance(
 						assertMockAppRunsWithOutput(t, assert, repoName, "Launch Dep Contents", "Cached Dep Contents")
 
 						t.Log("rebuild with --clear-cache")
-						output = pack.RunSuccessfully("build", repoName, "-p", appPath, "--clear-cache")
+						output = pack.RunSuccessfully("build", repoName, "-p", appPath, "--clear-cache", "--default-process", "web")
 
 						assertOutput = assertions.NewOutputAssertionManager(t, output)
 						assertOutput.ReportsSuccessfulImageBuild(repoName)


### PR DESCRIPTION
* One case didn't set default process, and therefore inspect-image was failing

Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
