### PR TITLE
Fix for GHA to work with default Windows runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,11 +58,20 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
           git config --global core.symlinks true
-      - name: Set docker host dns helpers
+      - name: Set docker to allow local registry using helpers dns names
         if: matrix.os == 'windows'
         run: |
-          # If helper names don't resolve, augment etc/hosts with entries using primary IP
+          # Lookup IP address by default-gateway network interface
           $IPAddress=(Get-NetIPAddress -InterfaceAlias ((Get-NetRoute "0.0.0.0/0").InterfaceAlias) -AddressFamily IPv4)[0].IPAddress
+
+          # Add daemon config allowing wildcard ports for machine ip address
+          $dockerConfig = @{}
+          $dockerConfig."insecure-registries" = @("${IPAddress}/32")
+          ConvertTo-Json -InputObject $dockerConfig | Set-Content c:\ProgramData\docker\config\daemon.json -Encoding Ascii
+          Restart-Service docker
+
+          # If helper names don't resolve, augment etc/hosts with entries using primary IP
+          # Matches Docker Desktop behavior: https://docs.docker.com/docker-for-windows/networking/#:~:text=host.docker.internal
           if (!(Resolve-DnsName host.docker.internal -ErrorAction SilentlyContinue)) {
             echo "`n${IPAddress} host.docker.internal" | Out-File -Filepath C:\Windows\System32\drivers\etc\hosts -Append -Encoding utf8
           }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,11 +64,13 @@ jobs:
           # If helper names don't resolve, augment etc/hosts with entries using primary IP
           $IPAddress=(Get-NetIPAddress -InterfaceAlias ((Get-NetRoute "0.0.0.0/0").InterfaceAlias) -AddressFamily IPv4)[0].IPAddress
           if (!(Resolve-DnsName host.docker.internal -ErrorAction SilentlyContinue)) {
-            echo "${IPAddress} host.docker.internal" | Out-File -Filepath C:\Windows\System32\drivers\etc\hosts -Append -Encoding utf8
+            echo "`n${IPAddress} host.docker.internal" | Out-File -Filepath C:\Windows\System32\drivers\etc\hosts -Append -Encoding utf8
           }
           if (!(Resolve-DnsName gateway.docker.internal -ErrorAction SilentlyContinue)) {
-            echo "${IPAddress} gateway.docker.internal" | Out-File -Filepath C:\Windows\System32\drivers\etc\hosts -Append -Encoding utf8
+            echo "`n${IPAddress} gateway.docker.internal" | Out-File -Filepath C:\Windows\System32\drivers\etc\hosts -Append -Encoding utf8
           }
+          echo "Contents:"
+          Get-Content C:\Windows\System32\drivers\etc\hosts
       - uses: actions/checkout@v2
       - name: Derive pack version from branch name
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
             pack_bin: pack.exe
           - config: windows-wcow
             os: windows
-            runner: [self-hosted, windows, wcow]
+            runner: windows-latest
             no_docker: "false"
             pack_bin: pack.exe
     runs-on: ${{ matrix.runner }}
@@ -58,6 +58,17 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
           git config --global core.symlinks true
+      - name: Set docker host dns helpers
+        if: matrix.os == 'windows'
+        run: |
+          # If helper names don't resolve, augment etc/hosts with entries using primary IP
+          $IPAddress=(Get-NetIPAddress -InterfaceAlias ((Get-NetRoute "0.0.0.0/0").InterfaceAlias) -AddressFamily IPv4)[0].IPAddress
+          if (!(Resolve-DnsName host.docker.internal -ErrorAction SilentlyContinue)) {
+            echo "${IPAddress} host.docker.internal" | Out-File -Filepath C:\Windows\System32\drivers\etc\hosts -Append -Encoding utf8
+          }
+          if (!(Resolve-DnsName gateway.docker.internal -ErrorAction SilentlyContinue)) {
+            echo "${IPAddress} gateway.docker.internal" | Out-File -Filepath C:\Windows\System32\drivers\etc\hosts -Append -Encoding utf8
+          }
       - uses: actions/checkout@v2
       - name: Derive pack version from branch name
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           git config --global core.eol lf
           git config --global core.symlinks true
       - name: Set docker to allow local registry using helpers dns names
-        if: matrix.os == 'windows'
+        if: matrix.config == 'windows-wcow'
         run: |
           # Lookup IP address by default-gateway network interface
           $IPAddress=(Get-NetIPAddress -InterfaceAlias ((Get-NetRoute "0.0.0.0/0").InterfaceAlias) -AddressFamily IPv4)[0].IPAddress

--- a/acceptance/testdata/mock_buildpacks/0.2/internet-capable-buildpack/bin/detect.bat
+++ b/acceptance/testdata/mock_buildpacks/0.2/internet-capable-buildpack/bin/detect.bat
@@ -2,7 +2,7 @@
 
 echo ---- Detect: Internet capable buildpack
 
-ping -n 1 google.com
+curl.exe --silent --head google.com >NUL
 
 if %ERRORLEVEL% equ 0 (
   echo RESULT: Connected to the internet

--- a/acceptance/testdata/mock_stack/windows/run/Dockerfile
+++ b/acceptance/testdata/mock_stack/windows/run/Dockerfile
@@ -7,6 +7,8 @@ RUN go build /util/server.go
 
 FROM mcr.microsoft.com/windows/nanoserver:1809
 
+WORKDIR /util
+
 COPY --from=gobuild /util/server.exe /util/server.exe
 
 # placeholder values until correct values are deteremined


### PR DESCRIPTION
## Summary
 - Change `build.yml` to ignore self-hosted worker to use GHA default runner
 - Change `build.yml` to setup docker hostname helpers `host.docker.internal` so Docker for Windows Server matches those made by Docker Desktop [docs](https://docs.docker.com/docker-for-windows/networking/#:~:text=host.docker.internal)
 - Fix windows mock stack Dockerfile that failed to build on Docker for Windows Server

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
* Original context for creating self-hosted runner [slack](https://buildpacks.slack.com/archives/CSRHS92NP/p1595881563207600)
* Self-hosted runner [issue](https://github.com/buildpacks/ci/issues/20)
