### PR TITLE
Add link to pack cli documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@
 <img src="resources/pack-build.gif" width="600px" />
 
 ## Getting Started
-
 Get started by running through our tutorial: [An App’s Brief Journey from Source to Image][getting-started]
 
 ## Contributing
-
 - [CONTRIBUTING](CONTRIBUTING.md) - Information on how to contribute, including the pull request process.
 - [DEVELOPMENT](DEVELOPMENT.md) - Further detail to help you during the development process.
 - [RELEASE](RELEASE.md) - Further details about our release process.
+
+## Documentation
+Check out the command line documentation [here][pack-docs]
 
 ## Specifications
 `pack` is a CLI implementation of the [Platform Interface Specification][platform-spec] for [Cloud Native Buildpacks][buildpacks.io].
@@ -39,3 +40,4 @@ To learn more about the details, check out the [specs repository][specs].
 [getting-started]: https://buildpacks.io/docs/app-journey
 [specs]: https://github.com/buildpacks/spec/
 [platform-spec]: https://github.com/buildpacks/spec/blob/main/platform.md
+[pack-docs]: https://buildpacks.io/docs/reference/pack/pack/


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This adds a link to the pack cli documentation in the README. 

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #812 