### PR TITLE
Fix unrunnable Windows app images due to incomplete PATH env var

### DIFF
--- a/acceptance/testdata/mock_stack/windows/run/Dockerfile
+++ b/acceptance/testdata/mock_stack/windows/run/Dockerfile
@@ -21,3 +21,6 @@ LABEL io.buildpacks.stack.id=pack.test.stack
 LABEL io.buildpacks.stack.mixins="[\"mixinA\", \"netcat\", \"mixin3\"]"
 
 USER pack
+
+# launcher requires a non-empty PATH to workaround https://github.com/buildpacks/pack/issues/800
+ENV PATH c:\\Windows\\system32;C:\\Windows


### PR DESCRIPTION
- Run images need to explicitly set `Config.Env.PATH=C:\\windows...` to workaround differences in conventions for well-known Windows (mcr.microsoft.com/windows/nanoserver:1809) and Linux (alpine/bionic) base images
- Windows base image configs set `Config.Env=null` and use a default setting when `null`
- Linux base image configs set `Config.Env=["PATH=/usr/local/bin...",]`

- Works-around #800 though a proper fix in lifecycle will be needed to allow unmodified stacks

Signed-off-by: Micah Young <ymicah@vmware.com>

## Summary
Adds an explicit `PATH` env var image config entry for run image mock stacks. This allows Windows stack images to work like Linux stack images which always inherit a `PATH` env var from their base images. On Windows, a `null` path gets converted to a default setting of `c:\windows\system32;c:\windows` so the explicit value here is the same. This only affected platform v4 which now adds new entries to `PATH` for Windows, which v3 did not (resulting in `null`).

## Output
N/A

#### Before
Acceptance tests failed
#### After
Acceptance tests pass

## Documentation
There is a reference implementation pending-merge in samples https://github.com/buildpacks/samples/pull/85/commits/dbfc2e96a1cadc20f87bed83db0207c45f754cef

Besides that, we should probably document this unless we want to support `PATH=null` image configs in lifecycle.

- Should this change be documented?
    - [x] Yes, see #800 
    - [] No

## Related
Related to #800 but we should discuss how to proceed to accommodate stacks that do not include this workaround