### PR TITLE
Use a default package config for a buildpackage 

### DIFF
--- a/buildpackage/config_reader.go
+++ b/buildpackage/config_reader.go
@@ -12,11 +12,24 @@ import (
 	"github.com/buildpacks/pack/internal/style"
 )
 
+const defaultOS = "linux"
+
 // Config encapsulates the possible configuration options for buildpackage creation.
 type Config struct {
 	Buildpack    dist.BuildpackURI `toml:"buildpack"`
 	Dependencies []dist.ImageOrURI `toml:"dependencies"`
 	Platform     dist.Platform     `toml:"platform"`
+}
+
+func DefaultConfig() Config {
+	return Config{
+		Buildpack: dist.BuildpackURI{
+			URI: ".",
+		},
+		Platform: dist.Platform{
+			OS: defaultOS,
+		},
+	}
 }
 
 // NewConfigReader returns an instance of ConfigReader. It does not take any parameters.
@@ -53,7 +66,7 @@ func (r *ConfigReader) Read(path string) (Config, error) {
 	}
 
 	if packageConfig.Platform.OS == "" {
-		packageConfig.Platform.OS = "linux"
+		packageConfig.Platform.OS = defaultOS
 	}
 
 	if packageConfig.Platform.OS != "linux" && packageConfig.Platform.OS != "windows" {

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -11,7 +11,6 @@ import (
 	"github.com/buildpacks/pack"
 	pubbldpkg "github.com/buildpacks/pack/buildpackage"
 	"github.com/buildpacks/pack/internal/config"
-	"github.com/buildpacks/pack/internal/dist"
 	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/logging"
 )
@@ -65,11 +64,7 @@ func PackageBuildpack(logger logging.Logger, cfg config.Config, client Buildpack
 
 			var cfg pubbldpkg.Config
 			if flags.PackageTomlPath == "" {
-				cfg = pubbldpkg.Config{
-					Buildpack: dist.BuildpackURI{
-						URI: ".",
-					},
-				}
+				cfg = pubbldpkg.DefaultConfig()
 			} else {
 				cfg, err = packageConfigReader.Read(flags.PackageTomlPath)
 				if err != nil {

--- a/internal/commands/package_buildpack_test.go
+++ b/internal/commands/package_buildpack_test.go
@@ -187,7 +187,7 @@ func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("no config path is specified", func() {
-			it("errors with a descriptive message", func() {
+			it("creates a default config", func() {
 				config := &packageCommandConfig{
 					logger:              logging.NewLogWithWriters(&bytes.Buffer{}, &bytes.Buffer{}),
 					packageConfigReader: fakes.NewFakePackageConfigReader(),
@@ -200,7 +200,10 @@ func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 				cmd.SetArgs([]string{config.imageName})
 
 				err := cmd.Execute()
-				h.AssertError(t, err, "Please provide a package config path")
+				h.AssertNil(t, err)
+
+				receivedOptions := config.buildpackPackager.CreateCalledWithOptions
+				h.AssertEq(t, receivedOptions.Config.Buildpack.URI, ".")
 			})
 		})
 


### PR DESCRIPTION
## Summary

This change causes pack to create a default configuration when no `package.toml` file is provided to the `package-buildpack` command. The default is the equivalent of:

```toml
[buildpack]
uri = "."
```

This is important for buildpack authors who want to publish to the Buildpack Registry. In order to publish, you must create a buildpackage, but learning about the `package.toml` file in order to share your buildpack is an unnecessary hurdle for a simple buildpack.

## Output

#### Before

```
$ pack package-buildpack my-cnb
ERROR: Please provide a package config path, using --config
```

#### After

If the buildpack is a normal buildpack, it just works:
```
$ pack package-buildpack my-cnb
Successfully created package my-cnb
```

If the buildpack is a meta-buildpack it will create an error:

```
$ pack package-buildpack my-meta-cnb
ERROR: saving image: buildpack jkutner/minecraft@0.1.0 references buildpack heroku/jvm@0.1 which is not present
```

## Documentation

- Should this change be documented?
    - [x] Yes, see #TBD
    - [ ] No
