### PR TITLE
Revert "Remove `/lifecycle` symlink created on builders"

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -32,12 +32,13 @@ const (
 
 	cnbDir = "/cnb"
 
-	orderPath    = "/cnb/order.toml"
-	stackPath    = "/cnb/stack.toml"
-	platformDir  = "/platform"
-	lifecycleDir = "/cnb/lifecycle"
-	workspaceDir = "/workspace"
-	layersDir    = "/layers"
+	orderPath          = "/cnb/order.toml"
+	stackPath          = "/cnb/stack.toml"
+	platformDir        = "/platform"
+	lifecycleDir       = "/cnb/lifecycle"
+	compatLifecycleDir = "/lifecycle"
+	workspaceDir       = "/workspace"
+	layersDir          = "/layers"
 
 	metadataLabel = "io.buildpacks.builder.metadata"
 	stackLabel    = "io.buildpacks.stack.id"
@@ -579,6 +580,16 @@ func (b *Builder) lifecycleLayer(dest string) (string, error) {
 	err = b.embedLifecycleTar(lw)
 	if err != nil {
 		return "", errors.Wrap(err, "embedding lifecycle tar")
+	}
+
+	if err := lw.WriteHeader(&tar.Header{
+		Name:     compatLifecycleDir,
+		Linkname: lifecycleDir,
+		Typeflag: tar.TypeSymlink,
+		Mode:     0644,
+		ModTime:  archive.NormalizedDateTime,
+	}); err != nil {
+		return "", errors.Wrapf(err, "creating %s symlink", style.Symbol(compatLifecycleDir))
 	}
 
 	return fh.Name(), nil

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -657,6 +657,14 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 					h.HasFileMode(0755),
 					h.HasModTime(archive.NormalizedDateTime),
 				)
+
+				it("should add lifecycle symlink", func() {
+					h.AssertOnTarEntry(t, layerTar, "/lifecycle",
+						h.SymlinksTo("/cnb/lifecycle"),
+						h.HasFileMode(0644),
+						h.HasModTime(archive.NormalizedDateTime),
+					)
+				})
 			})
 
 			it("sets the lifecycle version on the metadata", func() {


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->

Reverts changes from #763 based on larger user impact than expected based on [feedback provided](https://paketobuildpacks.slack.com/archives/CU8RVQZ1R/p1597856974007000) by Spring Boot users.

This reverts commit 5b6731320073fe1451f440ac93c27edf2f792a2a.
This reverts commit bd59022e6ce7532c10388b99ede2780e746a2b67.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

```
$ ./out/pack create-builder my-builder -c ~/dev/buildpacks/samples/builders/alpine/builder.toml
alpine: Pulling from cnbs/sample-stack-run
21c83c524219: Pull complete
0c4331fef8cd: Pull complete
2240f5e7c4eb: Pull complete
Digest: sha256:e19e21a6902da6c23fbaecc9a89c2250264e6974994c1e4a16587031a15f67be
Status: Downloaded newer image for cnbs/sample-stack-run:alpine
alpine: Pulling from cnbs/sample-stack-build
21c83c524219: Already exists
0c4331fef8cd: Already exists
2240f5e7c4eb: Already exists
5cd7f52045a5: Pull complete
21aac71abba2: Pull complete
Digest: sha256:6045fa8d02f30d1bedbc2d99590c129d19ae7afd7aec3f67fcb390431ff27e8b
Status: Downloaded newer image for cnbs/sample-stack-build:alpine
hello-universe: Pulling from cnbs/sample-package
Digest: sha256:c797967a15cf0199d73716dd9625b6d2ffe9bece90675a83f0a6132c7395f361
Status: Image is up to date for cnbs/sample-package:hello-universe
Successfully created builder image my-builder
Tip: Run pack build <image-name> --builder my-builder to use this builder

$ docker run --rm my-builder /bin/sh -c "ls -alR /lifecycle"
ls: /lifecycle: No such file or directory

$ docker run --rm my-builder /bin/sh -c "ls -al /"
total 80
drwxr-xr-x    1 root     root          4096 Aug 19 20:12 .
drwxr-xr-x    1 root     root          4096 Aug 19 20:12 ..
-rwxr-xr-x    1 root     root             0 Aug 19 20:12 .dockerenv
drwxr-xr-x    1 root     root          4096 Aug 17 13:47 bin
drwxr-xr-x    1 root     root          4096 Aug 19 20:10 cnb
drwxr-xr-x    5 root     root           340 Aug 19 20:12 dev
drwxr-xr-x    1 root     root          4096 Aug 19 20:12 etc
drwxr-xr-x    1 root     root          4096 Aug 17 13:47 home
drwxr-xr-x    2 cnb      cnb           4096 Jan  1  1980 layers
drwxr-xr-x    1 root     root          4096 Apr 23 12:52 lib
drwxr-xr-x    5 root     root          4096 Apr 23 12:52 media
drwxr-xr-x    2 root     root          4096 Apr 23 12:52 mnt
drwxr-xr-x    2 root     root          4096 Apr 23 12:52 opt
drwxr-xr-x    3 root     root          4096 Jan  1  1980 platform
dr-xr-xr-x  188 root     root             0 Aug 19 20:12 proc
drwx------    2 root     root          4096 Apr 23 12:52 root
drwxr-xr-x    2 root     root          4096 Apr 23 12:52 run
drwxr-xr-x    2 root     root          4096 Apr 23 12:52 sbin
drwxr-xr-x    2 root     root          4096 Apr 23 12:52 srv
dr-xr-xr-x   12 root     root             0 Aug 19 20:12 sys
drwxrwxrwt    2 root     root          4096 Apr 23 12:52 tmp
drwxr-xr-x    1 root     root          4096 Aug 17 13:47 usr
drwxr-xr-x    1 root     root          4096 Aug 17 13:47 var
drwxr-xr-x    2 cnb      cnb           4096 Jan  1  1980 workspace
```

#### After

```
$ ./out/pack create-builder my-builder -c ~/dev/buildpacks/samples/builders/alpine/builder.toml
alpine: Pulling from cnbs/sample-stack-run
Digest: sha256:e19e21a6902da6c23fbaecc9a89c2250264e6974994c1e4a16587031a15f67be
Status: Image is up to date for cnbs/sample-stack-run:alpine
alpine: Pulling from cnbs/sample-stack-build
Digest: sha256:6045fa8d02f30d1bedbc2d99590c129d19ae7afd7aec3f67fcb390431ff27e8b
Status: Image is up to date for cnbs/sample-stack-build:alpine
hello-universe: Pulling from cnbs/sample-package
Digest: sha256:c797967a15cf0199d73716dd9625b6d2ffe9bece90675a83f0a6132c7395f361
Status: Image is up to date for cnbs/sample-package:hello-universe
Successfully created builder image my-builder
Tip: Run pack build <image-name> --builder my-builder to use this builder

$ docker run --rm my-builder /bin/sh -c "ls -alR /lifecycle"
lrwxrwxrwx    1 root     root            14 Jan  1  1980 /lifecycle -> /cnb/lifecycle

$ docker run --rm my-builder /bin/sh -c "ls -al /"
total 80
drwxr-xr-x    1 root     root          4096 Aug 19 20:13 .
drwxr-xr-x    1 root     root          4096 Aug 19 20:13 ..
-rwxr-xr-x    1 root     root             0 Aug 19 20:13 .dockerenv
drwxr-xr-x    1 root     root          4096 Aug 17 13:47 bin
drwxr-xr-x    1 root     root          4096 Aug 19 20:12 cnb
drwxr-xr-x    5 root     root           340 Aug 19 20:13 dev
drwxr-xr-x    1 root     root          4096 Aug 19 20:13 etc
drwxr-xr-x    1 root     root          4096 Aug 17 13:47 home
drwxr-xr-x    2 cnb      cnb           4096 Jan  1  1980 layers
drwxr-xr-x    1 root     root          4096 Apr 23 12:52 lib
lrwxrwxrwx    1 root     root            14 Jan  1  1980 lifecycle -> /cnb/lifecycle
drwxr-xr-x    5 root     root          4096 Apr 23 12:52 media
drwxr-xr-x    2 root     root          4096 Apr 23 12:52 mnt
drwxr-xr-x    2 root     root          4096 Apr 23 12:52 opt
drwxr-xr-x    3 root     root          4096 Jan  1  1980 platform
dr-xr-xr-x  189 root     root             0 Aug 19 20:13 proc
drwx------    2 root     root          4096 Apr 23 12:52 root
drwxr-xr-x    2 root     root          4096 Apr 23 12:52 run
drwxr-xr-x    2 root     root          4096 Apr 23 12:52 sbin
drwxr-xr-x    2 root     root          4096 Apr 23 12:52 srv
dr-xr-xr-x   12 root     root             0 Aug 19 20:13 sys
drwxrwxrwt    2 root     root          4096 Apr 23 12:52 tmp
drwxr-xr-x    1 root     root          4096 Aug 17 13:47 usr
drwxr-xr-x    1 root     root          4096 Aug 17 13:47 var
drwxr-xr-x    2 cnb      cnb           4096 Jan  1  1980 workspace
```

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Relates to https://github.com/spring-projects/spring-boot/issues/23009
