### PR TITLE
Ensure every line from phase output has prefix

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -2,7 +2,6 @@
 package logging
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 
@@ -60,26 +59,6 @@ func IsQuiet(logger Logger) bool {
 	}
 
 	return false
-}
-
-// PrefixWriter will prefix writes
-type PrefixWriter struct {
-	out    io.Writer
-	prefix string
-}
-
-// NewPrefixWriter writes by w will be prefixed
-func NewPrefixWriter(w io.Writer, prefix string) *PrefixWriter {
-	return &PrefixWriter{
-		out:    w,
-		prefix: fmt.Sprintf("[%s] ", style.Prefix(prefix)),
-	}
-}
-
-// Writes bytes to the embedded log function
-func (w *PrefixWriter) Write(buf []byte) (int, error) {
-	_, _ = fmt.Fprint(w.out, w.prefix+string(buf))
-	return len(buf), nil
 }
 
 // Tip logs a tip.

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -2,7 +2,6 @@ package logging_test
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/heroku/color"
@@ -71,16 +70,6 @@ func testLogging(t *testing.T, when spec.G, it spec.S) {
 				logger := logging.New(&w)
 				h.AssertEq(t, logging.IsQuiet(logger), false)
 			})
-		})
-	})
-
-	when("PrefixWriter#Write", func() {
-		it("prepends prefix to string", func() {
-			var w bytes.Buffer
-			prefix := "test prefix"
-			writer := logging.NewPrefixWriter(&w, prefix)
-			_, _ = writer.Write([]byte("test"))
-			h.AssertEq(t, w.String(), fmt.Sprintf("[%s] %s", prefix, "test"))
 		})
 	})
 

--- a/logging/prefix_writer.go
+++ b/logging/prefix_writer.go
@@ -1,0 +1,34 @@
+package logging
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/buildpacks/pack/internal/style"
+)
+
+// PrefixWriter will prefix writes
+type PrefixWriter struct {
+	out    io.Writer
+	prefix string
+}
+
+// NewPrefixWriter writes by w will be prefixed
+func NewPrefixWriter(w io.Writer, prefix string) *PrefixWriter {
+	return &PrefixWriter{
+		out:    w,
+		prefix: fmt.Sprintf("[%s] ", style.Prefix(prefix)),
+	}
+}
+
+// Writes bytes to the embedded log function
+func (w *PrefixWriter) Write(buf []byte) (int, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(buf))
+	for scanner.Scan() {
+		_, _ = fmt.Fprintln(w.out, w.prefix+scanner.Text())
+	}
+
+	return len(buf), nil
+}

--- a/logging/prefix_writer_test.go
+++ b/logging/prefix_writer_test.go
@@ -1,0 +1,45 @@
+package logging_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestPrefixWriter(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "PrefixWriter", testPrefixWriter, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func testPrefixWriter(t *testing.T, when spec.G, it spec.S) {
+	when("#Write", func() {
+		it("prepends prefix to string", func() {
+			var w bytes.Buffer
+			prefix := "test prefix"
+			writer := logging.NewPrefixWriter(&w, prefix)
+			_, _ = writer.Write([]byte("test"))
+			h.AssertEq(t, w.String(), fmt.Sprintf("[%s] %s", prefix, "test\n"))
+		})
+
+		it("prepends prefix to multi-line string", func() {
+			var w bytes.Buffer
+
+			writer := logging.NewPrefixWriter(&w, "prefix")
+			_, _ = writer.Write([]byte("line 1\nline 2\nline 3"))
+			h.AssertEq(t,
+				w.String(),
+				`[prefix] line 1
+[prefix] line 2
+[prefix] line 3
+`)
+		})
+	})
+}


### PR DESCRIPTION

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

See original issue: https://github.com/buildpacks/pack/issues/860

#### After

```
$ ./out/pack build my-ruby-app -p ../samples/apps/ruby-bundler/ -B cnbs/sample-builder:bionic --pull-policy never
===> DETECTING
[detector] samples/ruby-bundler 0.0.1
===> ANALYZING
[analyzer] Restoring metadata for "samples/ruby-bundler:bundler" from app image
[analyzer] Restoring metadata for "samples/ruby-bundler:ruby" from app image
===> RESTORING
[restorer] Restoring data for "samples/ruby-bundler:bundler" from cache
===> BUILDING
[builder] ---> Ruby Buildpack
[builder] ---> Downloading and extracting Ruby 2.5.0
[builder] ---> Installing bundler
[builder] Successfully installed bundler-2.1.4
[builder] 1 gem installed
[builder] ---> Reusing gems
===> EXPORTING
[exporter] Reusing layer 'samples/ruby-bundler:bundler'
[exporter] Reusing layer 'samples/ruby-bundler:ruby'
[exporter] Reusing 1/1 app layer(s)
[exporter] Reusing layer 'launcher'
[exporter] Reusing layer 'config'
[exporter] Reusing layer 'process-types'
[exporter] Adding label 'io.buildpacks.lifecycle.metadata'
[exporter] Adding label 'io.buildpacks.build.metadata'
[exporter] Adding label 'io.buildpacks.project.metadata'
[exporter] Setting default process type 'web'
[exporter] *** Images (52c1942a0071):
[exporter]       my-ruby-app
[exporter] Reusing cache layer 'samples/ruby-bundler:bundler'
Successfully built image my-ruby-app

```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    -  No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #860 
