### PR TITLE
Sets the default process to web

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -476,7 +476,6 @@ func testWithoutSpecificBuilderRequirement(
 			output, err := pack.Run(
 				"build", "some/image",
 				"-p", filepath.Join("testdata", "mock_app"),
-				"--default-process", "web",
 			)
 
 			assert.NotNil(err)
@@ -639,7 +638,6 @@ func testAcceptance(
 						output := pack.RunSuccessfully(
 							"build", repoName,
 							"-p", filepath.Join("testdata", "mock_app"),
-							"--default-process", "web",
 							"-B", untrustedBuilderName,
 						)
 
@@ -680,7 +678,6 @@ func testAcceptance(
 						output := pack.RunSuccessfully(
 							"build", repoName,
 							"-p", appPath,
-							"--default-process", "web",
 						)
 
 						imgId, err := imgIDForRepoName(repoName)
@@ -727,7 +724,6 @@ func testAcceptance(
 						output = pack.RunSuccessfully(
 							"build", repoName,
 							"-p", appPath,
-							"--default-process", "web",
 						)
 						assertOutput.ReportsSuccessfulImageBuild(repoName)
 
@@ -751,7 +747,7 @@ func testAcceptance(
 						assertMockAppRunsWithOutput(t, assert, repoName, "Launch Dep Contents", "Cached Dep Contents")
 
 						t.Log("rebuild with --clear-cache")
-						output = pack.RunSuccessfully("build", repoName, "-p", appPath, "--clear-cache", "--default-process", "web")
+						output = pack.RunSuccessfully("build", repoName, "-p", appPath, "--clear-cache")
 
 						assertOutput = assertions.NewOutputAssertionManager(t, output)
 						assertOutput.ReportsSuccessfulImageBuild(repoName)
@@ -1021,8 +1017,7 @@ func testAcceptance(
 								output := pack.RunSuccessfully(
 									"build", repoName,
 									"-p", filepath.Join("testdata", "mock_app"),
-									"--default-process", "web",
-									"--buildpack", "simple/layers", // Can omit version if only one
+									"--buildpack", "simple/layers", // can omit version if only one
 									"--buildpack", "noop.buildpack@noop.buildpack.version",
 								)
 
@@ -1115,7 +1110,6 @@ func testAcceptance(
 								output := pack.RunSuccessfully(
 									"build", repoName,
 									"-p", filepath.Join("testdata", "mock_app"),
-									"--default-process", "web",
 									"--buildpack", packageImageName,
 								)
 
@@ -1170,7 +1164,6 @@ func testAcceptance(
 								output := pack.RunSuccessfully(
 									"build", repoName,
 									"-p", filepath.Join("testdata", "mock_app"),
-									"--default-process", "web",
 									"--buildpack", packageFile,
 								)
 
@@ -1202,7 +1195,6 @@ func testAcceptance(
 								output, err := pack.Run(
 									"build", repoName,
 									"-p", filepath.Join("testdata", "mock_app"),
-									"--default-process", "web",
 									"--buildpack", otherStackBuilderTgz,
 								)
 
@@ -1241,7 +1233,6 @@ func testAcceptance(
 							output := pack.RunSuccessfully(
 								"build", repoName,
 								"-p", filepath.Join("testdata", "mock_app"),
-								"--default-process", "web",
 								"--env-file", envPath,
 							)
 
@@ -1268,7 +1259,6 @@ func testAcceptance(
 							output := pack.RunSuccessfully(
 								"build", repoName,
 								"-p", filepath.Join("testdata", "mock_app"),
-								"--default-process", "web",
 								"--env", "DETECT_ENV_BUILDPACK=true",
 								"--env", `ENV1_CONTENTS="Env1 Layer Contents From Command Line"`,
 								"--env", "ENV2_CONTENTS",
@@ -1313,7 +1303,6 @@ func testAcceptance(
 								output := pack.RunSuccessfully(
 									"build", repoName,
 									"-p", filepath.Join("testdata", "mock_app"),
-									"--default-process", "web",
 									"--run-image", runImageName,
 								)
 								assertOutput := assertions.NewOutputAssertionManager(t, output)
@@ -1351,7 +1340,6 @@ func testAcceptance(
 								output, err := pack.Run(
 									"build", repoName,
 									"-p", filepath.Join("testdata", "mock_app"),
-									"--default-process", "web",
 									"--run-image", runImageName,
 								)
 								assert.NotNil(err)
@@ -1370,7 +1358,6 @@ func testAcceptance(
 							buildArgs := []string{
 								repoName,
 								"-p", filepath.Join("testdata", "mock_app"),
-								"--default-process", "web",
 								"--publish",
 							}
 							if dockerHostOS() != "windows" {
@@ -1442,7 +1429,6 @@ func testAcceptance(
 								buf,
 								"build", repoName,
 								"-p", filepath.Join("testdata", "mock_app"),
-								"--default-process", "web",
 							)
 
 							go command.TerminateAtStep("DETECTING")
@@ -1790,7 +1776,6 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 					pack.RunSuccessfully(
 						"build", repoName,
 						"-p", filepath.Join("testdata", "mock_app"),
-						"--default-process", "web",
 						"--builder", builderName,
 						"--run-image", runBefore,
 						"--no-pull",

--- a/acceptance/testdata/pack_fixtures/report_output.txt
+++ b/acceptance/testdata/pack_fixtures/report_output.txt
@@ -2,7 +2,7 @@ Pack:
   Version:  {{ .Version }}
   OS/Arch:  {{ .OS }}/{{ .Arch }}
 
-Default Lifecycle Version:  0.9.0
+Default Lifecycle Version:  0.9.1
 
 Config:
   default-builder-image = "{{ .DefaultBuilder }}"

--- a/build_test.go
+++ b/build_test.go
@@ -1534,7 +1534,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.PullPolicy, config.PullNever)
 
-					args = fakeImageFetcher.FetchCalls["buildpacksio/lifecycle:0.9.0"]
+					args = fakeImageFetcher.FetchCalls["buildpacksio/lifecycle:0.9.1"]
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.PullPolicy, config.PullNever)
 				})

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -295,6 +295,34 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				configProvider := fakePhaseFactory.NewCalledWithProvider
 				h.AssertSliceContains(t, configProvider.ContainerConfig().Env, "CNB_REGISTRY_AUTH={}")
 			})
+
+			when("platform 0.3", func() {
+				it("doesn't hint at default process type", func() {
+					fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.3")}))
+					h.AssertNil(t, err)
+					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+					err = lifecycle.Export(context.Background(), "test", "test", true, "test", "test", "test", fakePhaseFactory)
+					h.AssertNil(t, err)
+					configProvider := fakePhaseFactory.NewCalledWithProvider
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-process-type")
+				})
+			})
+
+			when("platform 0.4", func() {
+				it("hints at default process type", func() {
+					fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.4")}))
+					h.AssertNil(t, err)
+					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+					err = lifecycle.Export(context.Background(), "test", "test", true, "test", "test", "test", fakePhaseFactory)
+					h.AssertNil(t, err)
+					configProvider := fakePhaseFactory.NewCalledWithProvider
+					h.AssertIncludeAllExpectedPatterns(t, configProvider.ContainerConfig().Cmd, []string{"-process-type", "web"})
+				})
+			})
 		})
 
 		when("publish is false", func() {
@@ -370,6 +398,34 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 
 				configProvider := fakePhaseFactory.NewCalledWithProvider
 				h.AssertSliceContains(t, configProvider.HostConfig().Binds, expectedBinds...)
+			})
+
+			when("platform 0.3", func() {
+				it("doesn't hint at default process type", func() {
+					fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.3")}))
+					h.AssertNil(t, err)
+					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+					err = lifecycle.Export(context.Background(), "test", "test", false, "test", "test", "test", fakePhaseFactory)
+					h.AssertNil(t, err)
+					configProvider := fakePhaseFactory.NewCalledWithProvider
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-process-type")
+				})
+			})
+
+			when("platform 0.4", func() {
+				it("hints at default process type", func() {
+					fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.4")}))
+					h.AssertNil(t, err)
+					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+					err = lifecycle.Export(context.Background(), "test", "test", false, "test", "test", "test", fakePhaseFactory)
+					h.AssertNil(t, err)
+					configProvider := fakePhaseFactory.NewCalledWithProvider
+					h.AssertIncludeAllExpectedPatterns(t, configProvider.ContainerConfig().Cmd, []string{"-process-type", "web"})
+				})
 			})
 		})
 	})
@@ -935,6 +991,34 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				configProvider := fakePhaseFactory.NewCalledWithProvider
 				h.AssertIncludeAllExpectedPatterns(t, configProvider.ContainerConfig().Cmd, expectedDefaultProc)
 			})
+
+			when("platform 0.3", func() {
+				it("doesn't hint at default process type", func() {
+					fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.3")}))
+					h.AssertNil(t, err)
+					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+					err = lifecycle.Export(context.Background(), "test", "test", true, "test", "test", "test", fakePhaseFactory)
+					h.AssertNil(t, err)
+					configProvider := fakePhaseFactory.NewCalledWithProvider
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-process-type")
+				})
+			})
+
+			when("platform 0.4", func() {
+				it("hints at default process type", func() {
+					fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.4")}))
+					h.AssertNil(t, err)
+					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+					err = lifecycle.Export(context.Background(), "test", "test", true, "test", "test", "test", fakePhaseFactory)
+					h.AssertNil(t, err)
+					configProvider := fakePhaseFactory.NewCalledWithProvider
+					h.AssertIncludeAllExpectedPatterns(t, configProvider.ContainerConfig().Cmd, []string{"-process-type", "web"})
+				})
+			})
 		})
 
 		when("publish is false", func() {
@@ -1043,6 +1127,34 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 				configProvider := fakePhaseFactory.NewCalledWithProvider
 				h.AssertIncludeAllExpectedPatterns(t, configProvider.ContainerConfig().Cmd, expectedDefaultProc)
+			})
+
+			when("platform 0.3", func() {
+				it("doesn't hint at default process type", func() {
+					fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.3")}))
+					h.AssertNil(t, err)
+					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+					err = lifecycle.Export(context.Background(), "test", "test", false, "test", "test", "test", fakePhaseFactory)
+					h.AssertNil(t, err)
+					configProvider := fakePhaseFactory.NewCalledWithProvider
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-process-type")
+				})
+			})
+
+			when("platform 0.4", func() {
+				it("hints at default process type", func() {
+					fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.4")}))
+					h.AssertNil(t, err)
+					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+					err = lifecycle.Export(context.Background(), "test", "test", false, "test", "test", "test", fakePhaseFactory)
+					h.AssertNil(t, err)
+					configProvider := fakePhaseFactory.NewCalledWithProvider
+					h.AssertIncludeAllExpectedPatterns(t, configProvider.ContainerConfig().Cmd, []string{"-process-type", "web"})
+				})
 			})
 		})
 	})

--- a/internal/builder/lifecycle.go
+++ b/internal/builder/lifecycle.go
@@ -14,7 +14,7 @@ import (
 
 // A snapshot of the latest tested lifecycle version values
 const (
-	DefaultLifecycleVersion    = "0.9.0"
+	DefaultLifecycleVersion    = "0.9.1"
 	DefaultBuildpackAPIVersion = "0.2"
 )
 

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -158,8 +158,8 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringVar(&buildFlags.Network, "network", "", "Connect detect and build containers to network")
 	cmd.Flags().StringVarP(&buildFlags.DescriptorPath, "descriptor", "d", "", "Path to the project descriptor file")
 	cmd.Flags().StringArrayVar(&buildFlags.Volumes, "volume", nil, "Mount host volume into the build container, in the form '<host path>:<target path>[:<mode>]'."+multiValueHelp("volume"))
-	cmd.Flags().StringVarP(&buildFlags.DefaultProcessType, "default-process", "D", "web", "Set the default process type")
-	cmd.Flags().StringVar(&buildFlags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
+	cmd.Flags().StringVarP(&buildFlags.DefaultProcessType, "default-process", "D", "", `Set the default process type. (default "web")`)
+	cmd.Flags().StringVar(&buildFlags.Policy, "pull-policy", "", `Pull policy to use. Accepted values are always, never, and if-not-present. (default "always")`)
 	// TODO: Remove --no-pull flag after v0.13.0 released. See https://github.com/buildpacks/pack/issues/775
 	cmd.Flags().BoolVar(&buildFlags.NoPull, "no-pull", false, "Skip pulling builder and run images before use")
 	cmd.Flags().MarkHidden("no-pull")

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -158,7 +158,7 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringVar(&buildFlags.Network, "network", "", "Connect detect and build containers to network")
 	cmd.Flags().StringVarP(&buildFlags.DescriptorPath, "descriptor", "d", "", "Path to the project descriptor file")
 	cmd.Flags().StringArrayVar(&buildFlags.Volumes, "volume", nil, "Mount host volume into the build container, in the form '<host path>:<target path>[:<mode>]'."+multiValueHelp("volume"))
-	cmd.Flags().StringVarP(&buildFlags.DefaultProcessType, "default-process", "D", "", "Set the default process type")
+	cmd.Flags().StringVarP(&buildFlags.DefaultProcessType, "default-process", "D", "web", "Set the default process type")
 	cmd.Flags().StringVar(&buildFlags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
 	// TODO: Remove --no-pull flag after v0.13.0 released. See https://github.com/buildpacks/pack/issues/775
 	cmd.Flags().BoolVar(&buildFlags.NoPull, "no-pull", false, "Skip pulling builder and run images before use")


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
`pack` now passes the default process type of `web` to the lifecycle since [later versions of the lifecycle](https://github.com/buildpacks/lifecycle/releases/tag/v0.9.0) are no longer opinionated.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

```bash
$ ./out/pack create-builder my-builder:p0.4 -c ~/dev/buildpacks/samples/builders/bionic/builder.toml
bionic: Pulling from cnbs/sample-stack-run
Digest: sha256:c1baaa9eeb47dada3d914ebef51696b7844bf410047c2b45e2f768d2a1c5b21e
Status: Image is up to date for cnbs/sample-stack-run:bionic
bionic: Pulling from cnbs/sample-stack-build
Digest: sha256:daa2f382500ebdd466a2bb64fe09f92b07b0facfd4421e33172cc63138e53106
Status: Image is up to date for cnbs/sample-stack-build:bionic
hello-universe: Pulling from cnbs/sample-package
Digest: sha256:c797967a15cf0199d73716dd9625b6d2ffe9bece90675a83f0a6132c7395f361
Status: Image is up to date for cnbs/sample-package:hello-universe
Successfully created builder image my-builder:p0.4
Tip: Run pack build <image-name> --builder my-builder:p0.4 to use this builder

$ ./out/pack inspect-builder my-builder:p0.4
Inspecting builder: my-builder:p0.4

REMOTE:
(not present)

LOCAL:

Created By:
  Name: Pack CLI
  Version: 0.0.0+git-3f70cc9

Trusted: No

Stack:
  ID: io.buildpacks.samples.stacks.bionic

Lifecycle:
  Version: 0.9.0
  Buildpack APIs:
    Deprecated: (none)
    Supported: 0.2, 0.3, 0.4
  Platform APIs:
    Deprecated: (none)
    Supported: 0.3, 0.4

Run Images:
  cnbs/sample-stack-run:bionic

Buildpacks:
  ID                            VERSION        HOMEPAGE
  samples/java-maven            0.0.1          https://github.com/buildpacks/samples/tree/main/buildpacks/java-maven
  samples/kotlin-gradle         0.0.1          https://github.com/buildpacks/samples/tree/main/buildpacks/kotlin-gradle
  samples/ruby-bundler          0.0.1          https://github.com/buildpacks/samples/tree/main/buildpacks/ruby-bundler
  samples/hello-universe        0.0.1          https://github.com/buildpacks/samples/tree/main/buildpacks/hello-universe
  samples/hello-moon            0.0.1          https://github.com/buildpacks/samples/tree/main/buildpacks/hello-moon
  samples/hello-world           0.0.1          https://github.com/buildpacks/samples/tree/main/buildpacks/hello-world

Detection Order:
 ├ Group #1:
 │  └ samples/java-maven@0.0.1    
 ├ Group #2:
 │  └ samples/kotlin-gradle@0.0.1    
 ├ Group #3:
 │  └ samples/ruby-bundler@0.0.1    
 └ Group #4:
    └ samples/hello-universe@0.0.1    
       └ Group #1:
          ├ samples/hello-world@0.0.1    
          └ samples/hello-moon@0.0.1     

$ ./out/pack build my-bash-app -p ~/dev/buildpacks/samples/apps/bash-script/ -B my-builder:p0.4
bionic: Pulling from cnbs/sample-stack-run
Digest: sha256:c1baaa9eeb47dada3d914ebef51696b7844bf410047c2b45e2f768d2a1c5b21e
Status: Image is up to date for cnbs/sample-stack-run:bionic
0.9.0: Pulling from buildpacksio/lifecycle
Digest: sha256:1ca5d38c85aec390a17e721e6d7e79499f307d9c6c808962558de61cc6ccb17c
Status: Image is up to date for buildpacksio/lifecycle:0.9.0
===> DETECTING
[detector] samples/bash-script 0.0.1
===> ANALYZING
===> RESTORING
===> BUILDING
[builder] ---> Hello World buildpack
[builder] ---> Hello Bash Script buildpack
[builder] 
[builder] Here are the contents of the current working directory:
[builder] .:
[builder] total 16
[builder] drwxr-xr-x 2 cnb  cnb  4096 Aug 18 00:31 .
[builder] drwxr-xr-x 1 root root 4096 Aug 18 00:31 ..
[builder] -rwxr-xr-x 1 cnb  cnb   738 Apr  6 23:13 app.sh
[builder] -rw-r--r-- 1 cnb  cnb   202 Apr  6 23:13 project.toml
===> EXPORTING
[exporter] Reusing 1/1 app layer(s)
[exporter] Reusing layer 'launcher'
[exporter] Reusing layer 'config'
[exporter] Reusing layer 'process-types'
[exporter] Adding label 'io.buildpacks.lifecycle.metadata'
[exporter] Adding label 'io.buildpacks.build.metadata'
[exporter] Adding label 'io.buildpacks.project.metadata'
[exporter] *** Images (cd18d6533c1a):
[exporter]       index.docker.io/library/my-bash-app:latest
Successfully built image my-bash-app

$ ./out/pack inspect-image my-bash-app
Inspecting image: my-bash-app

REMOTE:
(not present)

LOCAL:

Stack: io.buildpacks.samples.stacks.bionic

Base Image:
  Reference: 1b1c340a619e91d035a8108da795630d05234781a76bf583cd1396d85575cc45
  Top Layer: sha256:e7d9e63e3016d2419dfdc1175d4b53dbc97356921c59caaa887c541b783f290b

Run Images:
  cnbs/sample-stack-run:bionic

Buildpacks:
  ID                         VERSION
  samples/bash-script        0.0.1

Processes:
  TYPE         SHELL        COMMAND           ARGS
  hello        bash         ./world.sh        
  web          bash         ./app.sh          

$ docker run --rm -it my-bash-app
ERROR: failed to launch: determine start command: when there is no default process a command is required
```


#### After

```bash
$ ./out/pack build --help
Generate app image from source code

Usage:
  pack build <image-name> [flags]

Flags:
  -B, --builder string              Builder image (default "gcr.io/paketo-buildpacks/builder:base")
  -b, --buildpack strings           Buildpack reference in the form of '<buildpack>@<version>',
                                      path to a buildpack directory (not supported on Windows),
                                      path/URL to a buildpack .tar or .tgz file, or
                                      the name of a packaged buildpack image
                                    Repeat for each buildpack in order,
                                      or supply once by comma-separated list
  -R, --buildpack-registry string   Buildpack Registry URL
      --clear-cache                 Clear image's associated cache before building
  -D, --default-process string      Set the default process type. (default "web")
  -d, --descriptor string           Path to the project descriptor file
  -e, --env stringArray             Build-time environment variable, in the form 'VAR=VALUE' or 'VAR'.
                                    When using latter value-less form, value will be taken from current
                                      environment at the time this command is executed.
                                    This flag may be specified multiple times and will override
                                      individual values defined by --env-file.
      --env-file stringArray        Build-time environment variables file
                                    One variable per line, of the form 'VAR=VALUE' or 'VAR'
                                    When using latter value-less form, value will be taken from current
                                      environment at the time this command is executed
  -h, --help                        Help for 'build'
      --network string              Connect detect and build containers to network
  -p, --path string                 Path to app dir or zip-formatted file (defaults to current working directory)
      --publish                     Publish to registry
      --pull-policy string          Pull policy to use. Accepted values are always, never, and if-not-present. (default "always")
      --run-image string            Run image (defaults to default stack's run image)
      --trust-builder               Trust the provided builder
                                    All lifecycle phases will be run in a single container (if supported by the lifecycle).
      --volume stringArray          Mount host volume into the build container, in the form '<host path>:<target path>[:<mode>]'.
                                    Repeat for each volume in order,
                                      or supply once by comma-separated list

Global Flags:
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output
```

```bash
$ ./out/pack create-builder my-builder:p0.4 -c ~/dev/buildpacks/samples/builders/bionic/builder.toml
bionic: Pulling from cnbs/sample-stack-run
Digest: sha256:c1baaa9eeb47dada3d914ebef51696b7844bf410047c2b45e2f768d2a1c5b21e
Status: Image is up to date for cnbs/sample-stack-run:bionic
bionic: Pulling from cnbs/sample-stack-build
Digest: sha256:daa2f382500ebdd466a2bb64fe09f92b07b0facfd4421e33172cc63138e53106
Status: Image is up to date for cnbs/sample-stack-build:bionic
hello-universe: Pulling from cnbs/sample-package
Digest: sha256:c797967a15cf0199d73716dd9625b6d2ffe9bece90675a83f0a6132c7395f361
Status: Image is up to date for cnbs/sample-package:hello-universe
Successfully created builder image my-builder:p0.4
Tip: Run pack build <image-name> --builder my-builder:p0.4 to use this builder

$ ./out/pack inspect-builder my-builder:p0.4
Inspecting builder: my-builder:p0.4

REMOTE:
(not present)

LOCAL:

Created By:
  Name: Pack CLI
  Version: 0.0.0+git-5fca480

Trusted: No

Stack:
  ID: io.buildpacks.samples.stacks.bionic

Lifecycle:
  Version: 0.9.1
  Buildpack APIs:
    Deprecated: (none)
    Supported: 0.2, 0.3, 0.4
  Platform APIs:
    Deprecated: (none)
    Supported: 0.3, 0.4

Run Images:
  cnbs/sample-stack-run:bionic

Buildpacks:
  ID                            VERSION        HOMEPAGE
  samples/java-maven            0.0.1          https://github.com/buildpacks/samples/tree/main/buildpacks/java-maven
  samples/kotlin-gradle         0.0.1          https://github.com/buildpacks/samples/tree/main/buildpacks/kotlin-gradle
  samples/ruby-bundler          0.0.1          https://github.com/buildpacks/samples/tree/main/buildpacks/ruby-bundler
  samples/hello-universe        0.0.1          https://github.com/buildpacks/samples/tree/main/buildpacks/hello-universe
  samples/hello-world           0.0.1          https://github.com/buildpacks/samples/tree/main/buildpacks/hello-world
  samples/hello-moon            0.0.1          https://github.com/buildpacks/samples/tree/main/buildpacks/hello-moon

Detection Order:
 ├ Group #1:
 │  └ samples/java-maven@0.0.1    
 ├ Group #2:
 │  └ samples/kotlin-gradle@0.0.1    
 ├ Group #3:
 │  └ samples/ruby-bundler@0.0.1    
 └ Group #4:
    └ samples/hello-universe@0.0.1    
       └ Group #1:
          ├ samples/hello-world@0.0.1    
          └ samples/hello-moon@0.0.1     

$ ./out/pack build my-bash-app -p ~/dev/buildpacks/samples/apps/bash-script/ -B my-builder:p0.4
bionic: Pulling from cnbs/sample-stack-run
Digest: sha256:c1baaa9eeb47dada3d914ebef51696b7844bf410047c2b45e2f768d2a1c5b21e
Status: Image is up to date for cnbs/sample-stack-run:bionic
0.9.1: Pulling from buildpacksio/lifecycle
Digest: sha256:53bf0e18a734e0c4071aa39b950ed8841f82936e53fb2a0df56c6aa07f9c5023
Status: Image is up to date for buildpacksio/lifecycle:0.9.1
===> DETECTING
[detector] samples/bash-script 0.0.1
===> ANALYZING
===> RESTORING
===> BUILDING
[builder] ---> Hello World buildpack
[builder] ---> Hello Bash Script buildpack
[builder] 
[builder] Here are the contents of the current working directory:
[builder] .:
[builder] total 16
[builder] drwxr-xr-x 2 cnb  cnb  4096 Aug 18 00:33 .
[builder] drwxr-xr-x 1 root root 4096 Aug 18 00:33 ..
[builder] -rwxr-xr-x 1 cnb  cnb   738 Apr  6 23:13 app.sh
[builder] -rw-r--r-- 1 cnb  cnb   202 Apr  6 23:13 project.toml
===> EXPORTING
[exporter] Reusing 1/1 app layer(s)
[exporter] Adding layer 'launcher'
[exporter] Reusing layer 'config'
[exporter] Reusing layer 'process-types'
[exporter] Adding label 'io.buildpacks.lifecycle.metadata'
[exporter] Adding label 'io.buildpacks.build.metadata'
[exporter] Adding label 'io.buildpacks.project.metadata'
[exporter] Setting default process type 'web'
[exporter] *** Images (3bfef0a18097):
[exporter]       index.docker.io/library/my-bash-app:latest
Successfully built image my-bash-app

$ ./out/pack inspect-image my-bash-app
Inspecting image: my-bash-app

REMOTE:
(not present)

LOCAL:

Stack: io.buildpacks.samples.stacks.bionic

Base Image:
  Reference: 1b1c340a619e91d035a8108da795630d05234781a76bf583cd1396d85575cc45
  Top Layer: sha256:e7d9e63e3016d2419dfdc1175d4b53dbc97356921c59caaa887c541b783f290b

Run Images:
  cnbs/sample-stack-run:bionic

Buildpacks:
  ID                         VERSION
  samples/bash-script        0.0.1

Processes:
  TYPE                 SHELL        COMMAND           ARGS
  web (default)        bash         ./app.sh          
  hello                bash         ./world.sh        

$ docker run --rm -it my-bash-app

    |'-_ _-'|       ____          _  _      _                      _             _
    |   |   |      |  _ \        (_)| |    | |                    | |           (_)
     '-_|_-'       | |_) | _   _  _ | |  __| | _ __    __ _   ___ | | __ ___     _   ___
|'-_ _-'|'-_ _-'|  |  _ < | | | || || | / _` || '_ \  / _` | / __|| |/ // __|   | | / _ \
|   |   |   |   |  | |_) || |_| || || || (_| || |_) || (_| || (__ |   < \__ \ _ | || (_) |
 '-_|_-' '-_|_-'   |____/  \__,_||_||_| \__,_|| .__/  \__,_| \___||_|\_\|___/(_)|_| \___/
                                              | |
                                              |_|


Here are the contents of the current working directory:
.:
total 16
drwxr-xr-x 2 cnb  cnb  4096 Jan  1  1980 .
drwxr-xr-x 1 root root 4096 Aug 18 00:33 ..
-rwxr-xr-x 1 cnb  cnb   738 Jan  1  1980 app.sh
-rw-r--r-- 1 cnb  cnb   202 Jan  1  1980 project.toml

```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #801
