### PR TITLE
Format inspect-builder json output before printing

### DIFF
--- a/internal/builder/writer/json.go
+++ b/internal/builder/writer/json.go
@@ -1,6 +1,7 @@
 package writer
 
 import (
+	"bytes"
 	"encoding/json"
 )
 
@@ -11,7 +12,15 @@ type JSON struct {
 func NewJSON() BuilderWriter {
 	return &JSON{
 		StructuredFormat: StructuredFormat{
-			MarshalFunc: json.Marshal,
+			MarshalFunc: func(i interface{}) ([]byte, error) {
+				buf, err := json.Marshal(i)
+				if err != nil {
+					return []byte{}, err
+				}
+				formattedBuf := bytes.NewBuffer(nil)
+				err = json.Indent(formattedBuf, buf, "", "  ")
+				return formattedBuf.Bytes(), err
+			},
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: dwillist <dthornton@vmware.com>

## Summary
Simple formatting update for `inspect-builder` json output

## Output
Output contents is equivalent json, just with some formatting for human readability. 

Resolves #952 
