### PR TITLE
Fix URL link to pack CLI docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ To learn more about the details, check out the [specs repository][specs].
 [getting-started]: https://buildpacks.io/docs/app-journey
 [specs]: https://github.com/buildpacks/spec/
 [platform-spec]: https://github.com/buildpacks/spec/blob/main/platform.md
-[pack-docs]: https://buildpacks.io/docs/reference/pack/pack/
+[pack-docs]: https://buildpacks.io/docs/tools/pack/cli/pack/


### PR DESCRIPTION
## Summary
Pack CLI documentation URL points to the old non-existent location (https://buildpacks.io/docs/reference/pack/pack/) which results in 404.

Valid URL is https://buildpacks.io/docs/tools/pack/cli/pack/

#### Before
![image](https://user-images.githubusercontent.com/7780330/94130591-271f5580-fe5d-11ea-9a45-2f338a59e84d.png)

#### After

![image](https://user-images.githubusercontent.com/7780330/94130859-7d8c9400-fe5d-11ea-8af2-709aaee689b6.png)

