### PR TITLE
Add option to install pack CLI using scoop on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,10 +204,16 @@ jobs:
 
             On Windows, you can use [Chocolatey](https://chocolatey.org/):
 
-            ```bash
+            ```cmd
             choco install pack
             ```
-
+            
+            or [scoop](https://scoop.sh/):
+            
+            ```cmd
+            scoop install pack
+            ```
+            
             #### Manually
 
             1. Download the `.tgz` or `.zip` file for your platform


### PR DESCRIPTION
## Summary
An additional option to install pack CLI (using scoop) on Windows has been documented on the release page.
Scoop's packages database is refreshed automatically once a day so it will always install the latest version available.

#### Before

> #### Windows
>
>On Windows, you can use [Chocolatey](https://chocolatey.org/):
>
>```bash
>choco install pack
>```

#### After
> #### Windows
>
>On Windows, you can use [Chocolatey](https://chocolatey.org/):
>
>```cmd
>choco install pack
>```
>
>or [scoop](https://scoop.sh/):
>
>```cmd
>scoop install pack
>``` 

## Related
buildpacks/docs#217