### PR TITLE
Fix registry selector flag in build command and validation for the input

### DIFF
--- a/build.go
+++ b/build.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -76,7 +75,7 @@ type BuildOptions struct {
 	// required. Builder image name.
 	Builder string
 
-	// URI to a buildpack registry. Used to
+	// Name of the buildpack registry. Used to
 	// add buildpacks to a build.
 	Registry string
 
@@ -652,11 +651,6 @@ func (c *Client) processBuildpacks(ctx context.Context, builderImage imgutil.Ima
 			fetchedBPs = append(append(fetchedBPs, mainBP), depBPs...)
 			order = appendBuildpackToOrder(order, mainBP.Descriptor().Info)
 		case buildpack.RegistryLocator:
-			r := regexp.MustCompile(`^(https|git)(://|@)([^/:]+)[/:]([^/:]+)/(.+).git$`)
-			if r.MatchString(registry) {
-				return fetchedBPs, order, errors.New("registry should be only specified as named")
-			}
-
 			registryCache, err := c.getRegistry(c.logger, registry)
 			if err != nil {
 				return fetchedBPs, order, errors.Wrapf(err, "invalid registry '%s'", registry)

--- a/build.go
+++ b/build.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -651,6 +652,11 @@ func (c *Client) processBuildpacks(ctx context.Context, builderImage imgutil.Ima
 			fetchedBPs = append(append(fetchedBPs, mainBP), depBPs...)
 			order = appendBuildpackToOrder(order, mainBP.Descriptor().Info)
 		case buildpack.RegistryLocator:
+			r := regexp.MustCompile(`^(https|git)(://|@)([^/:]+)[/:]([^/:]+)/(.+).git$`)
+			if r.MatchString(registry) {
+				return fetchedBPs, order, errors.New("registry should be only specified as named")
+			}
+
 			registryCache, err := c.getRegistry(c.logger, registry)
 			if err != nil {
 				return fetchedBPs, order, errors.Wrapf(err, "invalid registry '%s'", registry)

--- a/common.go
+++ b/common.go
@@ -76,7 +76,7 @@ func (c *Client) getRegistry(logger logging.Logger, registryName string) (regist
 		return registry.NewDefaultRegistryCache(logger, home)
 	}
 
-	for _, reg := range cfg.Registries {
+	for _, reg := range config.GetRegistries(cfg) {
 		if reg.Name == registryName {
 			return registry.NewRegistryCache(logger, home, reg.URL)
 		}

--- a/create_builder.go
+++ b/create_builder.go
@@ -33,7 +33,7 @@ type CreateBuilderOptions struct {
 	// Requires BuilderName to be a valid registry location.
 	Publish bool
 
-	// Buildpack registry location. Defines where all registry buildpacks will be pulled from.
+	// Buildpack registry name. Defines where all registry buildpacks will be pulled from.
 	Registry string
 
 	// Strategy for updating images before a build.

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -144,8 +144,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Config) {
 	cmd.Flags().StringVarP(&buildFlags.AppPath, "path", "p", "", "Path to app dir or zip-formatted file (defaults to current working directory)")
 	cmd.Flags().StringVarP(&buildFlags.Builder, "builder", "B", cfg.DefaultBuilder, "Builder image")
-	//nolint:staticcheck
-	cmd.Flags().StringVarP(&buildFlags.Registry, "buildpack-registry", "R", cfg.DefaultRegistry, "Buildpack Registry URL")
+	cmd.Flags().StringVarP(&buildFlags.Registry, "buildpack-registry", "r", cfg.DefaultRegistry, "Buildpack Registry URL")
 	if !cfg.Experimental {
 		cmd.Flags().MarkHidden("buildpack-registry")
 	}

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -144,7 +144,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Config) {
 	cmd.Flags().StringVarP(&buildFlags.AppPath, "path", "p", "", "Path to app dir or zip-formatted file (defaults to current working directory)")
 	cmd.Flags().StringVarP(&buildFlags.Builder, "builder", "B", cfg.DefaultBuilder, "Builder image")
-	cmd.Flags().StringVarP(&buildFlags.Registry, "buildpack-registry", "r", cfg.DefaultRegistry, "Buildpack Registry by name")
+	cmd.Flags().StringVarP(&buildFlags.Registry, "buildpack-registry", "r", cfg.DefaultRegistryName, "Buildpack Registry by name")
 	if !cfg.Experimental {
 		cmd.Flags().MarkHidden("buildpack-registry")
 	}

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -144,7 +144,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Config) {
 	cmd.Flags().StringVarP(&buildFlags.AppPath, "path", "p", "", "Path to app dir or zip-formatted file (defaults to current working directory)")
 	cmd.Flags().StringVarP(&buildFlags.Builder, "builder", "B", cfg.DefaultBuilder, "Builder image")
-	cmd.Flags().StringVarP(&buildFlags.Registry, "buildpack-registry", "r", cfg.DefaultRegistry, "Buildpack Registry URL")
+	cmd.Flags().StringVarP(&buildFlags.Registry, "buildpack-registry", "r", cfg.DefaultRegistry, "Buildpack Registry by name")
 	if !cfg.Experimental {
 		cmd.Flags().MarkHidden("buildpack-registry")
 	}

--- a/internal/commands/register_buildpack.go
+++ b/internal/commands/register_buildpack.go
@@ -30,6 +30,7 @@ func RegisterBuildpack(logger logging.Logger, cfg config.Config, client PackClie
 			opts.ImageName = args[0]
 			opts.Type = registry.Type
 			opts.URL = registry.URL
+			opts.Name = registry.Name
 
 			if err := client.RegisterBuildpack(cmd.Context(), opts); err != nil {
 				return err

--- a/internal/commands/register_buildpack_test.go
+++ b/internal/commands/register_buildpack_test.go
@@ -67,6 +67,7 @@ func testRegisterBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 					ImageName: buildpackImage,
 					Type:      "github",
 					URL:       "https://github.com/buildpacks/registry-index",
+					Name:      "official",
 				}
 
 				mockClient.EXPECT().
@@ -94,6 +95,7 @@ func testRegisterBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 						ImageName: buildpackImage,
 						Type:      "github",
 						URL:       "https://github.com/berneuse/buildpack-registry",
+						Name:      "berneuse",
 					}
 
 					mockClient.EXPECT().
@@ -137,6 +139,7 @@ func testRegisterBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 					ImageName: buildpackImage,
 					Type:      "github",
 					URL:       "https://github.com/override/buildpack-registry",
+					Name:      "override",
 				}
 				mockClient.EXPECT().
 					RegisterBuildpack(gomock.Any(), opts).

--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -24,6 +24,7 @@ import (
 )
 
 const DefaultRegistryURL = "https://github.com/buildpacks/registry-index"
+const DefaultRegistryName = "official"
 const defaultRegistryDir = "registry"
 
 // Cache is a RegistryCache

--- a/register_buildpack.go
+++ b/register_buildpack.go
@@ -20,6 +20,7 @@ type RegisterBuildpackOptions struct {
 	ImageName string
 	Type      string
 	URL       string
+	Name      string
 }
 
 // RegisterBuildpack updates the Buildpack Registry with to include a new buildpack specified in
@@ -77,7 +78,7 @@ func (c *Client) RegisterBuildpack(ctx context.Context, opts RegisterBuildpackOp
 
 		return cmd.Start()
 	} else if opts.Type == "git" {
-		registryCache, err := c.getRegistry(c.logger, opts.URL)
+		registryCache, err := c.getRegistry(c.logger, opts.Name)
 		if err != nil {
 			return err
 		}

--- a/register_buildpack_test.go
+++ b/register_buildpack_test.go
@@ -60,6 +60,7 @@ func testRegisterBuildpack(t *testing.T, when spec.G, it spec.S) {
 					ImageName: "invalid/image",
 					Type:      "github",
 					URL:       registry.DefaultRegistryURL,
+					Name:      registry.DefaultRegistryName,
 				}))
 		})
 
@@ -73,6 +74,7 @@ func testRegisterBuildpack(t *testing.T, when spec.G, it spec.S) {
 					ImageName: "missinglabel/image",
 					Type:      "github",
 					URL:       registry.DefaultRegistryURL,
+					Name:      registry.DefaultRegistryName,
 				}))
 		})
 
@@ -82,6 +84,7 @@ func testRegisterBuildpack(t *testing.T, when spec.G, it spec.S) {
 					ImageName: "buildpack/image",
 					Type:      "github",
 					URL:       "",
+					Name:      "official",
 				}), "missing github URL")
 		})
 
@@ -91,6 +94,7 @@ func testRegisterBuildpack(t *testing.T, when spec.G, it spec.S) {
 					ImageName: "buildpack/image",
 					Type:      "git",
 					URL:       "",
+					Name:      "official",
 				}), "invalid url: cannot parse username from url")
 		})
 
@@ -100,6 +104,7 @@ func testRegisterBuildpack(t *testing.T, when spec.G, it spec.S) {
 					ImageName: "buildpack/image",
 					Type:      "git",
 					URL:       "https://github.com//buildpack-registry/",
+					Name:      "official",
 				}), "invalid url: username is empty")
 		})
 
@@ -112,6 +117,7 @@ func testRegisterBuildpack(t *testing.T, when spec.G, it spec.S) {
 					ImageName: "invalid/image",
 					Type:      "git",
 					URL:       registry.DefaultRegistryURL,
+					Name:      registry.DefaultRegistryName,
 				}))
 		})
 
@@ -125,6 +131,7 @@ func testRegisterBuildpack(t *testing.T, when spec.G, it spec.S) {
 					ImageName: "missinglabel/image",
 					Type:      "git",
 					URL:       registry.DefaultRegistryURL,
+					Name:      registry.DefaultRegistryName,
 				}))
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Supratik Das <rick.das08@gmail.com>

## Summary
This PR attempts to fix #747. It replaces the `-R` flag for selecting the registry in `pack build` to `-r`. It also puts a validation for rejecting git/https based URLs. 

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #747
