### PR TITLE
Fix: CI - run action as root (to access daemon)

### DIFF
--- a/.github/workflows/actions/pack/Dockerfile
+++ b/.github/workflows/actions/pack/Dockerfile
@@ -4,4 +4,6 @@ COPY --from=busybox:latest /bin /bin
 COPY --from=docker:stable /usr/local/bin/docker /usr/local/bin/docker
 COPY entrypoint.sh /entrypoint.sh
 
+USER 0:0
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
The action container must run as root so that pack may access the docker daemon.
