### PR TITLE
Limit Windows support to platform API 0.3

### DIFF
--- a/acceptance/testdata/mock_stack/windows/run/Dockerfile
+++ b/acceptance/testdata/mock_stack/windows/run/Dockerfile
@@ -21,6 +21,3 @@ LABEL io.buildpacks.stack.id=pack.test.stack
 LABEL io.buildpacks.stack.mixins="[\"mixinA\", \"netcat\", \"mixin3\"]"
 
 USER pack
-
-# launcher requires a non-empty PATH to workaround https://github.com/buildpacks/pack/issues/800
-ENV PATH c:\\Windows\\system32;C:\\Windows

--- a/internal/build/phase_config_provider_test.go
+++ b/internal/build/phase_config_provider_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	ifakes "github.com/buildpacks/imgutil/fakes"
+	"github.com/buildpacks/lifecycle/api"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/heroku/color"
@@ -65,7 +66,9 @@ func testPhaseConfigProvider(t *testing.T, when spec.G, it spec.S) {
 			it("sets process isolation", func() {
 				fakeBuilderImage := ifakes.NewImage("fake-builder", "", nil)
 				fakeBuilderImage.SetPlatform("windows", "", "")
-				fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithImage(fakeBuilderImage))
+				fakeBuilder, err := fakes.NewFakeBuilder(
+					fakes.WithImage(fakeBuilderImage),
+					fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.3")}))
 				h.AssertNil(t, err)
 				lifecycle := newTestLifecycleExec(t, false, fakes.WithBuilder(fakeBuilder))
 
@@ -142,7 +145,9 @@ func testPhaseConfigProvider(t *testing.T, when spec.G, it spec.S) {
 				it("sets daemon access on the config", func() {
 					fakeBuilderImage := ifakes.NewImage("fake-builder", "", nil)
 					fakeBuilderImage.SetPlatform("windows", "", "")
-					fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithImage(fakeBuilderImage))
+					fakeBuilder, err := fakes.NewFakeBuilder(
+						fakes.WithImage(fakeBuilderImage),
+						fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.3")}))
 					h.AssertNil(t, err)
 					lifecycle := newTestLifecycleExec(t, false, fakes.WithBuilder(fakeBuilder))
 
@@ -243,7 +248,9 @@ func testPhaseConfigProvider(t *testing.T, when spec.G, it spec.S) {
 				it("sets root user on the config", func() {
 					fakeBuilderImage := ifakes.NewImage("fake-builder", "", nil)
 					fakeBuilderImage.SetPlatform("windows", "", "")
-					fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithImage(fakeBuilderImage))
+					fakeBuilder, err := fakes.NewFakeBuilder(
+						fakes.WithImage(fakeBuilderImage),
+						fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.3")}))
 					h.AssertNil(t, err)
 					lifecycle := newTestLifecycleExec(t, false, fakes.WithBuilder(fakeBuilder))
 


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
This change limits support of platform API for Windows to 0.3 as a workaround for https://github.com/buildpacks/lifecycle/issues/384.

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #800 
