### PR TITLE
Add dependabot integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Set update schedule for gomod
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+
+  # Set update schedule for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"


### PR DESCRIPTION
* Set up for Go and for github-actions

Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This uses [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) to update all of our go-mod and github-actions. (used [this](https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-github-dependabot) as the base)
 
## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
