### PR TITLE
Fix docker delivery action

### DIFF
--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -37,15 +37,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: v${{ steps.version.outputs.result }}
+      # This has to come after the first checkout, so it isn't clobbered
       - name: Checkout delivery configuration
         uses: actions/checkout@v2
         with:
           path: ./head
-      - name: Check dir
-        run: |
-          ls head
-          ls ./head
-          ls head/.github/workflows/delivery/docker/
       - name: Setup Working Dir
         shell: bash
         run: |

--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -36,15 +36,20 @@ jobs:
       - name: Checkout delivery configuration
         uses: actions/checkout@v2
         with:
-          path: ./head
+          path: head
       - name: Checkout source at tag
         uses: actions/checkout@v2
         with:
           ref: v${{ steps.version.outputs.result }}
+      - name: Check dir
+        run: |
+          ls head
+          ls ./head
+          ls head/.github/workflows/delivery/docker/
       - name: Setup Working Dir
         shell: bash
         run: |
-          cp ./head/.github/workflows/delivery/docker/buildpack.yml buildpack.yml
+          cp head/.github/workflows/delivery/docker/buildpack.yml buildpack.yml
       - name: Fill buildpack.yml
         uses: cschleiden/replace-tokens@v1
         env:

--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -33,14 +33,14 @@ jobs:
             }
 
             return tag.replace(/^v/, '');
-      - name: Checkout delivery configuration
-        uses: actions/checkout@v2
-        with:
-          path: head
       - name: Checkout source at tag
         uses: actions/checkout@v2
         with:
           ref: v${{ steps.version.outputs.result }}
+      - name: Checkout delivery configuration
+        uses: actions/checkout@v2
+        with:
+          path: ./head
       - name: Check dir
         run: |
           ls head


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
This PR fixes an issue in the delivery/docker pipeline, which had caused [this](https://github.com/buildpacks/pack/actions/runs/358040537) failure (and is proven by [this successful run](https://github.com/buildpacks/pack/actions/runs/358096037))

