### PR TITLE
Replace docker with pack when building pack image

### DIFF
--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -1,19 +1,14 @@
 name: delivery / docker
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag_name:
-        description: 'tag'
-        required: true
-#  release:
-#    types:
-#      - published
+  release:
+    types:
+      - published
 
 env:
   BUILDER: "paketobuildpacks/builder:tiny"
   IMG_NAME: 'pack'
-  USERNAME: 'dfreilich'
+  USERNAME: 'buildpacksio'
 
 jobs:
   deliver-docker:
@@ -24,7 +19,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          echo "::set-output name=VERSION::$(echo ${{ github.event.inputs.tag_name }} | cut -d "v" -f2)"
+          echo "::set-output name=VERSION::$(echo ${{ github.event.release.tag_name }} | cut -d "v" -f2)"
       - name: Setup Working Dir
         shell: bash
         run: |

--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -1,26 +1,57 @@
 name: delivery / docker
 
 on:
-  release:
-    types:
-      - published
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'tag'
+        required: true
+#  release:
+#    types:
+#      - published
+
+env:
+  BUILDER: "paketobuildpacks/builder:tiny"
+  IMG_NAME: 'pack'
+  USERNAME: 'dfreilich'
 
 jobs:
   deliver-docker:
     runs-on: ubuntu-latest
+    container:
+      image: docker:stable
+      volumes:
+        - /home/runner:/var/www
     steps:
       - uses: actions/checkout@v2
       - name: Determine version
         id: version
         shell: bash
         run: |
-          echo "::set-output name=VERSION::$(echo ${{ github.event.release.tag_name }} | cut -d "v" -f2)"
-      - name: Build and Push Image
-        uses: docker/build-push-action@v1
+          echo "::set-output name=VERSION::$(echo ${{ github.event.inputs.tag_name }} | cut -d "v" -f2)"
+      - name: Setup Working Dir
+        shell: bash
+        run: |
+          cp .github/workflows/delivery/docker/buildpack.yml buildpack.yml
+      - name: Fill buildpack.yml
+        uses: cschleiden/replace-tokens@v1
+        with:
+          files: buildpack.yml
+        env:
+          PACK_VERSION: ${{ steps.version.outputs.VERSION }}
+      - name: Determine App Name
+        run: 'echo "::set-env name=IMG_NAME::$(echo ${USERNAME})/$(echo ${IMG_NAME})"'
+      - name: Login to Dockerhub
+        uses: docker/login-action@v1.3.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: buildpacksio/pack
-          path: .github/workflows/delivery/docker
-          build_args: VERSION=${{ steps.version.outputs.VERSION }}
-          tags: latest, ${{ steps.version.outputs.VERSION }}
+      - name: Pack Build/Publish
+        uses: dfreilich/pack-action@v0.0.2
+        with:
+          args: 'build ${{ env.IMG_NAME }}:${{ steps.version.outputs.VERSION }} --builder ${{ env.BUILDER }} --publish'
+      - name: Tag Image as Latest
+        run: |
+          docker pull ${{ env.IMG_NAME }}:${{ steps.version.outputs.VERSION }}
+          docker tag ${{ env.IMG_NAME }}:${{ steps.version.outputs.VERSION }} ${{ env.IMG_NAME }}:latest
+          docker push ${{ env.IMG_NAME }}:latest

--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -18,10 +18,6 @@ env:
 jobs:
   deliver-docker:
     runs-on: ubuntu-latest
-    container:
-      image: docker:stable
-      volumes:
-        - /home/runner:/var/www
     steps:
       - uses: actions/checkout@v2
       - name: Determine version
@@ -41,15 +37,12 @@ jobs:
           PACK_VERSION: ${{ steps.version.outputs.VERSION }}
       - name: Determine App Name
         run: 'echo "::set-env name=IMG_NAME::$(echo ${USERNAME})/$(echo ${IMG_NAME})"'
-      - name: Login to Dockerhub
-        uses: docker/login-action@v1.3.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Pack Build/Publish
-        uses: dfreilich/pack-action@v0.0.2
+        uses: dfreilich/pack-action@v1.0
         with:
           args: 'build ${{ env.IMG_NAME }}:${{ steps.version.outputs.VERSION }} --builder ${{ env.BUILDER }} --publish'
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Tag Image as Latest
         run: |
           docker pull ${{ env.IMG_NAME }}:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -43,6 +43,11 @@ jobs:
           args: 'build ${{ env.IMG_NAME }}:${{ steps.version.outputs.VERSION }} --builder ${{ env.BUILDER }} --publish'
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to Dockerhub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Tag Image as Latest
         run: |
           docker pull ${{ env.IMG_NAME }}:${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/delivery/docker/Dockerfile
+++ b/.github/workflows/delivery/docker/Dockerfile
@@ -1,6 +1,0 @@
-FROM alpine:3.10
-
-ARG VERSION
-ENV PACK_URL "https://github.com/buildpack/pack/releases/download/v${VERSION}/pack-v${VERSION}-linux.tgz"
-RUN wget -O- "${PACK_URL}" | tar -C /usr/local/bin -xz pack
-ENTRYPOINT ["/usr/local/bin/pack"]

--- a/.github/workflows/delivery/docker/buildpack.yml
+++ b/.github/workflows/delivery/docker/buildpack.yml
@@ -6,5 +6,4 @@ go:
     # The go.build.flags property allows you to override the default build
     # flags when compiling your program.
     flags:
-      - -buildmode=default
-      - -ldflags="-s -w -X 'github.com/buildpacks/pack.Version=#{PACK_VERSION}#' -extldflags ${LDFLAGS}"
+      - -ldflags="-s -w -X 'github.com/buildpacks/pack.Version=#{PACK_VERSION}#'"

--- a/.github/workflows/delivery/docker/buildpack.yml
+++ b/.github/workflows/delivery/docker/buildpack.yml
@@ -7,10 +7,4 @@ go:
     # flags when compiling your program.
     flags:
       - -buildmode=default
-      - -tags=paketo
       - -ldflags="-s -w -X 'github.com/buildpacks/pack.Version=#{PACK_VERSION}#' -extldflags ${LDFLAGS}"
-
-    # The go.build.import-path property allows you to specify an import path
-    # for your application. This is necessary if you are building a $GOPATH
-    # application that imports its own sub-packages.
-    import-path: github.com/buildpacks/pack

--- a/.github/workflows/delivery/docker/buildpack.yml
+++ b/.github/workflows/delivery/docker/buildpack.yml
@@ -1,0 +1,16 @@
+go:
+  targets:
+    - ./cmd/pack
+
+  build:
+    # The go.build.flags property allows you to override the default build
+    # flags when compiling your program.
+    flags:
+      - -buildmode=default
+      - -tags=paketo
+      - -ldflags="-s -w -X 'github.com/buildpacks/pack.Version=#{PACK_VERSION}#' -extldflags ${LDFLAGS}"
+
+    # The go.build.import-path property allows you to specify an import path
+    # for your application. This is necessary if you are building a $GOPATH
+    # application that imports its own sub-packages.
+    import-path: github.com/buildpacks/pack


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
As part of our delivery process, we push an image of pack to `buildapcksio/pack`. While we had been using docker for that, this PR uses [dfreilich/pack-action](https://github.com/dfreilich/pack-action) to release the image using `pack build....`

The release worked when I tried it out on my fork: [GH Action](https://github.com/dfreilich/pack/actions/runs/268939564), and the images are visible on DockerHub [here](https://hub.docker.com/r/dfreilich/pack/tags). 

#### Before
Docker

#### After
![dogfood](https://media2.giphy.com/media/3o7WItSnXGBtacU71C/giphy.gif)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
Relates to #515 
