### PR TITLE
feat: add buildpack registry

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -23,7 +23,7 @@ type ConfigurableLogger interface {
 // NewPackCommand generates a Pack command
 func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	cobra.EnableCommandSorting = false
-	cfg, err := initConfig()
+	cfg, cfgPath, err := initConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 
 	if cfg.Experimental {
 		rootCmd.AddCommand(commands.ListBuildpackRegistries(logger, cfg))
-		rootCmd.AddCommand(commands.AddBuildpackRegistry(logger, cfg))
+		rootCmd.AddCommand(commands.AddBuildpackRegistry(logger, cfg, cfgPath))
 		rootCmd.AddCommand(commands.RegisterBuildpack(logger, cfg, &packClient))
 		rootCmd.AddCommand(commands.YankBuildpack(logger, cfg, &packClient))
 	}
@@ -100,17 +100,17 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	return rootCmd, nil
 }
 
-func initConfig() (config.Config, error) {
+func initConfig() (config.Config, string, error) {
 	path, err := config.DefaultConfigPath()
 	if err != nil {
-		return config.Config{}, errors.Wrap(err, "getting config path")
+		return config.Config{}, "", errors.Wrap(err, "getting config path")
 	}
 
 	cfg, err := config.Read(path)
 	if err != nil {
-		return config.Config{}, errors.Wrap(err, "reading pack config")
+		return config.Config{}, "", errors.Wrap(err, "reading pack config")
 	}
-	return cfg, nil
+	return cfg, path, nil
 }
 
 func initClient(logger logging.Logger, cfg config.Config) (pack.Client, error) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -83,6 +83,7 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	rootCmd.AddCommand(commands.Report(logger, pack.Version))
 
 	if cfg.Experimental {
+		rootCmd.AddCommand(commands.AddBuildpackRegistry(logger, cfg))
 		rootCmd.AddCommand(commands.RegisterBuildpack(logger, cfg, &packClient))
 		rootCmd.AddCommand(commands.YankBuildpack(logger, cfg, &packClient))
 	}

--- a/internal/blob/downloader.go
+++ b/internal/blob/downloader.go
@@ -151,7 +151,7 @@ func (d *downloader) downloadAsStream(ctx context.Context, uri string, etag stri
 
 	return nil, "", fmt.Errorf(
 		"could not download from %s, code http status %s",
-		style.Symbol(uri), style.Symbol("%d", resp.StatusCode),
+		style.Symbol(uri), style.SymbolF("%d", resp.StatusCode),
 	)
 }
 

--- a/internal/commands/add_buildpack_registry.go
+++ b/internal/commands/add_buildpack_registry.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/style"
+
+	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/logging"
+)
+
+func AddBuildpackRegistry(logger logging.Logger, cfg config.Config) *cobra.Command {
+	var setDefault bool
+
+	cmd := &cobra.Command{
+		Use:   "add-buildpack-registry <name> <url> <type> (github | git)",
+		Args:  cobra.ExactArgs(3),
+		Short: "Adds a new buildpack registry to your pack config file",
+		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			newRegistry := config.Registry{
+				Name: args[0],
+				URL:  args[1],
+				Type: args[2],
+			}
+
+			err := addRegistry(newRegistry, cfg, setDefault)
+			if err != nil {
+				return errors.Wrapf(err, "add buildpack registry")
+			}
+			logger.Infof("Successfully added %s to buildpack registries", style.Symbol(newRegistry.Name))
+
+			return nil
+		}),
+	}
+	cmd.Example = "pack add-buildpack-registry myregistry github https://github.com/buildpacks/mybuildpack"
+	cmd.Flags().BoolVar(&setDefault, "default", false, "Set this buildpack registry as the default")
+	AddHelpFlag(cmd, "add-registry")
+
+	return cmd
+}
+
+func addRegistry(newRegistry config.Registry, cfg config.Config, setDefault bool) error {
+	if newRegistry.Type != "github" && newRegistry.Type != "git" {
+		return errors.Errorf(
+			"%s is not a valid type.  Supported types are %s or %s.",
+			style.Symbol(newRegistry.Type),
+			style.Symbol("github"),
+			style.Symbol("git"))
+	}
+	for _, r := range cfg.Registries {
+		if r.Name == newRegistry.Name {
+			return errors.Errorf(
+				"Buildpack registry %s already exists.  First run %s and try again.",
+				style.Symbol(newRegistry.Name),
+				style.Symbol(fmt.Sprintf("remove-buildpack-registry %s", newRegistry.Name)))
+		}
+	}
+
+	if setDefault {
+		cfg.DefaultRegistryName = newRegistry.Name
+	}
+	cfg.Registries = append(cfg.Registries, newRegistry)
+	configPath, err := config.DefaultConfigPath()
+	if err != nil {
+		return err
+	}
+
+	return config.Write(cfg, configPath)
+}

--- a/internal/commands/add_buildpack_registry.go
+++ b/internal/commands/add_buildpack_registry.go
@@ -13,17 +13,20 @@ import (
 )
 
 func AddBuildpackRegistry(logger logging.Logger, cfg config.Config) *cobra.Command {
-	var setDefault bool
+	var (
+		setDefault   bool
+		registryType string
+	)
 
 	cmd := &cobra.Command{
-		Use:   "add-buildpack-registry <name> <url> <type> (github | git)",
-		Args:  cobra.ExactArgs(3),
+		Use:   "add-buildpack-registry <name> <url>",
+		Args:  cobra.ExactArgs(2),
 		Short: "Adds a new buildpack registry to your pack config file",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			newRegistry := config.Registry{
 				Name: args[0],
 				URL:  args[1],
-				Type: args[2],
+				Type: registryType,
 			}
 
 			err := addRegistry(newRegistry, cfg, setDefault)
@@ -35,9 +38,10 @@ func AddBuildpackRegistry(logger logging.Logger, cfg config.Config) *cobra.Comma
 			return nil
 		}),
 	}
-	cmd.Example = "pack add-buildpack-registry myregistry github https://github.com/buildpacks/mybuildpack"
+	cmd.Example = "pack add-buildpack-registry my-registry https://github.com/buildpacks/my-buildpack"
 	cmd.Flags().BoolVar(&setDefault, "default", false, "Set this buildpack registry as the default")
-	AddHelpFlag(cmd, "add-registry")
+	cmd.Flags().StringVar(&registryType, "type", "github", "Type of buildpack registry [git|github]")
+	AddHelpFlag(cmd, "add-buildpack-registry")
 
 	return cmd
 }

--- a/internal/commands/add_buildpack_registry_test.go
+++ b/internal/commands/add_buildpack_registry_test.go
@@ -1,0 +1,74 @@
+package commands_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/commands"
+	"github.com/buildpacks/pack/internal/config"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestAddBuildpackRegistry(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+
+	spec.Run(t, "Commands", testAddBuildpackRegistryCommand, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func testAddBuildpackRegistryCommand(t *testing.T, when spec.G, it spec.S) {
+	var (
+		command *cobra.Command
+		logger  logging.Logger
+		outBuf  bytes.Buffer
+		cfg     config.Config
+	)
+
+	when("AddBuildpackRegistry", func() {
+		it.Before(func() {
+			logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+			cfg = config.Config{}
+
+			command = commands.AddBuildpackRegistry(logger, cfg)
+		})
+
+		it("fails with missing args", func() {
+			err := command.Execute()
+			h.AssertError(t, err, "accepts 3 arg")
+		})
+
+		it("should validate type", func() {
+			command = commands.AddBuildpackRegistry(logger, cfg)
+			command.SetArgs([]string{"bp", "https://github.com/buildpacks/registry-index/", "bogus"})
+			command.Execute()
+
+			output := outBuf.String()
+			h.AssertContains(t, output, "'bogus' is not a valid type.  Supported types are 'github' or 'git'.")
+		})
+
+		it("should throw error when registry already exists", func() {
+			cfg = config.Config{
+				Registries: []config.Registry{
+					{
+						Name: "bp",
+						Type: "github",
+						URL:  "https://github.com/buildpacks/registry-index/",
+					},
+				},
+			}
+			command = commands.AddBuildpackRegistry(logger, cfg)
+			command.SetArgs([]string{"bp", "https://github.com/buildpacks/registry-index/", "github"})
+			command.Execute()
+
+			output := outBuf.String()
+			h.AssertContains(t, output, "Buildpack registry 'bp' already exists.  First run 'remove-buildpack-registry bp' and try again.")
+		})
+	})
+}

--- a/internal/commands/add_buildpack_registry_test.go
+++ b/internal/commands/add_buildpack_registry_test.go
@@ -2,17 +2,17 @@ package commands_test
 
 import (
 	"bytes"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/heroku/color"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
-	"github.com/spf13/cobra"
 
 	"github.com/buildpacks/pack/internal/commands"
 	"github.com/buildpacks/pack/internal/config"
 	ilogging "github.com/buildpacks/pack/internal/logging"
-	"github.com/buildpacks/pack/logging"
 	h "github.com/buildpacks/pack/testhelpers"
 )
 
@@ -25,50 +25,76 @@ func TestAddBuildpackRegistry(t *testing.T) {
 
 func testAddBuildpackRegistryCommand(t *testing.T, when spec.G, it spec.S) {
 	var (
-		command *cobra.Command
-		logger  logging.Logger
-		outBuf  bytes.Buffer
-		cfg     config.Config
+		outBuf   bytes.Buffer
+		logger   = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+		packHome string
+		assert   = h.NewAssertionManager(t)
 	)
 
 	when("AddBuildpackRegistry", func() {
 		it.Before(func() {
-			logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
-			cfg = config.Config{}
+			tmpDir, err := ioutil.TempDir("", "pack-home-*")
+			assert.Nil(err)
 
-			command = commands.AddBuildpackRegistry(logger, cfg)
+			packHome = tmpDir
+			os.Setenv("PACK_HOME", packHome)
 		})
 
-		it("fails with missing args", func() {
-			err := command.Execute()
-			h.AssertError(t, err, "accepts 3 arg")
+		it.After(func() {
+			_ = os.RemoveAll(packHome)
+			os.Unsetenv("PACK_HOME")
 		})
 
-		it("should validate type", func() {
-			command = commands.AddBuildpackRegistry(logger, cfg)
-			command.SetArgs([]string{"bp", "https://github.com/buildpacks/registry-index/", "bogus"})
-			command.Execute()
+		when("default is true", func() {
+			it("sets newly added registry as the default", func() {
+				command := commands.AddBuildpackRegistry(logger, config.Config{})
+				command.SetArgs([]string{"bp", "https://github.com/buildpacks/registry-index/", "--default"})
+				assert.Succeeds(command.Execute())
 
-			output := outBuf.String()
-			h.AssertContains(t, output, "'bogus' is not a valid type.  Supported types are 'github' or 'git'.")
+				configPath, err := config.DefaultConfigPath()
+				assert.Nil(err)
+
+				cfg, err := config.Read(configPath)
+				assert.Nil(err)
+
+				assert.Equal(cfg.DefaultRegistryName, "bp")
+			})
 		})
 
-		it("should throw error when registry already exists", func() {
-			cfg = config.Config{
-				Registries: []config.Registry{
-					{
-						Name: "bp",
-						Type: "github",
-						URL:  "https://github.com/buildpacks/registry-index/",
+		when("validation", func() {
+			it("fails with missing args", func() {
+				command := commands.AddBuildpackRegistry(logger, config.Config{})
+				command.SetOut(ioutil.Discard)
+				command.SetArgs([]string{})
+				err := command.Execute()
+				assert.ErrorContains(err, "accepts 2 arg")
+			})
+
+			it("should validate type", func() {
+				command := commands.AddBuildpackRegistry(logger, config.Config{})
+				command.SetArgs([]string{"bp", "https://github.com/buildpacks/registry-index/", "--type=bogus"})
+				assert.Error(command.Execute())
+
+				output := outBuf.String()
+				h.AssertContains(t, output, "'bogus' is not a valid type.  Supported types are 'github' or 'git'.")
+			})
+
+			it("should throw error when registry already exists", func() {
+				command := commands.AddBuildpackRegistry(logger, config.Config{
+					Registries: []config.Registry{
+						{
+							Name: "bp",
+							Type: "github",
+							URL:  "https://github.com/buildpacks/registry-index/",
+						},
 					},
-				},
-			}
-			command = commands.AddBuildpackRegistry(logger, cfg)
-			command.SetArgs([]string{"bp", "https://github.com/buildpacks/registry-index/", "github"})
-			command.Execute()
+				})
+				command.SetArgs([]string{"bp", "https://github.com/buildpacks/registry-index/"})
+				assert.Error(command.Execute())
 
-			output := outBuf.String()
-			h.AssertContains(t, output, "Buildpack registry 'bp' already exists.  First run 'remove-buildpack-registry bp' and try again.")
+				output := outBuf.String()
+				h.AssertContains(t, output, "Buildpack registry 'bp' already exists.  First run 'remove-buildpack-registry bp' and try again.")
+			})
 		})
 	})
 }

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -144,6 +144,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Config) {
 	cmd.Flags().StringVarP(&buildFlags.AppPath, "path", "p", "", "Path to app dir or zip-formatted file (defaults to current working directory)")
 	cmd.Flags().StringVarP(&buildFlags.Builder, "builder", "B", cfg.DefaultBuilder, "Builder image")
+	//nolint:staticcheck
 	cmd.Flags().StringVarP(&buildFlags.Registry, "buildpack-registry", "R", cfg.DefaultRegistry, "Buildpack Registry URL")
 	if !cfg.Experimental {
 		cmd.Flags().MarkHidden("buildpack-registry")

--- a/internal/commands/create_builder.go
+++ b/internal/commands/create_builder.go
@@ -70,6 +70,7 @@ func CreateBuilder(logger logging.Logger, cfg config.Config, client PackClient) 
 		}),
 	}
 
+	//nolint:staticcheck
 	cmd.Flags().StringVarP(&flags.Registry, "buildpack-registry", "R", cfg.DefaultRegistry, "Buildpack Registry URL")
 	if !cfg.Experimental {
 		cmd.Flags().MarkHidden("buildpack-registry")

--- a/internal/commands/inspect_buildpack.go
+++ b/internal/commands/inspect_buildpack.go
@@ -69,6 +69,7 @@ func InspectBuildpack(logger logging.Logger, cfg *config.Config, client PackClie
 			buildpackName := args[0]
 			registry := flags.Registry
 			if registry == "" {
+				//nolint:staticcheck
 				registry = cfg.DefaultRegistry
 			}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,8 +11,9 @@ import (
 )
 
 type Config struct {
-	RunImages           []RunImage       `toml:"run-images"`
-	DefaultBuilder      string           `toml:"default-builder-image,omitempty"`
+	RunImages      []RunImage `toml:"run-images"`
+	DefaultBuilder string     `toml:"default-builder-image,omitempty"`
+	// Deprecated: Use DefaultRegistryName instead. See https://github.com/buildpacks/pack/issues/747.
 	DefaultRegistry     string           `toml:"default-registry-url,omitempty"`
 	DefaultRegistryName string           `toml:"default-registry,omitempty"`
 	Experimental        bool             `toml:"experimental,omitempty"`

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -1,0 +1,9 @@
+package slices
+
+func MapString(vs []string, f func(string) string) []string {
+	vsm := make([]string, len(vs))
+	for i, v := range vs {
+		vsm[i] = f(v)
+	}
+	return vsm
+}

--- a/internal/slices/slices_test.go
+++ b/internal/slices/slices_test.go
@@ -1,0 +1,31 @@
+package slices_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+
+	"github.com/buildpacks/pack/internal/slices"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestMapString(t *testing.T) {
+	spec.Run(t, "Slices", func(t *testing.T, when spec.G, it spec.S) {
+		var (
+			assert = h.NewAssertionManager(t)
+		)
+
+		when("#MapString", func() {
+			it("maps each value", func() {
+				input := []string{"hello", "1", "2", "world"}
+				expected := []string{"hello.", "1.", "2.", "world."}
+				fn := func(v string) string {
+					return v + "."
+				}
+
+				output := slices.MapString(input, fn)
+				assert.Equal(output, expected)
+			})
+		})
+	})
+}

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -6,11 +6,14 @@ import (
 	"github.com/heroku/color"
 )
 
-var Noop = func(format string, a ...interface{}) string {
-	return color.WhiteString("") + fmt.Sprintf(format, a...)
+var Symbol = func(value string) string {
+	if color.Enabled() {
+		return Key(value)
+	}
+	return "'" + value + "'"
 }
 
-var Symbol = func(format string, a ...interface{}) string {
+var SymbolF = func(format string, a ...interface{}) string {
 	if color.Enabled() {
 		return Key(format, a...)
 	}
@@ -30,9 +33,6 @@ var Step = func(format string, a ...interface{}) string {
 }
 
 var Prefix = color.CyanString
-
-var TimestampColorCode = color.FgHiBlack
-
 var Waiting = color.HiBlackString
 var Working = color.HiBlueString
 var Complete = color.GreenString

--- a/registry/type.go
+++ b/registry/type.go
@@ -1,0 +1,11 @@
+package registry
+
+const (
+	TypeGit    = "git"
+	TypeGitHub = "github"
+)
+
+var Types = []string{
+	TypeGit,
+	TypeGitHub,
+}

--- a/testhelpers/assertions.go
+++ b/testhelpers/assertions.go
@@ -188,6 +188,7 @@ func (a AssertionManager) NotContainWithMessage(actual, expected, messageFormat 
 	}
 }
 
+// Error checks that the provided value is an error (non-nil)
 func (a AssertionManager) Error(actual error) {
 	a.testObject.Helper()
 


### PR DESCRIPTION
## Summary (WIP)
This is a new command that allows users to add new buildpack registries to their `config.toml` file.   The user also has the option via `--default` flag to set the newly added registry as the new default registry.

## Output
```
➜  pack add-buildpack-registry --help                                          
Adds a new buildpack registry to your pack config file

Usage:
  pack add-buildpack-registry <name> <url> <type> (github | git) [flags]

Examples:
pack add-buildpack-registry myregistry github https://github.com/buildpacks/mybuildpack

Flags:
      --default   Set this buildpack registry as the default
  -h, --help      Help for 'add-registry'

Global Flags:
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output
```


```
➜ pack add-buildpack-registry buildpack https://github.com/buildpacks/registry github
Successfully added buildpack to buildpack registries
```

```
➜ pack add-buildpack-registry buildpack https://github.com/buildpacks/registry github
ERROR: add buildpack registry: Buildpack registry buildpack already exists.  First run remove-buildpack-registry buildpack and try again.
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [X] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
