### PR TITLE
Add Workflow Dispatch trigger to archlinux/homebrew pipelines

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -49,8 +49,8 @@ jobs:
           go-version: '1.14'
       - name: Set up go env
         run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
       - name: Acceptance
         env:

--- a/.github/workflows/delivery-archlinux-git.yml
+++ b/.github/workflows/delivery-archlinux-git.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   pack-cli-git:

--- a/.github/workflows/delivery-archlinux.yml
+++ b/.github/workflows/delivery-archlinux.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   pack-cli:
-    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     env:
       PACKAGE_NAME: pack-cli
     steps:
+      - uses: actions/checkout@v2
       - name: Determine version
         uses: actions/github-script@v3
         id: version
@@ -32,7 +32,6 @@ jobs:
       - name: Set PACK_VERSION
         run: echo "PACK_VERSION=${{ steps.version.outputs.result }}" >> $GITHUB_ENV
         shell: bash
-      - uses: actions/checkout@v2
       - name: Setup working dir
         run: |
           mkdir -p ${{ env.PACKAGE_NAME }}
@@ -75,6 +74,7 @@ jobs:
     env:
       PACKAGE_NAME: pack-cli-bin
     steps:
+      - uses: actions/checkout@v2
       - name: Determine version
         uses: actions/github-script@v3
         id: version
@@ -90,7 +90,6 @@ jobs:
       - name: Set PACK_VERSION
         run: echo "PACK_VERSION=${{ steps.version.outputs.result }}" >> $GITHUB_ENV
         shell: bash
-      - uses: actions/checkout@v2
       - name: Setup working dir
         run: |
           mkdir -p ${{ env.PACKAGE_NAME }}/

--- a/.github/workflows/delivery-archlinux.yml
+++ b/.github/workflows/delivery-archlinux.yml
@@ -30,7 +30,7 @@ jobs:
             }
             return tag.replace(/^v/, '');
       - name: Set PACK_VERSION
-        run: echo "::set-env name=PACK_VERSION::${{ steps.version.outputs.result }}"
+        run: echo "PACK_VERSION=${{ steps.version.outputs.result }}" >> $GITHUB_ENV
         shell: bash
       - uses: actions/checkout@v2
       - name: Setup working dir
@@ -88,7 +88,7 @@ jobs:
             }
             return tag.replace(/^v/, '');
       - name: Set PACK_VERSION
-        run: echo "::set-env name=PACK_VERSION::${{ steps.version.outputs.result }}"
+        run: echo "PACK_VERSION=${{ steps.version.outputs.result }}" >> $GITHUB_ENV
         shell: bash
       - uses: actions/checkout@v2
       - name: Setup working dir

--- a/.github/workflows/delivery-homebrew.yml
+++ b/.github/workflows/delivery-homebrew.yml
@@ -4,6 +4,11 @@ on:
   release:
     types:
       - released
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: The release tag to distribute
+        required: true
 
 jobs:
   update-tap:
@@ -23,7 +28,22 @@ jobs:
         id: assets
         with:
           script: |
-            context.payload.release.assets.forEach(asset => {
+            let payload = context.payload;
+            let tag = (payload.release && payload.release.tag_name) || (payload.inputs && payload.inputs.tag_name);
+            if (!tag) {
+              throw "ERROR: unable to determine tag"
+            }
+            let tag_name = tag.replace(/^v/, '');
+
+            var release = payload.release || await github.repos.listReleases(context.repo)
+                  .then(result => result.data.find(r => r.tag_name === tag_name))
+                  .catch(err => {throw "ERROR: " + err.message});
+
+            if (!release) {
+              throw "no release found with tag: " + tag_name;
+            }
+
+            release.assets.forEach(asset => {
               if (asset.name.endsWith("linux.tgz")) {
                 core.setOutput("linux_name", asset.name);
                 core.setOutput("linux_url", asset.browser_download_url);

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,6 +29,12 @@ The [release manager](#release-manager) will:
 
 For more information, see the [release process RFC][release-process]
 
+## Manual Releasing
+We release pack to a number of systems, including `homebrew`, `docker`, and `archlinux`. All of our delivery pipelines
+have workflow_dispatch triggers, if a maintainer needs to manually trigger them. To activate it, go to the
+[actions page](https://github.com/buildpacks/pack/actions), and select the desired workflow. Run it by providing the pack
+version to release, in the format `v<version>`.
+
 [maintainers]: https://github.com/buildpacks/community/blob/main/TEAMS.md#platform-team
 [release-process]: https://github.com/buildpacks/rfcs/blob/main/text/0039-release-process.md#change-control-board
 [release]: https://github.com/buildpacks/pack/releases


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
This PR adds a [workflow_dispatch](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) trigger to archlinux and homebrew pipelines, to allow for manual triggering. 

I also took out any occurrence of `set-env` or `add-path` GHA commands, both of which were deprecated by Github (see [here](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) for details)
## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #875 