### PR TITLE
Allow single buildpack in multiple groups

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -408,7 +408,7 @@ func processOrder(buildpacks []dist.BuildpackInfo, order dist.Order) (dist.Order
 			}
 
 			if bpRef.Version == "" {
-				if len(matchingBps) > 1 && len(uniqueVersions(matchingBps)) > 1 {
+				if len(uniqueVersions(matchingBps)) > 1 {
 					return dist.Order{}, fmt.Errorf("unable to resolve version: multiple versions of %s - must specify an explicit version", style.Symbol(bpRef.ID))
 				}
 

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -408,7 +408,7 @@ func processOrder(buildpacks []dist.BuildpackInfo, order dist.Order) (dist.Order
 			}
 
 			if bpRef.Version == "" {
-				if len(matchingBps) > 1 {
+				if len(matchingBps) > 1 && len(uniqueVersions(matchingBps)) > 1 {
 					return dist.Order{}, fmt.Errorf("unable to resolve version: multiple versions of %s - must specify an explicit version", style.Symbol(bpRef.ID))
 				}
 
@@ -512,6 +512,19 @@ func userAndGroupIDs(img imgutil.Image) (int, int, error) {
 	}
 
 	return uid, gid, nil
+}
+
+func uniqueVersions(buildpacks []dist.BuildpackInfo) []string {
+	results := []string{}
+	set := map[string]interface{}{}
+	for _, bpInfo := range buildpacks {
+		_, ok := set[bpInfo.Version]
+		if !ok {
+			results = append(results, bpInfo.Version)
+			set[bpInfo.Version] = true
+		}
+	}
+	return results
 }
 
 func (b *Builder) defaultDirsLayer(dest string) (string, error) {

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -45,9 +45,8 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 		bp1v2          dist.Buildpack
 		bp2v1          dist.Buildpack
 		bpOrder        dist.Buildpack
-		//bpOrderNoVersion dist.Buildpack
-		outBuf bytes.Buffer
-		logger logging.Logger
+		outBuf         bytes.Buffer
+		logger         logging.Logger
 	)
 
 	it.Before(func() {
@@ -473,15 +472,22 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 						subject.AddBuildpack(bp1v1)
 					})
 
-					when("order ommits version", func() {
+					when("order omits version", func() {
 						it("should de-duplicate identical buildpacks", func() {
-							subject.SetOrder(dist.Order{{
-								Group: []dist.BuildpackRef{
-									{BuildpackInfo: dist.BuildpackInfo{
+							subject.SetOrder(dist.Order{
+								{Group: []dist.BuildpackRef{{
+									BuildpackInfo: dist.BuildpackInfo{
 										ID:       bp1v1.Descriptor().Info.ID,
 										Homepage: bp1v1.Descriptor().Info.Homepage,
 									}}},
-							}})
+								},
+								{Group: []dist.BuildpackRef{{
+									BuildpackInfo: dist.BuildpackInfo{
+										ID:       bp1v1.Descriptor().Info.ID,
+										Homepage: bp1v1.Descriptor().Info.Homepage,
+									}}},
+								},
+							})
 
 							err := subject.Save(logger, builder.CreatorMetadata{})
 							h.AssertNil(t, err)

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -45,8 +45,9 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 		bp1v2          dist.Buildpack
 		bp2v1          dist.Buildpack
 		bpOrder        dist.Buildpack
-		outBuf         bytes.Buffer
-		logger         logging.Logger
+		//bpOrderNoVersion dist.Buildpack
+		outBuf bytes.Buffer
+		logger logging.Logger
 	)
 
 	it.Before(func() {
@@ -462,6 +463,28 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 							err := subject.Save(logger, builder.CreatorMetadata{})
 
 							h.AssertError(t, err, "buildpack 'buildpack-1-id' with version 'missing-buildpack-version' was not found on the builder")
+						})
+					})
+				})
+
+				when("has repeated buildpacks with the same ID and version", func() {
+					it.Before(func() {
+						subject.AddBuildpack(bp1v1)
+						subject.AddBuildpack(bp1v1)
+					})
+
+					when("order ommits version", func() {
+						it("should de-duplicate identical buildpacks", func() {
+							subject.SetOrder(dist.Order{{
+								Group: []dist.BuildpackRef{
+									{BuildpackInfo: dist.BuildpackInfo{
+										ID:       bp1v1.Descriptor().Info.ID,
+										Homepage: bp1v1.Descriptor().Info.Homepage,
+									}}},
+							}})
+
+							err := subject.Save(logger, builder.CreatorMetadata{})
+							h.AssertNil(t, err)
 						})
 					})
 				})


### PR DESCRIPTION
 add a check for buildpack repetitions with the same id and version

Signed-off-by: dwillist <dthornton@vmware.com>

## Summary
Fix a bug due to not checking if we have repeated buildpack `id` & `version` combinations when validating builtpack configuration. 

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related

Resolves #858 
