### PR TITLE
relax patch codecov diff

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ coverage:
         threshold: 1%
     patch:
       default:
-        threshold: 1%
+        threshold: 10%
 
 comment:
   layout: "reach,diff,flags"


### PR DESCRIPTION
## Summary
Relax Codecov patch coverage constraint. With the current settings it is difficult to get small changes merged. Settings already prohibit large untested changes by setting the `project-threshold` at 1%. 

- Should this change be documented?

    - [x] No
