### PR TITLE
fix nil pointer dereference

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -113,7 +113,7 @@ func initConfig() (config.Config, error) {
 func initClient(logger logging.Logger, cfg config.Config) (pack.Client, error) {
 	client, err := pack.NewClient(pack.WithLogger(logger), pack.WithExperimental(cfg.Experimental))
 	if err != nil {
-		return *client, err
+		return pack.Client{}, err
 	}
 
 	return *client, nil


### PR DESCRIPTION
Signed-off-by: ophum <inagaki0106@gmail.com>

Please excuse my poor English. 

## Summary
line 116 in `cmd/cmd.go`
will happen `invalid memory address or nil pointer dereference` when `err` is not `nil`.
because `client` is `nil`  

unuse returned `client`. use empty `pack.Client`.
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
