### PR TITLE
Move package `os` to be configured via `package.toml`

### DIFF
--- a/acceptance/buildpacks/manager.go
+++ b/acceptance/buildpacks/manager.go
@@ -53,7 +53,6 @@ func (b BuildpackManager) PrepareBuildpacks(destination string, buildpacks ...Te
 }
 
 type Modifiable interface {
-	SetOS(string)
 	SetPublish()
 	SetBuildpacks([]TestBuildpack)
 }
@@ -68,11 +67,5 @@ func WithRequiredBuildpacks(buildpacks ...TestBuildpack) PackageModifier {
 func WithPublish() PackageModifier {
 	return func(p Modifiable) {
 		p.SetPublish()
-	}
-}
-
-func WithOS(osVal string) PackageModifier {
-	return func(p Modifiable) {
-		p.SetOS(osVal)
 	}
 }

--- a/acceptance/buildpacks/package_file_buildpack.go
+++ b/acceptance/buildpacks/package_file_buildpack.go
@@ -21,11 +21,6 @@ type PackageFile struct {
 	destination          string
 	sourceConfigLocation string
 	buildpacks           []TestBuildpack
-	os                   string
-}
-
-func (p *PackageFile) SetOS(os string) {
-	p.os = os
 }
 
 func (p *PackageFile) SetBuildpacks(buildpacks []TestBuildpack) {
@@ -79,10 +74,6 @@ func (p PackageFile) Prepare(sourceDir, _ string) error {
 		"--no-color",
 		"-c", configLocation,
 		"--format", "file",
-	}
-
-	if p.os != "" {
-		packArgs = append(packArgs, "--os", p.os)
 	}
 
 	output := p.pack.RunSuccessfully("package-buildpack", packArgs...)

--- a/acceptance/buildpacks/package_image_buildpack.go
+++ b/acceptance/buildpacks/package_image_buildpack.go
@@ -23,11 +23,6 @@ type PackageImage struct {
 	sourceConfigLocation string
 	buildpacks           []TestBuildpack
 	publish              bool
-	os                   string
-}
-
-func (p *PackageImage) SetOS(os string) {
-	p.os = os
 }
 
 func (p *PackageImage) SetBuildpacks(buildpacks []TestBuildpack) {
@@ -86,10 +81,6 @@ func (p PackageImage) Prepare(sourceDir, _ string) error {
 
 	if p.publish {
 		packArgs = append(packArgs, "--publish")
-	}
-
-	if p.os != "" {
-		packArgs = append(packArgs, "--os", p.os)
 	}
 
 	output := p.pack.RunSuccessfully("package-buildpack", packArgs...)

--- a/acceptance/testdata/pack_fixtures/package.toml
+++ b/acceptance/testdata/pack_fixtures/package.toml
@@ -1,2 +1,5 @@
 [buildpack]
 uri = "simple-layers-buildpack.tgz"
+
+[platform]
+os = "{{ .OS }}"

--- a/acceptance/testdata/pack_fixtures/package_aggregate.toml
+++ b/acceptance/testdata/pack_fixtures/package_aggregate.toml
@@ -3,3 +3,6 @@ uri = "{{ .BuildpackURI }}"
 
 [[dependencies]]
 image = "{{ .PackageName }}"
+
+[platform]
+os = "{{ .OS }}"

--- a/acceptance/testdata/pack_fixtures/package_for_build_cmd.toml
+++ b/acceptance/testdata/pack_fixtures/package_for_build_cmd.toml
@@ -3,3 +3,6 @@ uri = "simple-layers-parent-buildpack"
 
 [[dependencies]]
 uri = "simple-layers-buildpack"
+
+[platform]
+os = "{{ .OS }}"

--- a/buildpackage/config_reader.go
+++ b/buildpackage/config_reader.go
@@ -16,6 +16,7 @@ import (
 type Config struct {
 	Buildpack    dist.BuildpackURI `toml:"buildpack"`
 	Dependencies []dist.ImageOrURI `toml:"dependencies"`
+	Platform     dist.Platform     `toml:"platform"`
 }
 
 // NewConfigReader returns an instance of ConfigReader. It does not take any parameters.
@@ -49,6 +50,10 @@ func (r *ConfigReader) Read(path string) (Config, error) {
 
 	if packageConfig.Buildpack.URI == "" {
 		return packageConfig, errors.Errorf("missing %s configuration", style.Symbol("buildpack.uri"))
+	}
+
+	if packageConfig.Platform.OS == "" {
+		packageConfig.Platform.OS = "linux"
 	}
 
 	configDir, err := filepath.Abs(filepath.Dir(path))

--- a/buildpackage/config_reader.go
+++ b/buildpackage/config_reader.go
@@ -56,6 +56,11 @@ func (r *ConfigReader) Read(path string) (Config, error) {
 		packageConfig.Platform.OS = "linux"
 	}
 
+	if packageConfig.Platform.OS != "linux" && packageConfig.Platform.OS != "windows" {
+		return packageConfig, errors.Errorf("invalid %s configuration: only [%s, %s] is permitted",
+			style.Symbol("platform.os"), style.Symbol("linux"), style.Symbol("windows"))
+	}
+
 	configDir, err := filepath.Abs(filepath.Dir(path))
 	if err != nil {
 		return packageConfig, err

--- a/buildpackage/config_reader_test.go
+++ b/buildpackage/config_reader_test.go
@@ -46,9 +46,24 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 			config, err := packageConfigReader.Read(configFile)
 			h.AssertNil(t, err)
 
+			h.AssertEq(t, config.Platform.OS, "some-os")
 			h.AssertEq(t, config.Buildpack.URI, "https://example.com/bp/a.tgz")
 			h.AssertEq(t, len(config.Dependencies), 1)
 			h.AssertEq(t, config.Dependencies[0].URI, "https://example.com/bp/b.tgz")
+		})
+
+		it("returns a config with 'linux' as default when platform is missing", func() {
+			configFile := filepath.Join(tmpDir, "package.toml")
+
+			err := ioutil.WriteFile(configFile, []byte(validPackageWithoutPlatformToml), os.ModePerm)
+			h.AssertNil(t, err)
+
+			packageConfigReader := buildpackage.NewConfigReader()
+
+			config, err := packageConfigReader.Read(configFile)
+			h.AssertNil(t, err)
+
+			h.AssertEq(t, config.Platform.OS, "linux")
 		})
 
 		it("returns an error when toml decode fails", func() {
@@ -189,6 +204,17 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 }
 
 const validPackageToml = `
+[buildpack]
+uri = "https://example.com/bp/a.tgz"
+
+[[dependencies]]
+uri = "https://example.com/bp/b.tgz"
+
+[platform]
+os = "some-os"
+`
+
+const validPackageWithoutPlatformToml = `
 [buildpack]
 uri = "https://example.com/bp/a.tgz"
 

--- a/buildpackage/config_reader_test.go
+++ b/buildpackage/config_reader_test.go
@@ -46,7 +46,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 			config, err := packageConfigReader.Read(configFile)
 			h.AssertNil(t, err)
 
-			h.AssertEq(t, config.Platform.OS, "some-os")
+			h.AssertEq(t, config.Platform.OS, "windows")
 			h.AssertEq(t, config.Buildpack.URI, "https://example.com/bp/a.tgz")
 			h.AssertEq(t, len(config.Dependencies), 1)
 			h.AssertEq(t, config.Dependencies[0].URI, "https://example.com/bp/b.tgz")
@@ -112,6 +112,20 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNotNil(t, err)
 			h.AssertError(t, err, "getting absolute path for")
 			h.AssertError(t, err, "https@@@@@@://example.com/bp/a.tgz")
+		})
+
+		it("returns an error when platform os is invalid", func() {
+			configFile := filepath.Join(tmpDir, "package.toml")
+
+			err := ioutil.WriteFile(configFile, []byte(invalidPlatformOSPackageToml), os.ModePerm)
+			h.AssertNil(t, err)
+
+			packageConfigReader := buildpackage.NewConfigReader()
+
+			_, err = packageConfigReader.Read(configFile)
+			h.AssertNotNil(t, err)
+			h.AssertError(t, err, "invalid 'platform.os' configuration")
+			h.AssertError(t, err, "only ['linux', 'windows'] is permitted")
 		})
 
 		it("returns an error when dependency uri is invalid", func() {
@@ -211,7 +225,7 @@ uri = "https://example.com/bp/a.tgz"
 uri = "https://example.com/bp/b.tgz"
 
 [platform]
-os = "some-os"
+os = "windows"
 `
 
 const validPackageWithoutPlatformToml = `
@@ -257,6 +271,14 @@ uri = "noop-buildpack.tgz"
 
 [[dependenceis]] # Notice: this is misspelled
 image = "some/package-dep"
+`
+
+const invalidPlatformOSPackageToml = `
+[buildpack]
+uri = "https://example.com/bp/a.tgz"
+
+[platform]
+os = "some-incorrect-platform"
 `
 
 const unknownBPKeyPackageToml = `

--- a/create_builder_test.go
+++ b/create_builder_test.go
@@ -762,6 +762,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 					Name: cnbFile,
 					Config: pubbldpkg.Config{
+						Platform:  dist.Platform{OS: "linux"},
 						Buildpack: dist.BuildpackURI{URI: buildpackPath},
 					},
 					Format: "file",
@@ -842,6 +843,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: packageImage.Name(),
 						Config: pubbldpkg.Config{
+							Platform:  dist.Platform{OS: "linux"},
 							Buildpack: dist.BuildpackURI{URI: createBuildpack(bpd)},
 						},
 						Publish: true,
@@ -915,6 +917,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: packageImage.Name(),
 						Config: pubbldpkg.Config{
+							Platform:  dist.Platform{OS: "linux"},
 							Buildpack: dist.BuildpackURI{URI: createBuildpack(bpd)},
 						},
 						Publish:    true,

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -19,7 +19,6 @@ import (
 type PackageBuildpackFlags struct {
 	PackageTomlPath string
 	Format          string
-	OS              string
 	Publish         bool
 	Policy          string
 }
@@ -72,7 +71,6 @@ func PackageBuildpack(logger logging.Logger, cfg config.Config, client Buildpack
 			if err := client.PackageBuildpack(cmd.Context(), pack.PackageBuildpackOptions{
 				Name:       name,
 				Format:     flags.Format,
-				OS:         flags.OS,
 				Config:     cfg,
 				Publish:    flags.Publish,
 				PullPolicy: pullPolicy,
@@ -93,10 +91,6 @@ func PackageBuildpack(logger logging.Logger, cfg config.Config, client Buildpack
 
 	cmd.Flags().StringVarP(&flags.Format, "format", "f", "", `Format to save package as ("image" or "file")`)
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, `Publish to registry (applies to "--format=image" only)`)
-	cmd.Flags().StringVar(&flags.OS, "os", "", `Operating system format of the package OCI image: "linux" or "windows" (defaults to "linux", except local images which use the daemon OS)`)
-	if !cfg.Experimental {
-		cmd.Flags().MarkHidden("os")
-	}
 	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
 
 	AddHelpFlag(cmd, "package-buildpack")
@@ -110,10 +104,6 @@ func validatePackageBuildpackFlags(p *PackageBuildpackFlags, cfg config.Config) 
 
 	if p.PackageTomlPath == "" {
 		return errors.Errorf("Please provide a package config path, using --config")
-	}
-
-	if p.OS != "" && !cfg.Experimental {
-		return pack.NewExperimentError("Support for OS flag is currently experimental.")
 	}
 
 	return nil

--- a/internal/commands/package_buildpack_test.go
+++ b/internal/commands/package_buildpack_test.go
@@ -122,34 +122,6 @@ func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 					h.AssertEq(t, receivedOptions.PullPolicy, pubcfg.PullAlways)
 				})
 			})
-
-			when("--os", func() {
-				when("experimental enabled", func() {
-					it("creates package with correct image name and os", func() {
-						fakeBuildpackPackager := &fakes.FakeBuildpackPackager{}
-
-						packageBuildpackCommand := packageBuildpackCommand(
-							withBuildpackPackager(fakeBuildpackPackager),
-							withExperimental(),
-						)
-
-						packageBuildpackCommand.SetArgs(
-							[]string{
-								"some-image-name",
-								"--config", "/path/to/some/file",
-								"--os", "windows",
-							},
-						)
-
-						err := packageBuildpackCommand.Execute()
-						h.AssertNil(t, err)
-
-						receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
-
-						h.AssertEq(t, receivedOptions.OS, "windows")
-					})
-				})
-			})
 		})
 	})
 
@@ -250,28 +222,6 @@ func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 				h.AssertError(t, command.Execute(), "parsing pull policy")
 			})
 		})
-
-		when("--os flag is specified but experimental isn't set in the config", func() {
-			it("errors with a descriptive message", func() {
-				fakeBuildpackPackager := &fakes.FakeBuildpackPackager{}
-
-				packageBuildpackCommand := packageBuildpackCommand(
-					withBuildpackPackager(fakeBuildpackPackager),
-				)
-
-				packageBuildpackCommand.SetArgs(
-					[]string{
-						"some-image-name",
-						"--config", "/path/to/some/file",
-						"--os", "windows",
-					},
-				)
-
-				err := packageBuildpackCommand.Execute()
-				h.AssertNotNil(t, err)
-				h.AssertError(t, err, "Support for OS flag is currently experimental")
-			})
-		})
 	})
 }
 
@@ -335,12 +285,6 @@ func withImageName(name string) packageCommandOption {
 func withPackageConfigPath(path string) packageCommandOption {
 	return func(config *packageCommandConfig) {
 		config.configPath = path
-	}
-}
-
-func withExperimental() packageCommandOption {
-	return func(config *packageCommandConfig) {
-		config.clientConfig.Experimental = true
 	}
 }
 

--- a/internal/dist/dist.go
+++ b/internal/dist/dist.go
@@ -17,6 +17,10 @@ type ImageOrURI struct {
 	ImageRef
 }
 
+type Platform struct {
+	OS string `toml:"os"`
+}
+
 type Order []OrderEntry
 
 type OrderEntry struct {

--- a/package_buildpack_test.go
+++ b/package_buildpack_test.go
@@ -84,6 +84,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 				err := subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 					Name: "Fake-Name",
 					Config: pubbldpkg.Config{
+						Platform:  dist.Platform{OS: "linux"},
 						Buildpack: dist.BuildpackURI{URI: ""},
 					},
 					Publish: true,
@@ -100,6 +101,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 				err := subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 					Name: "Fake-Name",
 					Config: pubbldpkg.Config{
+						Platform:  dist.Platform{OS: "linux"},
 						Buildpack: dist.BuildpackURI{URI: bpURL},
 					},
 					Publish: true,
@@ -117,6 +119,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 				err := subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 					Name: "Fake-Name",
 					Config: pubbldpkg.Config{
+						Platform:  dist.Platform{OS: "linux"},
 						Buildpack: dist.BuildpackURI{URI: bpURL},
 					},
 					Publish: true,
@@ -148,6 +151,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 				err := subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 					Name: "test",
 					Config: pubbldpkg.Config{
+						Platform:     dist.Platform{OS: "linux"},
 						Buildpack:    dist.BuildpackURI{URI: createBuildpack(packageDescriptor)},
 						Dependencies: []dist.ImageOrURI{{BuildpackURI: dist.BuildpackURI{URI: dependencyPath}}},
 					},
@@ -186,6 +190,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 						Format: pack.FormatImage,
 						Name:   fakeImage.Name(),
 						Config: pubbldpkg.Config{
+							Platform: dist.Platform{OS: daemonOS},
 							Buildpack: dist.BuildpackURI{URI: createBuildpack(dist.BuildpackDescriptor{
 								API:    api.MustParse("0.2"),
 								Info:   dist.BuildpackInfo{ID: "bp.basic", Version: "2.3.4"},
@@ -203,7 +208,6 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 
 			it("fails without experimental on Windows daemons", func() {
 				windowsMockDockerClient := testmocks.NewMockCommonAPIClient(mockController)
-				windowsMockDockerClient.EXPECT().Info(context.TODO()).Return(types.Info{OSType: "windows"}, nil).AnyTimes()
 
 				packClientWithoutExperimental, err := pack.NewClient(
 					pack.WithDockerClient(windowsMockDockerClient),
@@ -211,7 +215,13 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 				)
 				h.AssertNil(t, err)
 
-				err = packClientWithoutExperimental.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{})
+				err = packClientWithoutExperimental.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
+					Config: pubbldpkg.Config{
+						Platform: dist.Platform{
+							OS: "windows",
+						},
+					},
+				})
 				h.AssertError(t, err, "Windows buildpackage support is currently experimental.")
 			})
 		})
@@ -228,6 +238,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 					Name: nestedPackage.Name(),
 					Config: pubbldpkg.Config{
+						Platform: dist.Platform{OS: "linux"},
 						Buildpack: dist.BuildpackURI{URI: createBuildpack(dist.BuildpackDescriptor{
 							API:    api.MustParse("0.2"),
 							Info:   dist.BuildpackInfo{ID: "bp.nested", Version: "2.3.4"},
@@ -267,6 +278,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: packageImage.Name(),
 						Config: pubbldpkg.Config{
+							Platform: dist.Platform{OS: "linux"},
 							Buildpack: dist.BuildpackURI{URI: createBuildpack(dist.BuildpackDescriptor{
 								API:  api.MustParse("0.2"),
 								Info: dist.BuildpackInfo{ID: "bp.1", Version: "1.2.3"},
@@ -293,6 +305,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: packageImage.Name(),
 						Config: pubbldpkg.Config{
+							Platform: dist.Platform{OS: "linux"},
 							Buildpack: dist.BuildpackURI{URI: createBuildpack(dist.BuildpackDescriptor{
 								API:  api.MustParse("0.2"),
 								Info: dist.BuildpackInfo{ID: "bp.1", Version: "1.2.3"},
@@ -319,6 +332,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: packageImage.Name(),
 						Config: pubbldpkg.Config{
+							Platform: dist.Platform{OS: "linux"},
 							Buildpack: dist.BuildpackURI{URI: createBuildpack(dist.BuildpackDescriptor{
 								API:  api.MustParse("0.2"),
 								Info: dist.BuildpackInfo{ID: "bp.1", Version: "1.2.3"},
@@ -344,6 +358,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertError(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: "some/package",
 						Config: pubbldpkg.Config{
+							Platform: dist.Platform{OS: "linux"},
 							Buildpack: dist.BuildpackURI{URI: createBuildpack(dist.BuildpackDescriptor{
 								API:    api.MustParse("0.2"),
 								Info:   dist.BuildpackInfo{ID: "bp.1", Version: "1.2.3"},
@@ -368,6 +383,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 				h.AssertError(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 					Name: "some/package",
 					Config: pubbldpkg.Config{
+						Platform: dist.Platform{OS: "linux"},
 						Buildpack: dist.BuildpackURI{URI: createBuildpack(dist.BuildpackDescriptor{
 							API:    api.MustParse("0.2"),
 							Info:   dist.BuildpackInfo{ID: "bp.1", Version: "1.2.3"},
@@ -409,8 +425,8 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, packClientWithExperimental.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Format: pack.FormatFile,
 						Name:   packagePath,
-						OS:     imageOS,
 						Config: pubbldpkg.Config{
+							Platform: dist.Platform{OS: imageOS},
 							Buildpack: dist.BuildpackURI{URI: createBuildpack(dist.BuildpackDescriptor{
 								API:    api.MustParse("0.2"),
 								Info:   dist.BuildpackInfo{ID: "bp.basic", Version: "2.3.4"},
@@ -466,6 +482,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: nestedPackage.Name(),
 						Config: pubbldpkg.Config{
+							Platform:  dist.Platform{OS: "linux"},
 							Buildpack: dist.BuildpackURI{URI: createBuildpack(childDescriptor)},
 						},
 						Publish:    true,
@@ -481,6 +498,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: packagePath,
 						Config: pubbldpkg.Config{
+							Platform:     dist.Platform{OS: "linux"},
 							Buildpack:    dist.BuildpackURI{URI: createBuildpack(packageDescriptor)},
 							Dependencies: []dist.ImageOrURI{{ImageRef: dist.ImageRef{ImageName: nestedPackage.Name()}}},
 						},
@@ -500,6 +518,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: packagePath,
 						Config: pubbldpkg.Config{
+							Platform:     dist.Platform{OS: "linux"},
 							Buildpack:    dist.BuildpackURI{URI: createBuildpack(packageDescriptor)},
 							Dependencies: []dist.ImageOrURI{{BuildpackURI: dist.BuildpackURI{URI: createBuildpack(childDescriptor)}}},
 						},
@@ -521,6 +540,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 						err = subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 							Name: packagePath,
 							Config: pubbldpkg.Config{
+								Platform:     dist.Platform{OS: "linux"},
 								Buildpack:    dist.BuildpackURI{URI: createBuildpack(packageDescriptor)},
 								Dependencies: []dist.ImageOrURI{{BuildpackURI: dist.BuildpackURI{URI: bpURL}}},
 							},
@@ -543,6 +563,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 						err = subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 							Name: packagePath,
 							Config: pubbldpkg.Config{
+								Platform:     dist.Platform{OS: "linux"},
 								Buildpack:    dist.BuildpackURI{URI: createBuildpack(packageDescriptor)},
 								Dependencies: []dist.ImageOrURI{{BuildpackURI: dist.BuildpackURI{URI: bpURL}}},
 							},
@@ -576,6 +597,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: nestedPackage.Name(),
 						Config: pubbldpkg.Config{
+							Platform:  dist.Platform{OS: "linux"},
 							Buildpack: dist.BuildpackURI{URI: createBuildpack(childDescriptor)},
 						},
 						Publish:    true,
@@ -591,6 +613,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: packagePath,
 						Config: pubbldpkg.Config{
+							Platform:  dist.Platform{OS: "linux"},
 							Buildpack: dist.BuildpackURI{URI: createBuildpack(packageDescriptor)},
 							Dependencies: []dist.ImageOrURI{{ImageRef: dist.ImageRef{ImageName: nestedPackage.Name()}},
 								{BuildpackURI: dist.BuildpackURI{URI: createBuildpack(secondChildDescriptor)}}},
@@ -614,6 +637,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: dependencyPackagePath,
 						Config: pubbldpkg.Config{
+							Platform:  dist.Platform{OS: "linux"},
 							Buildpack: dist.BuildpackURI{URI: createBuildpack(childDescriptor)},
 						},
 						PullPolicy: pubcfg.PullAlways,
@@ -629,6 +653,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, subject.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
 						Name: packagePath,
 						Config: pubbldpkg.Config{
+							Platform:     dist.Platform{OS: "linux"},
 							Buildpack:    dist.BuildpackURI{URI: createBuildpack(packageDescriptor)},
 							Dependencies: []dist.ImageOrURI{{BuildpackURI: dist.BuildpackURI{URI: dependencyPackagePath}}},
 						},
@@ -651,6 +676,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 				Name:   "some-buildpack",
 				Format: "invalid-format",
 				Config: pubbldpkg.Config{
+					Platform: dist.Platform{OS: "linux"},
 					Buildpack: dist.BuildpackURI{URI: createBuildpack(dist.BuildpackDescriptor{
 						API:    api.MustParse("0.2"),
 						Info:   dist.BuildpackInfo{ID: "bp.1", Version: "1.2.3"},

--- a/package_buildpack_test.go
+++ b/package_buildpack_test.go
@@ -224,6 +224,27 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 				})
 				h.AssertError(t, err, "Windows buildpackage support is currently experimental.")
 			})
+
+			it("fails for mismatched platform and daemon os", func() {
+				windowsMockDockerClient := testmocks.NewMockCommonAPIClient(mockController)
+				windowsMockDockerClient.EXPECT().Info(context.TODO()).Return(types.Info{OSType: "windows"}, nil).AnyTimes()
+
+				packClientWithoutExperimental, err := pack.NewClient(
+					pack.WithDockerClient(windowsMockDockerClient),
+					pack.WithExperimental(false),
+				)
+				h.AssertNil(t, err)
+
+				err = packClientWithoutExperimental.PackageBuildpack(context.TODO(), pack.PackageBuildpackOptions{
+					Config: pubbldpkg.Config{
+						Platform: dist.Platform{
+							OS: "linux",
+						},
+					},
+				})
+
+				h.AssertError(t, err, "invalid 'platform.os' specified: DOCKER_OS is 'windows'")
+			})
 		})
 
 		when("nested package lives in registry", func() {


### PR DESCRIPTION
## Summary
The following PR is intended as an addendum to https://github.com/buildpacks/pack/pull/840, which enables `pack package-buildpack` for windows. It removes the recently added `--os` parameter in favor a **platform.os** declaration in one's `package.toml` . This new declaration is **optional**: defaulting to linux when omitted, and thus required for specifying windows. The intention is a more consistent (and backward compatible) user experience.

## Output

```bash
$ cat package.toml
[buildpack]
uri = "simple-layers-buildpack.tgz"

[platform]
os = "windows"

$ pack package-buildpack /tmp/package.tgz -f file -c package.toml
Successfully created package /tmp/package.tgz
```

## Documentation

Should this change be documented?

[x] Yes, see https://github.com/buildpacks/docs/pull/242

## Related
- https://github.com/buildpacks/pack/pull/840

cc: @micahyoung @TisVictress @ameyer-pivotal 