### PR TITLE
Add support for docker:// URIs 

### DIFF
--- a/build.go
+++ b/build.go
@@ -643,7 +643,8 @@ func (c *Client) processBuildpacks(ctx context.Context, builderImage imgutil.Ima
 			fetchedBPs = append(append(fetchedBPs, mainBP), dependencyBPs...)
 			order = appendBuildpackToOrder(order, mainBP.Descriptor().Info)
 		case buildpack.PackageLocator:
-			mainBP, depBPs, err := extractPackagedBuildpacks(ctx, bp, c.imageFetcher, publish, pullPolicy)
+			imageName := buildpack.ParsePackageLocator(bp)
+			mainBP, depBPs, err := extractPackagedBuildpacks(ctx, imageName, c.imageFetcher, publish, pullPolicy)
 			if err != nil {
 				return fetchedBPs, order, errors.Wrapf(err, "creating from buildpackage %s", style.Symbol(bp))
 			}

--- a/create_builder.go
+++ b/create_builder.go
@@ -202,6 +202,7 @@ func (c *Client) addBuildpacksToBuilder(ctx context.Context, opts CreateBuilderO
 
 		locator := b.URI
 		if locator == "" && b.ImageName != "" {
+			c.logger.Warn("The 'image' key is deprecated. Use 'uri=\"docker://...\"' instead.")
 			locator = b.ImageName
 		}
 
@@ -214,9 +215,9 @@ func (c *Client) addBuildpacksToBuilder(ctx context.Context, opts CreateBuilderO
 		var depBPs []dist.Buildpack
 		switch locatorType {
 		case buildpack.PackageLocator:
-			c.logger.Debugf("Downloading buildpack from image: %s", style.Symbol(b.ImageName))
-
-			mainBP, depBPs, err = extractPackagedBuildpacks(ctx, b.ImageName, c.imageFetcher, opts.Publish, opts.PullPolicy)
+			imageName := buildpack.ParsePackageLocator(locator)
+			c.logger.Debugf("Downloading buildpack from image: %s", style.Symbol(imageName))
+			mainBP, depBPs, err = extractPackagedBuildpacks(ctx, imageName, c.imageFetcher, opts.Publish, opts.PullPolicy)
 			if err != nil {
 				return err
 			}

--- a/internal/buildpack/locator_type_test.go
+++ b/internal/buildpack/locator_type_test.go
@@ -54,6 +54,21 @@ func testGetLocatorType(t *testing.T, when spec.G, it spec.S) {
 			expectedErr: "'from=builder:some-bp@some-other-version' is not a valid identifier",
 		},
 		{
+			locator:      "urn:cnb:builder:some-bp",
+			builderBPs:   []dist.BuildpackInfo{{ID: "some-bp", Version: "some-version"}},
+			expectedType: buildpack.IDLocator,
+		},
+		{
+			locator:     "urn:cnb:builder:some-bp",
+			builderBPs:  nil,
+			expectedErr: "'urn:cnb:builder:some-bp' is not a valid identifier",
+		},
+		{
+			locator:     "urn:cnb:builder:some-bp@some-other-version",
+			builderBPs:  []dist.BuildpackInfo{{ID: "some-bp", Version: "some-version"}},
+			expectedErr: "'urn:cnb:builder:some-bp@some-other-version' is not a valid identifier",
+		},
+		{
 			locator:      "some-bp",
 			builderBPs:   []dist.BuildpackInfo{{ID: "some-bp", Version: "any-version"}},
 			expectedType: buildpack.IDLocator,
@@ -69,17 +84,41 @@ func testGetLocatorType(t *testing.T, when spec.G, it spec.S) {
 			expectedType: buildpack.URILocator,
 		},
 		{
-			locator:      "cnbs/some-bp",
+			locator:      "docker://cnbs/some-bp",
 			builderBPs:   nil,
 			localPath:    "",
 			expectedType: buildpack.PackageLocator,
 		},
 		{
-			locator:      "cnbs/some-bp@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			locator:      "docker://cnbs/some-bp@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			expectedType: buildpack.PackageLocator,
 		},
 		{
-			locator:      "cnbs/some-bp:some-tag",
+			locator:      "docker://cnbs/some-bp:some-tag",
+			expectedType: buildpack.PackageLocator,
+		},
+		{
+			locator:      "docker://cnbs/some-bp:some-tag@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			expectedType: buildpack.PackageLocator,
+		},
+		{
+			locator:      "docker://registry.com/cnbs/some-bp",
+			expectedType: buildpack.PackageLocator,
+		},
+		{
+			locator:      "docker://registry.com/cnbs/some-bp@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			expectedType: buildpack.PackageLocator,
+		},
+		{
+			locator:      "docker://registry.com/cnbs/some-bp:some-tag",
+			expectedType: buildpack.PackageLocator,
+		},
+		{
+			locator:      "docker://registry.com/cnbs/some-bp:some-tag@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			expectedType: buildpack.PackageLocator,
+		},
+		{
+			locator:      "cnbs/some-bp@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			expectedType: buildpack.PackageLocator,
 		},
 		{

--- a/package_buildpack.go
+++ b/package_buildpack.go
@@ -3,12 +3,12 @@ package pack
 import (
 	"context"
 
-	"github.com/buildpacks/pack/config"
-
 	"github.com/pkg/errors"
 
 	pubbldpkg "github.com/buildpacks/pack/buildpackage"
+	"github.com/buildpacks/pack/config"
 	"github.com/buildpacks/pack/internal/archive"
+	"github.com/buildpacks/pack/internal/buildpack"
 	"github.com/buildpacks/pack/internal/buildpackage"
 	"github.com/buildpacks/pack/internal/dist"
 	"github.com/buildpacks/pack/internal/style"
@@ -71,31 +71,43 @@ func (c *Client) PackageBuildpack(ctx context.Context, opts PackageBuildpackOpti
 		var depBPs []dist.Buildpack
 
 		if dep.URI != "" {
-			blob, err := c.downloader.Download(ctx, dep.URI)
-			if err != nil {
-				return errors.Wrapf(err, "downloading buildpack from %s", style.Symbol(dep.URI))
-			}
-
-			isOCILayout, err := buildpackage.IsOCILayoutBlob(blob)
-			if err != nil {
-				return errors.Wrap(err, "inspecting buildpack blob")
-			}
-
-			if isOCILayout {
-				mainBP, deps, err := buildpackage.BuildpacksFromOCILayoutBlob(blob)
+			if buildpack.HasDockerLocator(dep.URI) {
+				imageName := buildpack.ParsePackageLocator(dep.URI)
+				c.logger.Debugf("Downloading buildpack from image: %s", style.Symbol(imageName))
+				mainBP, deps, err := extractPackagedBuildpacks(ctx, imageName, c.imageFetcher, opts.Publish, opts.PullPolicy)
 				if err != nil {
-					return errors.Wrapf(err, "extracting buildpacks from %s", style.Symbol(dep.URI))
+					return err
 				}
 
 				depBPs = append([]dist.Buildpack{mainBP}, deps...)
 			} else {
-				depBP, err := dist.BuildpackFromRootBlob(blob, archive.DefaultTarWriterFactory())
+				blob, err := c.downloader.Download(ctx, dep.URI)
 				if err != nil {
-					return errors.Wrapf(err, "creating buildpack from %s", style.Symbol(dep.URI))
+					return errors.Wrapf(err, "downloading buildpack from %s", style.Symbol(dep.URI))
 				}
-				depBPs = []dist.Buildpack{depBP}
+
+				isOCILayout, err := buildpackage.IsOCILayoutBlob(blob)
+				if err != nil {
+					return errors.Wrap(err, "inspecting buildpack blob")
+				}
+
+				if isOCILayout {
+					mainBP, deps, err := buildpackage.BuildpacksFromOCILayoutBlob(blob)
+					if err != nil {
+						return errors.Wrapf(err, "extracting buildpacks from %s", style.Symbol(dep.URI))
+					}
+
+					depBPs = append([]dist.Buildpack{mainBP}, deps...)
+				} else {
+					depBP, err := dist.BuildpackFromRootBlob(blob, archive.DefaultTarWriterFactory())
+					if err != nil {
+						return errors.Wrapf(err, "creating buildpack from %s", style.Symbol(dep.URI))
+					}
+					depBPs = []dist.Buildpack{depBP}
+				}
 			}
 		} else if dep.ImageName != "" {
+			c.logger.Warn("The 'image' key is deprecated. Use 'uri=\"docker://...\"' instead.")
 			mainBP, deps, err := extractPackagedBuildpacks(ctx, dep.ImageName, c.imageFetcher, opts.Publish, opts.PullPolicy)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary

Add support for `docker://` URIs and warn about image key. Also adds support for `urn:cnb:builder:` from [RFC-0037](https://github.com/buildpacks/rfcs/blob/main/text/0037-buildpack-uris.md#cnb-builder).

## Output

#### Before

No warning.

#### After

```
$ pack package-buildpack samples/hello-world --config package.toml 
Warning: The 'image' key is deprecated. Use 'uri="docker://..."' instead.
```

## Documentation

- Should this change be documented?
    - [x] Yes, see #TBD
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #766 
