### PR TITLE
Ensure there is always an official default registry

### DIFF
--- a/internal/commands/add_buildpack_registry.go
+++ b/internal/commands/add_buildpack_registry.go
@@ -32,6 +32,11 @@ func AddBuildpackRegistry(logger logging.Logger, cfg config.Config, cfgPath stri
 				Type: registryType,
 			}
 
+			if newRegistry.Name == config.OfficialRegistryName {
+				return errors.Errorf("%s is a reserved registry name, please provide a different name",
+					style.Symbol(config.OfficialRegistryName))
+			}
+
 			err := addRegistry(newRegistry, setDefault, cfg, cfgPath)
 			if err != nil {
 				return err

--- a/internal/commands/add_buildpack_registry_test.go
+++ b/internal/commands/add_buildpack_registry_test.go
@@ -93,6 +93,15 @@ func testAddBuildpackRegistryCommand(t *testing.T, when spec.G, it spec.S) {
 				output := outBuf.String()
 				h.AssertContains(t, output, "Buildpack registry 'bp' already exists.")
 			})
+
+			it("should throw error when registry name is official", func() {
+				command := commands.AddBuildpackRegistry(logger, config.Config{}, configFile)
+				command.SetArgs([]string{"official", "https://github.com/buildpacks/registry-index/", "--type=github"})
+				assert.Error(command.Execute())
+
+				output := outBuf.String()
+				h.AssertContains(t, output, "'official' is a reserved registry name, please provide a different name")
+			})
 		})
 	})
 }

--- a/internal/commands/list_buildpack_registries.go
+++ b/internal/commands/list_buildpack_registries.go
@@ -17,9 +17,14 @@ func ListBuildpackRegistries(logger logging.Logger, cfg config.Config) *cobra.Co
 		Args:  cobra.NoArgs,
 		Short: "Lists all buildpack registries",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			for _, registry := range cfg.Registries {
-				registryFmt := fmtRegistry(registry, registry.Name == cfg.DefaultRegistryName, logger.IsVerbose())
-				logger.Info(registryFmt)
+			for _, registry := range config.GetRegistries(cfg) {
+				isDefaultRegistry := (registry.Name == cfg.DefaultRegistryName) ||
+					(registry.Name == config.OfficialRegistryName && cfg.DefaultRegistryName == "")
+
+				logger.Info(fmtRegistry(
+					registry,
+					isDefaultRegistry,
+					logger.IsVerbose()))
 			}
 			logging.Tip(logger, "Run %s to add additional registries", style.Symbol("pack add-buildpack-registry"))
 

--- a/internal/commands/list_buildpack_registries_test.go
+++ b/internal/commands/list_buildpack_registries_test.go
@@ -76,11 +76,39 @@ func testListBuildpackRegistriesCommand(t *testing.T, when spec.G, it spec.S) {
 			h.AssertContains(t, outBuf.String(), "public registry")
 			h.AssertContains(t, outBuf.String(), "https://github.com/buildpacks/public-registry")
 
-			h.AssertContains(t, outBuf.String(), "private registry")
+			h.AssertContains(t, outBuf.String(), "* private registry")
 			h.AssertContains(t, outBuf.String(), "https://github.com/buildpacks/private-registry")
 
 			h.AssertContains(t, outBuf.String(), "personal registry")
 			h.AssertContains(t, outBuf.String(), "https://github.com/buildpacks/personal-registry")
+
+			h.AssertContains(t, outBuf.String(), "official")
+			h.AssertContains(t, outBuf.String(), "https://github.com/buildpacks/registry-index")
+		})
+
+		it("should indicate official as the default registry by default", func() {
+			logger := ilogging.NewLogWithWriters(&outBuf, &outBuf)
+			cfg.DefaultRegistryName = ""
+
+			command = commands.ListBuildpackRegistries(logger, cfg)
+
+			h.AssertNil(t, command.Execute())
+
+			h.AssertContains(t, outBuf.String(), "* official")
+			h.AssertContains(t, outBuf.String(), "public registry")
+			h.AssertContains(t, outBuf.String(), "private registry")
+			h.AssertContains(t, outBuf.String(), "personal registry")
+		})
+
+		it("should use official when no registries are defined", func() {
+			logger := ilogging.NewLogWithWriters(&outBuf, &outBuf)
+			cfg.DefaultRegistryName = ""
+
+			command = commands.ListBuildpackRegistries(logger, config.Config{})
+
+			h.AssertNil(t, command.Execute())
+
+			h.AssertContains(t, outBuf.String(), "* official")
 		})
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,16 @@ type TrustedBuilder struct {
 	Name string `toml:"name"`
 }
 
+const OfficialRegistryName = "official"
+
+func DefaultRegistry() Registry {
+	return Registry{
+		OfficialRegistryName,
+		"github",
+		"https://github.com/buildpacks/registry-index",
+	}
+}
+
 func DefaultConfigPath() (string, error) {
 	home, err := PackHome()
 	if err != nil {
@@ -94,22 +104,23 @@ func SetRunImageMirrors(cfg Config, image string, mirrors []string) Config {
 	return cfg
 }
 
+func GetRegistries(cfg Config) []Registry {
+	return append(cfg.Registries, DefaultRegistry())
+}
+
 func GetRegistry(cfg Config, registryName string) (Registry, error) {
-	if registryName == "" {
+	if registryName == "" && cfg.DefaultRegistryName != "" {
 		registryName = cfg.DefaultRegistryName
 	}
+	if registryName == "" && cfg.DefaultRegistryName == "" {
+		registryName = OfficialRegistryName
+	}
 	if registryName != "" {
-		for _, registry := range cfg.Registries {
+		for _, registry := range GetRegistries(cfg) {
 			if registry.Name == registryName {
 				return registry, nil
 			}
 		}
-		return Registry{}, errors.Errorf("registry %s is not defined in your config file", style.Symbol(registryName))
 	}
-
-	return Registry{
-		"official",
-		"github",
-		"https://github.com/buildpacks/registry-index",
-	}, nil
+	return Registry{}, errors.Errorf("registry %s is not defined in your config file", style.Symbol(registryName))
 }


### PR DESCRIPTION
## Summary
Given our limited control of the `.pack/config.toml` file, we should always ensure that a default registry is always being communicated to the user.   If, for some reason, no registries defined, the default registry will be displayed to the customer. 

## Output

#### Before


**When no registries exist**
```
❯ pack list-buildpack-registries -v
Tip: Run pack add-buildpack-registry to add additional registries
```

**When registries already exist**
```
❯ pack list-buildpack-registries -v
* travis     https://github.com/elbandito/buildpack-registry
  joe        https://github.com/jkutner/buildpack-registry
```

#### After
**When no registries exist**
```
❯ pack list-buildpack-registries -v
* official   https://github.com/buildpacks/registry-index
Tip: Run pack add-buildpack-registry to add additional registries
```

**When registries already exist**
```
❯ pack list-buildpack-registries -v
* travis     https://github.com/elbandito/buildpack-registry
  joe        https://github.com/jkutner/buildpack-registry
  official   https://github.com/buildpacks/registry-index
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #842 
