### PR TITLE
Prepend experimental to experimental commands

### DIFF
--- a/internal/commands/add_registry.go
+++ b/internal/commands/add_registry.go
@@ -22,9 +22,12 @@ func AddBuildpackRegistry(logger logging.Logger, cfg config.Config, cfgPath stri
 	)
 
 	cmd := &cobra.Command{
-		Use:   "add-registry <name> <url>",
-		Args:  cobra.ExactArgs(2),
-		Short: "Add buildpack registry to config file",
+		Use:     "add-registry <name> <url>",
+		Args:    cobra.ExactArgs(2),
+		Short:   prependExperimental("Add buildpack registry to your pack config file"),
+		Example: "pack add-registry my-registry https://github.com/buildpacks/my-registry",
+		Long: "A Buildpack Registry is a (still experimental) place to publish, store, and discover buildpacks. " +
+			"Users can add buildpacks registries using add-registry, and publish/yank buildpacks from it, as well as use those buildpacks when building applications.",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			newRegistry := config.Registry{
 				Name: args[0],
@@ -47,7 +50,6 @@ func AddBuildpackRegistry(logger logging.Logger, cfg config.Config, cfgPath stri
 			return nil
 		}),
 	}
-	cmd.Example = "pack add-registry my-registry https://github.com/buildpacks/my-buildpack"
 	cmd.Flags().BoolVar(&setDefault, "default", false, "Set this buildpack registry as the default")
 	cmd.Flags().StringVar(&registryType, "type", "github", "Type of buildpack registry [git|github]")
 	AddHelpFlag(cmd, "add-buildpack-registry")

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -77,6 +77,10 @@ func multiValueHelp(name string) string {
 	return fmt.Sprintf("\nRepeat for each %s in order,\n  or supply once by comma-separated list", name)
 }
 
+func prependExperimental(short string) string {
+	return fmt.Sprintf("(%s) %s", style.Warn("experimental"), short)
+}
+
 func getMirrors(config config.Config) map[string][]string {
 	mirrors := map[string][]string{}
 	for _, ri := range config.RunImages {

--- a/internal/commands/list_registries.go
+++ b/internal/commands/list_registries.go
@@ -15,7 +15,7 @@ func ListBuildpackRegistries(logger logging.Logger, cfg config.Config) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "list-registries",
 		Args:  cobra.NoArgs,
-		Short: "List buildpack registries",
+		Short: prependExperimental("List buildpack registries"),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			for _, registry := range config.GetRegistries(cfg) {
 				isDefaultRegistry := (registry.Name == cfg.DefaultRegistryName) ||

--- a/internal/commands/register_buildpack.go
+++ b/internal/commands/register_buildpack.go
@@ -21,7 +21,7 @@ func RegisterBuildpack(logger logging.Logger, cfg config.Config, client PackClie
 	cmd := &cobra.Command{
 		Use:   "register-buildpack <image>",
 		Args:  cobra.ExactArgs(1),
-		Short: "Register the buildpack to a registry",
+		Short: prependExperimental("Register the buildpack to a registry"),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			registry, err := config.GetRegistry(cfg, flags.BuildpackRegistry)
 			if err != nil {

--- a/internal/commands/remove_registry.go
+++ b/internal/commands/remove_registry.go
@@ -17,7 +17,7 @@ func RemoveRegistry(logger logging.Logger, cfg config.Config, cfgPath string) *c
 	cmd := &cobra.Command{
 		Use:     "remove-registry <name>",
 		Args:    cobra.ExactArgs(1),
-		Short:   "Remove registry",
+		Short:   prependExperimental("Remove registry"),
 		Example: "pack remove-registry myregistry",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			registryName = args[0]

--- a/internal/commands/set_default_registry.go
+++ b/internal/commands/set_default_registry.go
@@ -17,7 +17,7 @@ func SetDefaultRegistry(logger logging.Logger, cfg config.Config, cfgPath string
 	cmd := &cobra.Command{
 		Use:     "set-default-registry <name>",
 		Args:    cobra.ExactArgs(1),
-		Short:   "Set default registry",
+		Short:   prependExperimental("Set default registry"),
 		Example: "pack set-default-registry myregistry",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			registryName = args[0]

--- a/internal/commands/yank_buildpack.go
+++ b/internal/commands/yank_buildpack.go
@@ -24,7 +24,7 @@ func YankBuildpack(logger logging.Logger, cfg config.Config, client PackClient) 
 	cmd := &cobra.Command{
 		Use:   "yank-buildpack <buildpack-id-and-version>",
 		Args:  cobra.ExactArgs(1),
-		Short: "yank the buildpack from the registry",
+		Short: prependExperimental("Yank the buildpack from the registry"),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			buildpackIDVersion := args[0]
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,12 +11,12 @@ import (
 )
 
 type Config struct {
-	RunImages      []RunImage `toml:"run-images"`
-	DefaultBuilder string     `toml:"default-builder-image,omitempty"`
 	// Deprecated: Use DefaultRegistryName instead. See https://github.com/buildpacks/pack/issues/747.
 	DefaultRegistry     string           `toml:"default-registry-url,omitempty"`
 	DefaultRegistryName string           `toml:"default-registry,omitempty"`
+	DefaultBuilder      string           `toml:"default-builder-image,omitempty"`
 	Experimental        bool             `toml:"experimental,omitempty"`
+	RunImages           []RunImage       `toml:"run-images"`
 	TrustedBuilders     []TrustedBuilder `toml:"trusted-builders,omitempty"`
 	Registries          []Registry       `toml:"registries,omitempty"`
 }


### PR DESCRIPTION
* Adds Experimental prior to experimental command help flags
* Add long description for add_buildpacks_registry
* Fix spacing in config.go

(essentially, some small fixes for #847)

Signed-off-by: David Freilich <dfreilich@vmware.com>

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
![image](https://user-images.githubusercontent.com/7035673/94166864-83519c00-fe94-11ea-8e3c-0090ea03be0a.png)

#### After
![image](https://user-images.githubusercontent.com/7035673/94166779-6b7a1800-fe94-11ea-9f0f-8c345ea5e2e1.png)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No