### PR TITLE
chore: rename registry commands

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -84,8 +84,8 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	rootCmd.AddCommand(commands.Report(logger, pack.Version))
 
 	if cfg.Experimental {
-		rootCmd.AddCommand(commands.ListBuildpackRegistries(logger, cfg))
-		rootCmd.AddCommand(commands.AddBuildpackRegistry(logger, cfg, cfgPath))
+		rootCmd.AddCommand(commands.ListRegistries(logger, cfg))
+		rootCmd.AddCommand(commands.AddRegistry(logger, cfg, cfgPath))
 		rootCmd.AddCommand(commands.RegisterBuildpack(logger, cfg, &packClient))
 		rootCmd.AddCommand(commands.YankBuildpack(logger, cfg, &packClient))
 	}

--- a/internal/commands/add_registry.go
+++ b/internal/commands/add_registry.go
@@ -15,14 +15,14 @@ import (
 	"github.com/buildpacks/pack/logging"
 )
 
-func AddBuildpackRegistry(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
+func AddRegistry(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
 	var (
 		setDefault   bool
 		registryType string
 	)
 
 	cmd := &cobra.Command{
-		Use:   "add-buildpack-registry <name> <url>",
+		Use:   "add-registry <name> <url>",
 		Args:  cobra.ExactArgs(2),
 		Short: "Adds a new buildpack registry to your pack config file",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
@@ -42,10 +42,10 @@ func AddBuildpackRegistry(logger logging.Logger, cfg config.Config, cfgPath stri
 			return nil
 		}),
 	}
-	cmd.Example = "pack add-buildpack-registry my-registry https://github.com/buildpacks/my-buildpack"
+	cmd.Example = "pack add-registry my-registry https://github.com/buildpacks/my-buildpack"
 	cmd.Flags().BoolVar(&setDefault, "default", false, "Set this buildpack registry as the default")
 	cmd.Flags().StringVar(&registryType, "type", "github", "Type of buildpack registry [git|github]")
-	AddHelpFlag(cmd, "add-buildpack-registry")
+	AddHelpFlag(cmd, "add-registry")
 
 	return cmd
 }

--- a/internal/commands/add_registry_test.go
+++ b/internal/commands/add_registry_test.go
@@ -17,15 +17,15 @@ import (
 	h "github.com/buildpacks/pack/testhelpers"
 )
 
-func TestAddBuildpackRegistry(t *testing.T) {
+func TestAddRegistry(t *testing.T) {
 	color.Disable(true)
 	defer color.Disable(false)
 
-	spec.Run(t, "Commands", testAddBuildpackRegistryCommand, spec.Parallel(), spec.Report(report.Terminal{}))
+	spec.Run(t, "Commands", testAddRegistryCommand, spec.Parallel(), spec.Report(report.Terminal{}))
 }
 
-func testAddBuildpackRegistryCommand(t *testing.T, when spec.G, it spec.S) {
-	when("AddBuildpackRegistry", func() {
+func testAddRegistryCommand(t *testing.T, when spec.G, it spec.S) {
+	when("AddRegistry", func() {
 		var (
 			outBuf     bytes.Buffer
 			logger     = ilogging.NewLogWithWriters(&outBuf, &outBuf)
@@ -48,7 +48,7 @@ func testAddBuildpackRegistryCommand(t *testing.T, when spec.G, it spec.S) {
 
 		when("default is true", func() {
 			it("sets newly added registry as the default", func() {
-				command := commands.AddBuildpackRegistry(logger, config.Config{}, configFile)
+				command := commands.AddRegistry(logger, config.Config{}, configFile)
 				command.SetArgs([]string{"bp", "https://github.com/buildpacks/registry-index/", "--default"})
 				assert.Succeeds(command.Execute())
 
@@ -61,7 +61,7 @@ func testAddBuildpackRegistryCommand(t *testing.T, when spec.G, it spec.S) {
 
 		when("validation", func() {
 			it("fails with missing args", func() {
-				command := commands.AddBuildpackRegistry(logger, config.Config{}, configFile)
+				command := commands.AddRegistry(logger, config.Config{}, configFile)
 				command.SetOut(ioutil.Discard)
 				command.SetArgs([]string{})
 				err := command.Execute()
@@ -69,7 +69,7 @@ func testAddBuildpackRegistryCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("should validate type", func() {
-				command := commands.AddBuildpackRegistry(logger, config.Config{}, configFile)
+				command := commands.AddRegistry(logger, config.Config{}, configFile)
 				command.SetArgs([]string{"bp", "https://github.com/buildpacks/registry-index/", "--type=bogus"})
 				assert.Error(command.Execute())
 
@@ -78,7 +78,7 @@ func testAddBuildpackRegistryCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("should throw error when registry already exists", func() {
-				command := commands.AddBuildpackRegistry(logger, config.Config{
+				command := commands.AddRegistry(logger, config.Config{
 					Registries: []config.Registry{
 						{
 							Name: "bp",

--- a/internal/commands/list_registries.go
+++ b/internal/commands/list_registries.go
@@ -11,9 +11,9 @@ import (
 	"github.com/buildpacks/pack/logging"
 )
 
-func ListBuildpackRegistries(logger logging.Logger, cfg config.Config) *cobra.Command {
+func ListRegistries(logger logging.Logger, cfg config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list-buildpack-registries",
+		Use:   "list-registries",
 		Args:  cobra.NoArgs,
 		Short: "Lists all buildpack registries",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
@@ -21,7 +21,7 @@ func ListBuildpackRegistries(logger logging.Logger, cfg config.Config) *cobra.Co
 				registryFmt := fmtRegistry(registry, registry.Name == cfg.DefaultRegistryName, logger.IsVerbose())
 				logger.Info(registryFmt)
 			}
-			logging.Tip(logger, "Run %s to add additional registries", style.Symbol("pack add-buildpack-registry"))
+			logging.Tip(logger, "Run %s to add additional registries", style.Symbol("pack add-registry"))
 
 			return nil
 		}),

--- a/internal/commands/list_registries_test.go
+++ b/internal/commands/list_registries_test.go
@@ -18,14 +18,14 @@ import (
 	"github.com/buildpacks/pack/logging"
 )
 
-func TestListBuildpacksRegistries(t *testing.T) {
+func TestListRegistries(t *testing.T) {
 	color.Disable(true)
 	defer color.Disable(false)
 
-	spec.Run(t, "Commands", testListBuildpackRegistriesCommand, spec.Parallel(), spec.Report(report.Terminal{}))
+	spec.Run(t, "Commands", testListRegistriesCommand, spec.Parallel(), spec.Report(report.Terminal{}))
 }
 
-func testListBuildpackRegistriesCommand(t *testing.T, when spec.G, it spec.S) {
+func testListRegistriesCommand(t *testing.T, when spec.G, it spec.S) {
 	var (
 		command *cobra.Command
 		logger  logging.Logger
@@ -55,10 +55,10 @@ func testListBuildpackRegistriesCommand(t *testing.T, when spec.G, it spec.S) {
 				},
 			},
 		}
-		command = commands.ListBuildpackRegistries(logger, cfg)
+		command = commands.ListRegistries(logger, cfg)
 	})
 
-	when("#ListBuildpackRegistries", func() {
+	when("#ListRegistries", func() {
 		it("should list all registries", func() {
 			h.AssertNil(t, command.Execute())
 
@@ -69,7 +69,7 @@ func testListBuildpackRegistriesCommand(t *testing.T, when spec.G, it spec.S) {
 
 		it("should list registries in verbose mode", func() {
 			logger := ilogging.NewLogWithWriters(&outBuf, &outBuf, ilogging.WithVerbose())
-			command = commands.ListBuildpackRegistries(logger, cfg)
+			command = commands.ListRegistries(logger, cfg)
 
 			h.AssertNil(t, command.Execute())
 


### PR DESCRIPTION
## Summary
This is a refactor to rename the existing registry config commands to NOT include the word `buildpacks`.

`add-buildpack-registry `-> `add-registry`
`list-buildpack-registry` -> `list-registries`

## Output
```
❯ pack list-registries --help
Lists all buildpack registries

Usage:
  pack list-registries [flags]

Flags:
  -h, --help   help for list-registries

Global Flags:
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output
```

```
❯ pack add-registry --help
Adds a new buildpack registry to your pack config file

Usage:
  pack add-registry <name> <url> [flags]

Examples:
pack add-registry my-registry https://github.com/buildpacks/my-buildpack

Flags:
      --default       Set this buildpack registry as the default
  -h, --help          Help for 'add-registry'
      --type string   Type of buildpack registry [git|github] (default "github")

Global Flags:
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output
```

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
