### PR TITLE
Print only image name (and digest) when running `pack build` in quiet mode

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -813,6 +813,7 @@ func testAcceptance(
 						it("doesn't have color", func() {
 							appPath := filepath.Join("testdata", "mock_app")
 
+							//--no-color is set as a default option in our tests, and doesn't need to be explicitly provided
 							output := pack.RunSuccessfully("build", repoName, "-p", appPath)
 							imgId, err := imgIDForRepoName(repoName)
 							if err != nil {
@@ -824,6 +825,32 @@ func testAcceptance(
 
 							assertOutput.ReportsSuccessfulImageBuild(repoName)
 							assertOutput.WithoutColors()
+						})
+					})
+
+					when("--quiet", func() {
+						it.Before(func() {
+							h.SkipUnless(t,
+								pack.SupportsFeature(invoke.QuietMode),
+								"pack had a bug for quiet mode until 0.13.2",
+							)
+						})
+
+						it("only logs app name and sha", func() {
+							appPath := filepath.Join("testdata", "mock_app")
+
+							pack.SetVerbose(false)
+							defer pack.SetVerbose(true)
+
+							output := pack.RunSuccessfully("build", repoName, "-p", appPath, "--quiet")
+							imgId, err := imgIDForRepoName(repoName)
+							if err != nil {
+								t.Fatal(err)
+							}
+							defer h.DockerRmi(dockerCli, imgId)
+
+							assertOutput := assertions.NewOutputAssertionManager(t, output)
+							assertOutput.ReportSuccessfulQuietBuild(repoName)
 						})
 					})
 

--- a/acceptance/assertions/output.go
+++ b/acceptance/assertions/output.go
@@ -5,6 +5,7 @@ package assertions
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	h "github.com/buildpacks/pack/testhelpers"
@@ -28,6 +29,13 @@ func (o OutputAssertionManager) ReportsSuccessfulImageBuild(name string) {
 	o.testObject.Helper()
 
 	o.assert.ContainsF(o.output, "Successfully built image '%s'", name)
+}
+
+func (o OutputAssertionManager) ReportSuccessfulQuietBuild(name string) {
+	o.testObject.Helper()
+	o.testObject.Log("quiet mode")
+
+	o.assert.Matches(strings.TrimSpace(o.output), regexp.MustCompile(name+`@sha256:[\w]{12}`))
 }
 
 func (o OutputAssertionManager) ReportsSuccessfulRebase(name string) {

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -25,6 +25,7 @@ type PackInvoker struct {
 	home            string
 	dockerConfigDir string
 	fixtureManager  PackFixtureManager
+	verbose         bool
 }
 
 type packPathsProvider interface {
@@ -52,6 +53,7 @@ func NewPackInvoker(
 		path:            packAssets.Path(),
 		home:            home,
 		dockerConfigDir: dockerConfigDir,
+		verbose:         true,
 		fixtureManager: PackFixtureManager{
 			testObject: testObject,
 			assert:     assert,
@@ -72,7 +74,7 @@ func (i *PackInvoker) cmd(name string, args ...string) *exec.Cmd {
 
 	cmdArgs := append([]string{name}, args...)
 	cmdArgs = append(cmdArgs, "--no-color")
-	if i.Supports("--verbose") {
+	if i.verbose && i.Supports("--verbose") {
 		cmdArgs = append(cmdArgs, "--verbose")
 	}
 
@@ -96,6 +98,10 @@ func (i *PackInvoker) Run(name string, args ...string) (string, error) {
 	output, err := i.cmd(name, args...).CombinedOutput()
 
 	return string(output), err
+}
+
+func (i *PackInvoker) SetVerbose(verbose bool) {
+	i.verbose = verbose
 }
 
 func (i *PackInvoker) RunSuccessfully(name string, args ...string) string {
@@ -214,6 +220,7 @@ const (
 	CreatorInPack
 	ReadWriteVolumeMounts
 	NoColorInBuildpacks
+	QuietMode
 )
 
 var featureTests = map[Feature]func(i *PackInvoker) bool{
@@ -231,6 +238,9 @@ var featureTests = map[Feature]func(i *PackInvoker) bool{
 	},
 	NoColorInBuildpacks: func(i *PackInvoker) bool {
 		return i.atLeast("0.12.0")
+	},
+	QuietMode: func(i *PackInvoker) bool {
+		return i.atLeast("0.13.2")
 	},
 }
 

--- a/internal/image/fetcher.go
+++ b/internal/image/fetcher.go
@@ -98,7 +98,7 @@ func (f *Fetcher) pullImage(ctx context.Context, imageID string) error {
 		return err
 	}
 
-	writer := f.logger.Writer()
+	writer := logging.GetWriterForLevel(f.logger, logging.InfoLevel)
 	termFd, isTerm := isTerminal(writer)
 
 	err = jsonmessage.DisplayJSONMessagesStream(rc, &colorizedWriter{writer}, termFd, isTerm, nil)

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -4,6 +4,7 @@ package logging
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 
 	"github.com/buildpacks/pack/internal/style"
 )
@@ -50,6 +51,15 @@ func GetWriterForLevel(logger Logger, level Level) io.Writer {
 	}
 
 	return logger.Writer()
+}
+
+// IsQuiet defines whether a pack logger is set to quiet mode
+func IsQuiet(logger Logger) bool {
+	if writer := GetWriterForLevel(logger, InfoLevel); writer == ioutil.Discard {
+		return true
+	}
+
+	return false
 }
 
 // PrefixWriter will prefix writes

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -53,6 +53,27 @@ func testLogging(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("IsQuiet", func() {
+		when("implements WithSelectableWriter", func() {
+			it("return true for quiet mode", func() {
+				var w bytes.Buffer
+				logger := ilogging.NewLogWithWriters(&w, &w)
+				h.AssertEq(t, logging.IsQuiet(logger), false)
+
+				logger.WantQuiet(true)
+				h.AssertEq(t, logging.IsQuiet(logger), true)
+			})
+		})
+
+		when("doesn't implement WithSelectableWriter", func() {
+			it("always returns false", func() {
+				var w bytes.Buffer
+				logger := logging.New(&w)
+				h.AssertEq(t, logging.IsQuiet(logger), false)
+			})
+		})
+	})
+
 	when("PrefixWriter#Write", func() {
 		it("prepends prefix to string", func() {
 			var w bytes.Buffer


### PR DESCRIPTION
* Fetcher used to log directly to the Writer, and bypass quiet mode. This fixes that hole.
* This implements a request (#285) for having build -q to print the app name @ sha. It only adds it into the quiet mode; in a normal build, there's no need to print it, since the information is printed by the lifecycle. It is only in cases where we suppress that output (quiet mode) where we need to print it ourselves. 

Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
![image](https://user-images.githubusercontent.com/7035673/92101230-7daced00-ede5-11ea-9ff8-3dc2b54f2226.png)

#### After
![image](https://user-images.githubusercontent.com/7035673/92101252-856c9180-ede5-11ea-8b36-a95567c1f04a.png)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
Resolves #285
