### PR TITLE
Add version info when building pack-cli ppa

### DIFF
--- a/.github/workflows/delivery/ubuntu/debian/rules
+++ b/.github/workflows/delivery/ubuntu/debian/rules
@@ -10,7 +10,7 @@ override_dh_auto_test:
 
 override_dh_auto_build:
 	mkdir -p /tmp/.cache/go-build
-	GOCACHE=/tmp/.cache/go-build GOFLAGS="-mod=vendor" LDFLAGS="" dh_auto_build -- build
+	GOCACHE=/tmp/.cache/go-build GOFLAGS="-mod=vendor" LDFLAGS="" PACK_VERSION='{{PACK_VERSION}}' dh_auto_build -- build
 	rm -r /tmp/.cache/go-build
 
 


### PR DESCRIPTION
## Summary
adds version field when building `pack-cli` ppa

#### Before
`pack --version` -> `0.0.0`

#### After
`pack --version` -> `(actual version number)`

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #950 