### PR TITLE
Update windows base image to use LTSC Server Core 2019

### DIFF
--- a/acceptance/testdata/mock_stack/windows/build/Dockerfile
+++ b/acceptance/testdata/mock_stack/windows/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 # non-zero sets all user-owned directories to BUILTIN\Users
 ENV CNB_USER_ID=1

--- a/acceptance/testdata/mock_stack/windows/run/Dockerfile
+++ b/acceptance/testdata/mock_stack/windows/run/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.14-nanoserver-1809 AS gobuild
+FROM golang:1.14-windowsservercore-1809 AS gobuild
 
 # bake in a simple server util
 WORKDIR /util
 COPY server.go /util/server.go
 RUN go build /util/server.go
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 COPY --from=gobuild /util/server.exe /util/server.exe
 

--- a/internal/build/container_ops_test.go
+++ b/internal/build/container_ops_test.go
@@ -57,7 +57,7 @@ func testContainerOps(t *testing.T, when spec.G, it spec.S) {
 
 		dockerfileContent := `FROM busybox`
 		if osType == "windows" {
-			dockerfileContent = `FROM mcr.microsoft.com/windows/nanoserver:1809`
+			dockerfileContent = `FROM mcr.microsoft.com/windows/servercore:ltsc2019`
 		}
 
 		h.CreateImage(t, ctrClient, imageName, dockerfileContent)
@@ -98,11 +98,11 @@ func testContainerOps(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, errBuf.String(), "")
 			if osType == "windows" {
 				h.AssertContainsMatch(t, strings.ReplaceAll(outBuf.String(), "\r", ""), `
-(.*)    <DIR>          ...                    .
-(.*)    <DIR>          ...                    ..
-(.*)                17 ...                    fake-app-file
-(.*)    <SYMLINK>      ...                    fake-app-symlink \[fake-app-file\]
-(.*)                 0 ...                    file-to-ignore
+(.*)    <DIR>          (.*) .
+(.*)    <DIR>          (.*) ..
+(.*)                17 (.*) fake-app-file
+(.*)    <SYMLINK>      (.*) \[fake-app-file\]
+(.*)                 0 (.*) file-to-ignore
 `)
 			} else {
 				if runtime.GOOS == "windows" {
@@ -182,9 +182,9 @@ lrwxrwxrwx    1 123      456 (.*) fake-app-symlink -> fake-app-file
 			h.AssertEq(t, errBuf.String(), "")
 			if osType == "windows" {
 				h.AssertContainsMatch(t, strings.ReplaceAll(outBuf.String(), "\r", ""), `
-(.*)    <DIR>          ...                    .
-(.*)    <DIR>          ...                    ..
-(.*)                17 ...                    fake-app-file
+(.*)    <DIR>          (.*) .
+(.*)    <DIR>          (.*) ..
+(.*)                17 (.*) fake-app-file
 `)
 			} else {
 				h.AssertContainsMatch(t, outBuf.String(), `
@@ -231,7 +231,7 @@ lrwxrwxrwx    1 123      456 (.*) fake-app-symlink -> fake-app-file
 
 			h.AssertEq(t, errBuf.String(), "")
 			if osType == "windows" {
-				h.AssertContains(t, outBuf.String(), `01/01/1980  12:00 AM                69 ...                    stack.toml`)
+				h.AssertContainsMatch(t, strings.ReplaceAll(outBuf.String(), "\r", ""), `01/01/1980  12:00 AM (.*) 69 (.*) stack.toml`)
 			} else {
 				h.AssertContains(t, outBuf.String(), `-rwxr-xr-x    1 root     root            69 Jan  1  1980 /layers-vol/stack.toml`)
 			}


### PR DESCRIPTION
This change updates the windows base image used by acceptance tests to LTSC Server Core 2019 since `nanoserver` is going out of support.

#### Before
`mcr.microsoft.com/windows/nanoserver:1809` is used in acceptance tests

#### After
`mcr.microsoft.com/windows/nanoserver:1809` is no longer used in acceptance tests.  Instead, `mcr.microsoft.com/windows/servercore:ltsc2019` is used.

## Documentation
No documentation changes are necessary.