### PR TITLE
fix inspect-buildpack panic

### DIFF
--- a/internal/commands/inspect_buildpack.go
+++ b/internal/commands/inspect_buildpack.go
@@ -64,7 +64,7 @@ func InspectBuildpack(logger logging.Logger, cfg *config.Config, client PackClie
 	cmd := &cobra.Command{
 		Use:   "inspect-buildpack <image-name>",
 		Short: "Show information about a buildpack",
-		Args:  cobra.MaximumNArgs(4),
+		Args:  cobra.RangeArgs(1, 4),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			buildpackName := args[0]
 			registry := flags.Registry

--- a/internal/commands/inspect_buildpack_test.go
+++ b/internal/commands/inspect_buildpack_test.go
@@ -365,7 +365,7 @@ func testInspectBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 					}).Return(simpleInfo, nil)
 				})
 
-				it.Focus("succeeds", func() {
+				it("succeeds", func() {
 					command.SetArgs([]string{"test/buildpack"})
 					assert.Nil(command.Execute())
 
@@ -636,15 +636,15 @@ func testInspectBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 				err := command.Execute()
 
 				assert.Error(err)
-				assert.Contains(err.Error(), "error inspecting remote archive")
+				assert.Contains(err.Error(), "error writing buildpack output: \"no buildpacks found\"")
 			})
 		})
 
 		when("unable to inspect buildpack on registry", func() {
 			it.Before(func() {
 				mockClient.EXPECT().InspectBuildpack(pack.InspectBuildpackOptions{
-					BuildpackName: "image-failure-case/buildpack",
-					Daemon:        false,
+					BuildpackName: "urn:cnb:registry:registry-failure/buildpack",
+					Daemon:        true,
 					Registry:      "some-registry",
 				}).Return(&pack.BuildpackInfo{}, errors.New("error inspecting registry image"))
 			})


### PR DESCRIPTION
Signed-off-by: dwillist <dthornton@vmware.com>

## Summary
Fix bug causing crash when 0 args are provided to `inspect-buildpack` command.
Unfocus a test.

Resolves #843
