### PR TITLE
Add buildpack subcommand

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -297,7 +297,7 @@ func testWithoutSpecificBuilderRequirement(
 
 		it.Before(func() {
 			h.SkipUnless(t,
-				pack.SupportsFeature(invoke.BuildpackSubcommand) || pack.Supports("package-buildpack"),
+				pack.Supports("buildpack package") || pack.Supports("package-buildpack"),
 				"pack does not support 'package-buildpack'",
 			)
 
@@ -346,7 +346,7 @@ func testWithoutSpecificBuilderRequirement(
 				packageTomlPath := generatePackageTomlWithOS(t, assert, pack, tmpDir, simplePackageConfigFixtureName, dockerHostOS())
 
 				var output string
-				if pack.SupportsFeature(invoke.BuildpackSubcommand) {
+				if pack.Supports("buildpack package") {
 					output = pack.RunSuccessfully("buildpack", "package", packageName, "-c", packageTomlPath)
 				} else {
 					output = pack.RunSuccessfully("package-buildpack", packageName, "-c", packageTomlPath)
@@ -412,7 +412,7 @@ func testWithoutSpecificBuilderRequirement(
 					packageName := registryConfig.RepoName("test/package-" + h.RandString(10))
 
 					var output string
-					if pack.SupportsFeature(invoke.BuildpackSubcommand) {
+					if pack.Supports("buildpack package") {
 						output = pack.RunSuccessfully(
 							"buildpack", "package", packageName,
 							"-c", aggregatePackageToml,
@@ -456,7 +456,7 @@ func testWithoutSpecificBuilderRequirement(
 
 					packageName := registryConfig.RepoName("test/package-" + h.RandString(10))
 					defer h.DockerRmi(dockerCli, packageName)
-					if pack.SupportsFeature(invoke.BuildpackSubcommand) {
+					if pack.Supports("buildpack package") {
 						pack.JustRunSuccessfully(
 							"buildpack", "package", packageName,
 							"-c", aggregatePackageToml,
@@ -495,7 +495,7 @@ func testWithoutSpecificBuilderRequirement(
 						err    error
 					)
 
-					if pack.SupportsFeature(invoke.BuildpackSubcommand) {
+					if pack.Supports("buildpack package") {
 						output, err = pack.Run(
 							"buildpack", "package", packageName,
 							"-c", aggregatePackageToml,
@@ -524,7 +524,7 @@ func testWithoutSpecificBuilderRequirement(
 				packageTomlPath := generatePackageTomlWithOS(t, assert, pack, tmpDir, simplePackageConfigFixtureName, dockerHostOS())
 				destinationFile := filepath.Join(tmpDir, "package.cnb")
 				var output string
-				if pack.SupportsFeature(invoke.BuildpackSubcommand) {
+				if pack.Supports("buildpack package") {
 					output = pack.RunSuccessfully(
 						"buildpack", "package", destinationFile,
 						"--format", "file",
@@ -548,7 +548,7 @@ func testWithoutSpecificBuilderRequirement(
 					output string
 					err    error
 				)
-				if pack.SupportsFeature(invoke.BuildpackSubcommand) {
+				if pack.Supports("buildpack package") {
 					output, err = pack.Run(
 						"buildpack", "package", "some-package",
 						"-c", pack.FixtureManager().FixtureLocation("invalid_package.toml"),

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -392,7 +392,7 @@ func testWithoutSpecificBuilderRequirement(
 
 			when("--publish", func() {
 				it("publishes image to registry", func() {
-					h.SkipUnless(t, pack.SupportsFeature(invoke.OSInPackageToml), "os not supported")
+					h.SkipUnless(t, pack.SupportsFeature(invoke.OSInPackageTOML), "os not supported")
 
 					packageTomlPath := generatePackageTomlWithOS(t, assert, pack, tmpDir, simplePackageConfigFixtureName, dockerHostOS())
 					nestedPackageName := registryConfig.RepoName("test/package-" + h.RandString(10))
@@ -1410,7 +1410,7 @@ func testAcceptance(
 
 							it.Before(func() {
 								h.SkipUnless(t,
-									pack.SupportsFeature(invoke.OSInPackageToml),
+									pack.SupportsFeature(invoke.OSInPackageTOML),
 									"--buildpack does not accept buildpackage unless os is supported in the packakge config file",
 								)
 							})
@@ -1461,7 +1461,7 @@ func testAcceptance(
 
 							it.Before(func() {
 								h.SkipUnless(t,
-									pack.SupportsFeature(invoke.OSInPackageToml),
+									pack.SupportsFeature(invoke.OSInPackageTOML),
 									"--buildpack does not accept buildpackage unless os is supported in the package config file",
 								)
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -288,7 +288,7 @@ func testWithoutSpecificBuilderRequirement(
 		})
 	})
 
-	when("package-buildpack", func() {
+	when("buildpack package", func() {
 		var (
 			tmpDir                         string
 			buildpackManager               buildpacks.BuildpackManager
@@ -297,12 +297,12 @@ func testWithoutSpecificBuilderRequirement(
 
 		it.Before(func() {
 			h.SkipUnless(t,
-				pack.Supports("package-buildpack"),
+				pack.SupportsFeature(invoke.BuildpackSubcommand) || pack.Supports("package-buildpack"),
 				"pack does not support 'package-buildpack'",
 			)
 
 			var err error
-			tmpDir, err = ioutil.TempDir("", "package-buildpack-tests")
+			tmpDir, err = ioutil.TempDir("", "buildpack-package-tests")
 			assert.Nil(err)
 
 			buildpackManager = buildpacks.NewBuildpackManager(t, assert)
@@ -345,7 +345,12 @@ func testWithoutSpecificBuilderRequirement(
 				packageName := "test/package-" + h.RandString(10)
 				packageTomlPath := generatePackageTomlWithOS(t, assert, pack, tmpDir, simplePackageConfigFixtureName, dockerHostOS())
 
-				output := pack.RunSuccessfully("package-buildpack", packageName, "-c", packageTomlPath)
+				var output string
+				if pack.SupportsFeature(invoke.BuildpackSubcommand) {
+					output = pack.RunSuccessfully("buildpack", "package", packageName, "-c", packageTomlPath)
+				} else {
+					output = pack.RunSuccessfully("package-buildpack", packageName, "-c", packageTomlPath)
+				}
 				assertions.NewOutputAssertionManager(t, output).ReportsPackageCreation(packageName)
 				defer h.DockerRmi(dockerCli, packageName)
 
@@ -387,7 +392,7 @@ func testWithoutSpecificBuilderRequirement(
 
 			when("--publish", func() {
 				it("publishes image to registry", func() {
-					h.SkipIf(t, !pack.Supports("package-buildpack --os"), "os not supported")
+					h.SkipUnless(t, pack.SupportsFeature(invoke.OSInPackageToml), "os not supported")
 
 					packageTomlPath := generatePackageTomlWithOS(t, assert, pack, tmpDir, simplePackageConfigFixtureName, dockerHostOS())
 					nestedPackageName := registryConfig.RepoName("test/package-" + h.RandString(10))
@@ -405,11 +410,22 @@ func testWithoutSpecificBuilderRequirement(
 
 					aggregatePackageToml := generateAggregatePackageToml("simple-layers-parent-buildpack.tgz", nestedPackageName, dockerHostOS())
 					packageName := registryConfig.RepoName("test/package-" + h.RandString(10))
-					output := pack.RunSuccessfully(
-						"package-buildpack", packageName,
-						"-c", aggregatePackageToml,
-						"--publish",
-					)
+
+					var output string
+					if pack.SupportsFeature(invoke.BuildpackSubcommand) {
+						output = pack.RunSuccessfully(
+							"buildpack", "package", packageName,
+							"-c", aggregatePackageToml,
+							"--publish",
+						)
+					} else {
+						output = pack.RunSuccessfully(
+							"package-buildpack", packageName,
+							"-c", aggregatePackageToml,
+							"--publish",
+						)
+					}
+
 					defer h.DockerRmi(dockerCli, packageName)
 					assertions.NewOutputAssertionManager(t, output).ReportsPackagePublished(packageName)
 
@@ -440,11 +456,17 @@ func testWithoutSpecificBuilderRequirement(
 
 					packageName := registryConfig.RepoName("test/package-" + h.RandString(10))
 					defer h.DockerRmi(dockerCli, packageName)
-					pack.JustRunSuccessfully(
-						"package-buildpack", packageName,
-						"-c", aggregatePackageToml,
-						"--pull-policy", pubcfg.PullNever.String(),
-					)
+					if pack.SupportsFeature(invoke.BuildpackSubcommand) {
+						pack.JustRunSuccessfully(
+							"buildpack", "package", packageName,
+							"-c", aggregatePackageToml,
+							"--pull-policy", pubcfg.PullNever.String())
+					} else {
+						pack.JustRunSuccessfully(
+							"package-buildpack", packageName,
+							"-c", aggregatePackageToml,
+							"--pull-policy", pubcfg.PullNever.String())
+					}
 
 					_, _, err := dockerCli.ImageInspectWithRaw(context.Background(), packageName)
 					assert.Nil(err)
@@ -468,11 +490,25 @@ func testWithoutSpecificBuilderRequirement(
 
 					packageName := registryConfig.RepoName("test/package-" + h.RandString(10))
 					defer h.DockerRmi(dockerCli, packageName)
-					output, err := pack.Run(
-						"package-buildpack", packageName,
-						"-c", aggregatePackageToml,
-						"--pull-policy", pubcfg.PullNever.String(),
+					var (
+						output string
+						err    error
 					)
+
+					if pack.SupportsFeature(invoke.BuildpackSubcommand) {
+						output, err = pack.Run(
+							"buildpack", "package", packageName,
+							"-c", aggregatePackageToml,
+							"--pull-policy", pubcfg.PullNever.String(),
+						)
+					} else {
+						output, err = pack.Run(
+							"package-buildpack", packageName,
+							"-c", aggregatePackageToml,
+							"--pull-policy", pubcfg.PullNever.String(),
+						)
+					}
+
 					assert.NotNil(err)
 					assertions.NewOutputAssertionManager(t, output).ReportsImageNotExistingOnDaemon(nestedPackageName)
 				})
@@ -487,12 +523,20 @@ func testWithoutSpecificBuilderRequirement(
 			it("creates the package", func() {
 				packageTomlPath := generatePackageTomlWithOS(t, assert, pack, tmpDir, simplePackageConfigFixtureName, dockerHostOS())
 				destinationFile := filepath.Join(tmpDir, "package.cnb")
-				output, err := pack.Run(
-					"package-buildpack", destinationFile,
-					"--format", "file",
-					"-c", packageTomlPath,
-				)
-				assert.Nil(err)
+				var output string
+				if pack.SupportsFeature(invoke.BuildpackSubcommand) {
+					output = pack.RunSuccessfully(
+						"buildpack", "package", destinationFile,
+						"--format", "file",
+						"-c", packageTomlPath,
+					)
+				} else {
+					output = pack.RunSuccessfully(
+						"package-buildpack", destinationFile,
+						"--format", "file",
+						"-c", packageTomlPath,
+					)
+				}
 				assertions.NewOutputAssertionManager(t, output).ReportsPackageCreation(destinationFile)
 				h.AssertTarball(t, destinationFile)
 			})
@@ -500,10 +544,22 @@ func testWithoutSpecificBuilderRequirement(
 
 		when("package.toml is invalid", func() {
 			it("displays an error", func() {
-				output, err := pack.Run(
-					"package-buildpack", "some-package",
-					"-c", pack.FixtureManager().FixtureLocation("invalid_package.toml"),
+				var (
+					output string
+					err    error
 				)
+				if pack.SupportsFeature(invoke.BuildpackSubcommand) {
+					output, err = pack.Run(
+						"buildpack", "package", "some-package",
+						"-c", pack.FixtureManager().FixtureLocation("invalid_package.toml"),
+					)
+				} else {
+					output, err = pack.Run(
+						"package-buildpack", "some-package",
+						"-c", pack.FixtureManager().FixtureLocation("invalid_package.toml"),
+					)
+				}
+
 				assert.NotNil(err)
 				assert.Contains(output, "reading config")
 			})
@@ -1354,8 +1410,8 @@ func testAcceptance(
 
 							it.Before(func() {
 								h.SkipUnless(t,
-									pack.Supports("package-buildpack --os"),
-									"--buildpack does not accept buildpackage unless package-buildpack --os is supported",
+									pack.SupportsFeature(invoke.OSInPackageToml),
+									"--buildpack does not accept buildpackage unless os is supported in the packakge config file",
 								)
 							})
 
@@ -1367,11 +1423,12 @@ func testAcceptance(
 							it("adds the buildpacks to the builder and runs them", func() {
 								packageImageName = registryConfig.RepoName("buildpack-" + h.RandString(8))
 
+								packageTomlPath := generatePackageTomlWithOS(t, assert, pack, tmpDir, "package_for_build_cmd.toml", dockerHostOS())
 								packageImage := buildpacks.NewPackageImage(
 									t,
 									pack,
 									packageImageName,
-									pack.FixtureManager().FixtureLocation("package_for_build_cmd.toml"),
+									packageTomlPath,
 									buildpacks.WithRequiredBuildpacks(
 										buildpacks.FolderSimpleLayersParent,
 										buildpacks.FolderSimpleLayers,
@@ -1404,8 +1461,8 @@ func testAcceptance(
 
 							it.Before(func() {
 								h.SkipUnless(t,
-									pack.Supports("package-buildpack --os"),
-									"--buildpack does not accept buildpackage unless package-buildpack --os is supported",
+									pack.SupportsFeature(invoke.OSInPackageToml),
+									"--buildpack does not accept buildpackage unless os is supported in the package config file",
 								)
 
 								var err error
@@ -1423,11 +1480,12 @@ func testAcceptance(
 									fmt.Sprintf("buildpack-%s.cnb", h.RandString(8)),
 								)
 
+								packageTomlPath := generatePackageTomlWithOS(t, assert, pack, tmpDir, "package_for_build_cmd.toml", dockerHostOS())
 								packageFile := buildpacks.NewPackageFile(
 									t,
 									pack,
 									packageFileLocation,
-									pack.FixtureManager().FixtureLocation("package_for_build_cmd.toml"),
+									packageTomlPath,
 									buildpacks.WithRequiredBuildpacks(
 										buildpacks.FolderSimpleLayersParent,
 										buildpacks.FolderSimpleLayers,
@@ -1866,7 +1924,7 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 
 						h.SkipUnless(t,
 							pack.Supports("inspect-builder --depth"),
-							"pack does not support 'package-buildpack'",
+							"pack does not support 'inspect-builder --depth'",
 						)
 						// create a task, handled by a 'task manager' which executes our pack commands during tests.
 						// looks like this is used to de-dup tasks

--- a/acceptance/buildpacks/package_file_buildpack.go
+++ b/acceptance/buildpacks/package_file_buildpack.go
@@ -76,7 +76,12 @@ func (p PackageFile) Prepare(sourceDir, _ string) error {
 		"--format", "file",
 	}
 
-	output := p.pack.RunSuccessfully("package-buildpack", packArgs...)
+	var output string
+	if p.pack.SupportsFeature(invoke.BuildpackSubcommand) {
+		output = p.pack.RunSuccessfully("buildpack", append([]string{"package"}, packArgs...)...)
+	} else {
+		output = p.pack.RunSuccessfully("package-buildpack", packArgs...)
+	}
 
 	if !strings.Contains(output, fmt.Sprintf("Successfully created package '%s'", p.destination)) {
 		return errors.New("failed to create package")

--- a/acceptance/buildpacks/package_file_buildpack.go
+++ b/acceptance/buildpacks/package_file_buildpack.go
@@ -77,7 +77,7 @@ func (p PackageFile) Prepare(sourceDir, _ string) error {
 	}
 
 	var output string
-	if p.pack.SupportsFeature(invoke.BuildpackSubcommand) {
+	if p.pack.Supports("buildpack package") {
 		output = p.pack.RunSuccessfully("buildpack", append([]string{"package"}, packArgs...)...)
 	} else {
 		output = p.pack.RunSuccessfully("package-buildpack", packArgs...)

--- a/acceptance/buildpacks/package_image_buildpack.go
+++ b/acceptance/buildpacks/package_image_buildpack.go
@@ -83,7 +83,12 @@ func (p PackageImage) Prepare(sourceDir, _ string) error {
 		packArgs = append(packArgs, "--publish")
 	}
 
-	output := p.pack.RunSuccessfully("package-buildpack", packArgs...)
+	var output string
+	if p.pack.SupportsFeature(invoke.BuildpackSubcommand) {
+		output = p.pack.RunSuccessfully("buildpack", append([]string{"package"}, packArgs...)...)
+	} else {
+		output = p.pack.RunSuccessfully("package-buildpack", packArgs...)
+	}
 
 	assertOutput := assertions.NewOutputAssertionManager(p.testObject, output)
 	if p.publish {

--- a/acceptance/buildpacks/package_image_buildpack.go
+++ b/acceptance/buildpacks/package_image_buildpack.go
@@ -84,7 +84,7 @@ func (p PackageImage) Prepare(sourceDir, _ string) error {
 	}
 
 	var output string
-	if p.pack.SupportsFeature(invoke.BuildpackSubcommand) {
+	if p.pack.Supports("buildpack package") {
 		output = p.pack.RunSuccessfully("buildpack", append([]string{"package"}, packArgs...)...)
 	} else {
 		output = p.pack.RunSuccessfully("package-buildpack", packArgs...)

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -215,6 +215,8 @@ const (
 	NoColorInBuildpacks
 	QuietMode
 	InspectBuilderOutputFormat
+	OSInPackageToml
+	BuildpackSubcommand
 )
 
 var featureTests = map[Feature]func(i *PackInvoker) bool{
@@ -238,6 +240,12 @@ var featureTests = map[Feature]func(i *PackInvoker) bool{
 	},
 	InspectBuilderOutputFormat: func(i *PackInvoker) bool {
 		return i.laterThan("0.14.2")
+	},
+	OSInPackageToml: func(i *PackInvoker) bool {
+		return i.laterThan("0.15.0")
+	},
+	BuildpackSubcommand: func(i *PackInvoker) bool {
+		return i.atLeast("0.16.0")
 	},
 }
 

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -216,7 +216,6 @@ const (
 	QuietMode
 	InspectBuilderOutputFormat
 	OSInPackageToml
-	BuildpackSubcommand
 )
 
 var featureTests = map[Feature]func(i *PackInvoker) bool{
@@ -243,9 +242,6 @@ var featureTests = map[Feature]func(i *PackInvoker) bool{
 	},
 	OSInPackageToml: func(i *PackInvoker) bool {
 		return i.laterThan("0.15.0")
-	},
-	BuildpackSubcommand: func(i *PackInvoker) bool {
-		return i.atLeast("0.16.0")
 	},
 }
 

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -215,7 +215,7 @@ const (
 	NoColorInBuildpacks
 	QuietMode
 	InspectBuilderOutputFormat
-	OSInPackageToml
+	OSInPackageTOML
 )
 
 var featureTests = map[Feature]func(i *PackInvoker) bool{
@@ -240,7 +240,7 @@ var featureTests = map[Feature]func(i *PackInvoker) bool{
 	InspectBuilderOutputFormat: func(i *PackInvoker) bool {
 		return i.laterThan("0.14.2")
 	},
-	OSInPackageToml: func(i *PackInvoker) bool {
+	OSInPackageTOML: func(i *PackInvoker) bool {
 		return i.laterThan("0.15.0")
 	},
 }

--- a/buildpackage/config_reader.go
+++ b/buildpackage/config_reader.go
@@ -70,8 +70,8 @@ func (r *ConfigReader) Read(path string) (Config, error) {
 	}
 
 	if packageConfig.Platform.OS != "linux" && packageConfig.Platform.OS != "windows" {
-		return packageConfig, errors.Errorf("invalid %s configuration: only [%s, %s] is permitted",
-			style.Symbol("platform.os"), style.Symbol("linux"), style.Symbol("windows"))
+		return packageConfig, errors.Errorf("invalid %s configuration: only [%s, %s] is permitted, found %s",
+			style.Symbol("platform.os"), style.Symbol("linux"), style.Symbol("windows"), style.Symbol(packageConfig.Platform.OS))
 	}
 
 	configDir, err := filepath.Abs(filepath.Dir(path))

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -85,6 +85,7 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	//nolint:staticcheck
 	rootCmd.AddCommand(commands.CreateBuilder(logger, cfg, &packClient))
 
+	//nolint:staticcheck
 	rootCmd.AddCommand(commands.PackageBuildpack(logger, cfg, &packClient, buildpackage.NewConfigReader()))
 
 	//nolint:staticcheck
@@ -96,9 +97,11 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	if cfg.Experimental {
 		rootCmd.AddCommand(commands.AddBuildpackRegistry(logger, cfg, cfgPath))
 		rootCmd.AddCommand(commands.ListBuildpackRegistries(logger, cfg))
+		//nolint:staticcheck
 		rootCmd.AddCommand(commands.RegisterBuildpack(logger, cfg, &packClient))
 		rootCmd.AddCommand(commands.SetDefaultRegistry(logger, cfg, cfgPath))
 		rootCmd.AddCommand(commands.RemoveRegistry(logger, cfg, cfgPath))
+		//nolint:staticcheck
 		rootCmd.AddCommand(commands.YankBuildpack(logger, cfg, &packClient))
 		rootCmd.AddCommand(commands.PullBuildpack(logger, cfg, &packClient))
 	}
@@ -113,6 +116,8 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	rootCmd.AddCommand(commands.NewConfigCommand(logger, cfg, cfgPath))
 	rootCmd.AddCommand(commands.NewStackCommand(logger))
 	rootCmd.AddCommand(commands.NewBuilderCommand(logger, cfg, &packClient))
+
+	rootCmd.AddCommand(commands.NewBuildpackCommand(logger, cfg, &packClient, buildpackage.NewConfigReader()))
 
 	rootCmd.Version = pack.Version
 	rootCmd.SetVersionTemplate(`{{.Version}}{{"\n"}}`)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -103,7 +103,6 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 		rootCmd.AddCommand(commands.RemoveRegistry(logger, cfg, cfgPath))
 		//nolint:staticcheck
 		rootCmd.AddCommand(commands.YankBuildpack(logger, cfg, &packClient))
-		rootCmd.AddCommand(commands.PullBuildpack(logger, cfg, &packClient))
 	}
 
 	packHome, err := config.PackHome()

--- a/internal/commands/buildpack.go
+++ b/internal/commands/buildpack.go
@@ -8,14 +8,20 @@ import (
 )
 
 func NewBuildpackCommand(logger logging.Logger, cfg config.Config, client PackClient, packageConfigReader PackageConfigReader) *cobra.Command {
-	cmd := cobra.Command{
-		Use:   "buildpack",
-		Short: "Interact with buildpacks",
-		RunE:  nil,
+	cmd := &cobra.Command{
+		Use:     "buildpack",
+		Aliases: []string{"buildpacks"},
+		Short:   "Interact with buildpacks",
+		RunE:    nil,
 	}
 
 	cmd.AddCommand(BuildpackPackage(logger, client, packageConfigReader))
-	cmd.AddCommand(BuildpackRegister(logger, cfg, client))
-	cmd.AddCommand(BuildpackYank(logger, cfg, client))
-	return &cmd
+	if cfg.Experimental {
+		cmd.AddCommand(BuildpackPull(logger, cfg, client))
+		cmd.AddCommand(BuildpackRegister(logger, cfg, client))
+		cmd.AddCommand(BuildpackYank(logger, cfg, client))
+	}
+
+	AddHelpFlag(cmd, "buildpack")
+	return cmd
 }

--- a/internal/commands/buildpack.go
+++ b/internal/commands/buildpack.go
@@ -1,0 +1,21 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/logging"
+)
+
+func NewBuildpackCommand(logger logging.Logger, cfg config.Config, client PackClient, packageConfigReader PackageConfigReader) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "buildpack",
+		Short: "Interact with buildpacks",
+		RunE:  nil,
+	}
+
+	cmd.AddCommand(BuildpackPackage(logger, client, packageConfigReader))
+	cmd.AddCommand(BuildpackRegister(logger, cfg, client))
+	cmd.AddCommand(BuildpackYank(logger, cfg, client))
+	return &cmd
+}

--- a/internal/commands/buildpack_package.go
+++ b/internal/commands/buildpack_package.go
@@ -37,6 +37,7 @@ func BuildpackPackage(logger logging.Logger, client BuildpackPackager, packageCo
 	cmd := &cobra.Command{
 		Use:     "package <name> --config <config-path>",
 		Short:   "Package buildpack in OCI format.",
+		Args:    cobra.ExactValidArgs(1),
 		Example: "pack buildpack package my-buildpack --config ./package.toml",
 		Long: "buildpack package allows users to package (a) buildpack(s) into OCI format, which can then to be hosted in " +
 			"image repositories. You can also package a number of buildpacks together, to enable easier distribution of " +

--- a/internal/commands/buildpack_package.go
+++ b/internal/commands/buildpack_package.go
@@ -1,37 +1,49 @@
 package commands
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	pubcfg "github.com/buildpacks/pack/config"
-
 	"github.com/buildpacks/pack"
 	pubbldpkg "github.com/buildpacks/pack/buildpackage"
-	"github.com/buildpacks/pack/internal/config"
+	pubcfg "github.com/buildpacks/pack/config"
 	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/logging"
 )
 
-// Deprecated: use BuildpackPackage instead
-// PackageBuildpack packages (a) buildpack(s) into OCI format, based on a package config
-func PackageBuildpack(logger logging.Logger, cfg config.Config, client BuildpackPackager, packageConfigReader PackageConfigReader) *cobra.Command {
-	var flags BuildpackPackageFlags
+// BuildpackPackageFlags define flags provided to the BuildpackPackage command
+type BuildpackPackageFlags struct {
+	PackageTomlPath string
+	Format          string
+	Publish         bool
+	Policy          string
+}
 
+// BuildpackPackager packages buildpacks
+type BuildpackPackager interface {
+	PackageBuildpack(ctx context.Context, options pack.PackageBuildpackOptions) error
+}
+
+// PackageConfigReader reads BuildpackPackage configs
+type PackageConfigReader interface {
+	Read(path string) (pubbldpkg.Config, error)
+}
+
+// BuildpackPackage packages (a) buildpack(s) into OCI format, based on a package config
+func BuildpackPackage(logger logging.Logger, client BuildpackPackager, packageConfigReader PackageConfigReader) *cobra.Command {
+	var flags BuildpackPackageFlags
 	cmd := &cobra.Command{
-		Use:     `package-buildpack <name> --config <package-config-path>`,
-		Hidden:  true,
-		Args:    cobra.ExactValidArgs(1),
+		Use:     "package <name> --config <config-path>",
 		Short:   "Package buildpack in OCI format.",
-		Example: "pack package-buildpack my-buildpack --config ./package.toml",
-		Long: "package-buildpack allows users to package (a) buildpack(s) into OCI format, which can then to be hosted in " +
+		Example: "pack buildpack package my-buildpack --config ./package.toml",
+		Long: "buildpack package allows users to package (a) buildpack(s) into OCI format, which can then to be hosted in " +
 			"image repositories. You can also package a number of buildpacks together, to enable easier distribution of " +
 			"a set of buildpacks. Packaged buildpacks can be used as inputs to `pack build` (using the `--buildpack` flag), " +
-			"and they can be included in the configs used in `pack create-builder` and `pack package-buildpack`. For more " +
+			"and they can be included in the configs used in `pack builder create` and `pack buildpack package`. For more " +
 			"on how to package a buildpack, see: https://buildpacks.io/docs/buildpack-author-guide/package-a-buildpack/.",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			logger.Warn("Command 'pack package-buildpack' has been deprecated, please use 'pack buildpack package' instead")
-
 			if err := validateBuildpackPackageFlags(&flags); err != nil {
 				return err
 			}
@@ -72,12 +84,20 @@ func PackageBuildpack(logger logging.Logger, cfg config.Config, client Buildpack
 			return nil
 		}),
 	}
-	cmd.Flags().StringVarP(&flags.PackageTomlPath, "config", "c", "", "Path to package TOML config (required)")
 
+	cmd.Flags().StringVarP(&flags.PackageTomlPath, "config", "c", "", "Path to package TOML config (required)")
 	cmd.Flags().StringVarP(&flags.Format, "format", "f", "", `Format to save package as ("image" or "file")`)
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, `Publish to registry (applies to "--format=image" only)`)
 	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
 
-	AddHelpFlag(cmd, "package-buildpack")
+	AddHelpFlag(cmd, "package")
 	return cmd
+}
+
+func validateBuildpackPackageFlags(p *BuildpackPackageFlags) error {
+	if p.Publish && p.Policy == pubcfg.PullNever.String() {
+		return errors.Errorf("--publish and --pull-policy never cannot be used together. The --publish flag requires the use of remote images.")
+	}
+
+	return nil
 }

--- a/internal/commands/buildpack_package_test.go
+++ b/internal/commands/buildpack_package_test.go
@@ -1,0 +1,253 @@
+package commands_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/pkg/errors"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	pubbldpkg "github.com/buildpacks/pack/buildpackage"
+	pubcfg "github.com/buildpacks/pack/config"
+	"github.com/buildpacks/pack/internal/commands"
+	"github.com/buildpacks/pack/internal/commands/fakes"
+	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/internal/dist"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestPackageCommand(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "PackageCommand", testPackageCommand, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func testPackageCommand(t *testing.T, when spec.G, it spec.S) {
+	var (
+		logger *ilogging.LogWithWriters
+		outBuf bytes.Buffer
+	)
+
+	it.Before(func() {
+		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+	})
+
+	when("Package#Execute", func() {
+		var fakeBuildpackPackager *fakes.FakeBuildpackPackager
+
+		it.Before(func() {
+			fakeBuildpackPackager = &fakes.FakeBuildpackPackager{}
+		})
+
+		when("valid package config", func() {
+			it("reads package config from the configured path", func() {
+				fakePackageConfigReader := fakes.NewFakePackageConfigReader()
+				expectedPackageConfigPath := "/path/to/some/file"
+
+				cmd := packageCommand(
+					withPackageConfigReader(fakePackageConfigReader),
+					withPackageConfigPath(expectedPackageConfigPath),
+				)
+				err := cmd.Execute()
+				h.AssertNil(t, err)
+
+				h.AssertEq(t, fakePackageConfigReader.ReadCalledWithArg, expectedPackageConfigPath)
+			})
+
+			it("creates package with correct image name", func() {
+				cmd := packageCommand(
+					withImageName("my-specific-image"),
+					withBuildpackPackager(fakeBuildpackPackager),
+				)
+				err := cmd.Execute()
+				h.AssertNil(t, err)
+
+				receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+				h.AssertEq(t, receivedOptions.Name, "my-specific-image")
+			})
+
+			it("creates package with config returned by the reader", func() {
+				myConfig := pubbldpkg.Config{
+					Buildpack: dist.BuildpackURI{URI: "test"},
+				}
+
+				cmd := packageCommand(
+					withBuildpackPackager(fakeBuildpackPackager),
+					withPackageConfigReader(fakes.NewFakePackageConfigReader(whereReadReturns(myConfig, nil))),
+				)
+				err := cmd.Execute()
+				h.AssertNil(t, err)
+
+				receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+				h.AssertEq(t, receivedOptions.Config, myConfig)
+			})
+
+			when("pull-policy", func() {
+				var pullPolicyArgs = []string{
+					"some-image-name",
+					"--config", "/path/to/some/file",
+					"--pull-policy",
+				}
+
+				it("pull-policy=never sets policy", func() {
+					cmd := packageCommand(withBuildpackPackager(fakeBuildpackPackager))
+					cmd.SetArgs(append(pullPolicyArgs, "never"))
+					h.AssertNil(t, cmd.Execute())
+
+					receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+					h.AssertEq(t, receivedOptions.PullPolicy, pubcfg.PullNever)
+				})
+
+				it("pull-policy=always sets policy", func() {
+					cmd := packageCommand(withBuildpackPackager(fakeBuildpackPackager))
+					cmd.SetArgs(append(pullPolicyArgs, "always"))
+					h.AssertNil(t, cmd.Execute())
+
+					receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+					h.AssertEq(t, receivedOptions.PullPolicy, pubcfg.PullAlways)
+				})
+			})
+		})
+
+		when("no config path is specified", func() {
+			it("creates a default config", func() {
+				cmd := packageCommand(withBuildpackPackager(fakeBuildpackPackager))
+				cmd.SetArgs([]string{"some-name"})
+				h.AssertNil(t, cmd.Execute())
+
+				receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+				h.AssertEq(t, receivedOptions.Config.Buildpack.URI, ".")
+			})
+		})
+	})
+
+	when("invalid flags", func() {
+		when("both --publish and --pull-policy never flags are specified", func() {
+			it("errors with a descriptive message", func() {
+				cmd := packageCommand()
+				cmd.SetArgs([]string{
+					"some-image-name", "--config", "/path/to/some/file",
+					"--publish",
+					"--pull-policy", "never",
+				})
+
+				err := cmd.Execute()
+				h.AssertNotNil(t, err)
+				h.AssertError(t, err, "--publish and --pull-policy never cannot be used together. The --publish flag requires the use of remote images.")
+			})
+		})
+
+		it("logs an error and exits when package toml is invalid", func() {
+			expectedErr := errors.New("it went wrong")
+
+			cmd := packageCommand(
+				withLogger(logger),
+				withPackageConfigReader(
+					fakes.NewFakePackageConfigReader(whereReadReturns(pubbldpkg.Config{}, expectedErr)),
+				),
+			)
+
+			err := cmd.Execute()
+			h.AssertNotNil(t, err)
+
+			h.AssertContains(t, outBuf.String(), fmt.Sprintf("ERROR: reading config: %s", expectedErr))
+		})
+
+		when("package-config is specified", func() {
+			it("errors with a descriptive message", func() {
+				cmd := packageCommand()
+				cmd.SetArgs([]string{"some-name", "--package-config", "some-path"})
+
+				err := cmd.Execute()
+				h.AssertError(t, err, "unknown flag: --package-config")
+			})
+		})
+
+		when("--pull-policy unknown-policy", func() {
+			it("fails to run", func() {
+				cmd := packageCommand()
+				cmd.SetArgs([]string{
+					"some-image-name",
+					"--config", "/path/to/some/file",
+					"--pull-policy",
+					"unknown-policy",
+				})
+
+				h.AssertError(t, cmd.Execute(), "parsing pull policy")
+			})
+		})
+	})
+}
+
+type packageCommandConfig struct {
+	logger              *ilogging.LogWithWriters
+	packageConfigReader *fakes.FakePackageConfigReader
+	buildpackPackager   *fakes.FakeBuildpackPackager
+	clientConfig        config.Config
+	imageName           string
+	configPath          string
+}
+
+type packageCommandOption func(config *packageCommandConfig)
+
+func packageCommand(ops ...packageCommandOption) *cobra.Command {
+	config := &packageCommandConfig{
+		logger:              ilogging.NewLogWithWriters(&bytes.Buffer{}, &bytes.Buffer{}),
+		packageConfigReader: fakes.NewFakePackageConfigReader(),
+		buildpackPackager:   &fakes.FakeBuildpackPackager{},
+		clientConfig:        config.Config{},
+		imageName:           "some-image-name",
+		configPath:          "/path/to/some/file",
+	}
+
+	for _, op := range ops {
+		op(config)
+	}
+
+	cmd := commands.BuildpackPackage(config.logger, config.buildpackPackager, config.packageConfigReader)
+	cmd.SetArgs([]string{config.imageName, "--config", config.configPath})
+
+	return cmd
+}
+
+func withLogger(logger *ilogging.LogWithWriters) packageCommandOption {
+	return func(config *packageCommandConfig) {
+		config.logger = logger
+	}
+}
+
+func withPackageConfigReader(reader *fakes.FakePackageConfigReader) packageCommandOption {
+	return func(config *packageCommandConfig) {
+		config.packageConfigReader = reader
+	}
+}
+
+func withBuildpackPackager(creator *fakes.FakeBuildpackPackager) packageCommandOption {
+	return func(config *packageCommandConfig) {
+		config.buildpackPackager = creator
+	}
+}
+
+func withImageName(name string) packageCommandOption {
+	return func(config *packageCommandConfig) {
+		config.imageName = name
+	}
+}
+
+func withPackageConfigPath(path string) packageCommandOption {
+	return func(config *packageCommandConfig) {
+		config.configPath = path
+	}
+}
+
+func whereReadReturns(config pubbldpkg.Config, err error) func(*fakes.FakePackageConfigReader) {
+	return func(r *fakes.FakePackageConfigReader) {
+		r.ReadReturnConfig = config
+		r.ReadReturnError = err
+	}
+}

--- a/internal/commands/buildpack_pull.go
+++ b/internal/commands/buildpack_pull.go
@@ -9,19 +9,19 @@ import (
 	"github.com/buildpacks/pack/logging"
 )
 
-type PullBuildpackFlags struct {
+type BuildpackPullFlags struct {
 	BuildpackRegistry string
 }
 
-func PullBuildpack(logger logging.Logger, cfg config.Config, client PackClient) *cobra.Command {
+func BuildpackPull(logger logging.Logger, cfg config.Config, client PackClient) *cobra.Command {
 	var opts pack.PullBuildpackOptions
-	var flags PullBuildpackFlags
+	var flags BuildpackPullFlags
 
 	cmd := &cobra.Command{
-		Use:     "pull-buildpack <uri>",
+		Use:     "pull <uri>",
 		Args:    cobra.ExactArgs(1),
-		Short:   prependExperimental("Pull the buildpack and store it locally"),
-		Example: "pack pull-buildpack example/my-buildpack@1.0.0",
+		Short:   prependExperimental("Pull the buildpack from a registry and store it locally"),
+		Example: "pack buildpack pull example/my-buildpack@1.0.0",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			registry, err := config.GetRegistry(cfg, flags.BuildpackRegistry)
 			if err != nil {
@@ -40,6 +40,6 @@ func PullBuildpack(logger logging.Logger, cfg config.Config, client PackClient) 
 		}),
 	}
 	cmd.Flags().StringVarP(&flags.BuildpackRegistry, "buildpack-registry", "r", "", "Buildpack Registry name")
-	AddHelpFlag(cmd, "pull-buildpack")
+	AddHelpFlag(cmd, "pull")
 	return cmd
 }

--- a/internal/commands/buildpack_pull_test.go
+++ b/internal/commands/buildpack_pull_test.go
@@ -38,10 +38,10 @@ func testPullBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 		mockClient = testmocks.NewMockPackClient(mockController)
 		cfg = config.Config{}
 
-		command = commands.PullBuildpack(logger, cfg, mockClient)
+		command = commands.BuildpackPull(logger, cfg, mockClient)
 	})
 
-	when("#PullBuildpackCommand", func() {
+	when("#BuildpackPullCommand", func() {
 		when("no buildpack is provided", func() {
 			it("fails to run", func() {
 				err := command.Execute()

--- a/internal/commands/buildpack_register.go
+++ b/internal/commands/buildpack_register.go
@@ -4,23 +4,24 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/buildpacks/pack"
-	"github.com/buildpacks/pack/internal/style"
-
 	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/logging"
 )
 
-// Deprecated: Use BuildpackRegister instead
-func RegisterBuildpack(logger logging.Logger, cfg config.Config, client PackClient) *cobra.Command {
+type BuildpackRegisterFlags struct {
+	BuildpackRegistry string
+}
+
+func BuildpackRegister(logger logging.Logger, cfg config.Config, client PackClient) *cobra.Command {
 	var opts pack.RegisterBuildpackOptions
 	var flags BuildpackRegisterFlags
 
 	cmd := &cobra.Command{
-		Use:     "register-buildpack <image>",
-		Hidden:  true,
+		Use:     "register <image>",
 		Args:    cobra.ExactArgs(1),
 		Short:   prependExperimental("Register the buildpack to a registry"),
-		Example: "pack register-buildpack my-buildpack",
+		Example: "pack register my-buildpack",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			registry, err := config.GetRegistry(cfg, flags.BuildpackRegistry)
 			if err != nil {
@@ -39,6 +40,6 @@ func RegisterBuildpack(logger logging.Logger, cfg config.Config, client PackClie
 		}),
 	}
 	cmd.Flags().StringVarP(&flags.BuildpackRegistry, "buildpack-registry", "r", "", "Buildpack Registry name")
-	AddHelpFlag(cmd, "register-buildpack")
+	AddHelpFlag(cmd, "register")
 	return cmd
 }

--- a/internal/commands/buildpack_register_test.go
+++ b/internal/commands/buildpack_register_test.go
@@ -19,13 +19,13 @@ import (
 	h "github.com/buildpacks/pack/testhelpers"
 )
 
-func TestRegisterBuildpackCommand(t *testing.T) {
-	spec.Run(t, "Commands", testRegisterBuildpackCommand, spec.Parallel(), spec.Report(report.Terminal{}))
+func TestRegisterCommand(t *testing.T) {
+	spec.Run(t, "RegisterCommand", testRegisterCommand, spec.Parallel(), spec.Report(report.Terminal{}))
 }
 
-func testRegisterBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
+func testRegisterCommand(t *testing.T, when spec.G, it spec.S) {
 	var (
-		command        *cobra.Command
+		cmd            *cobra.Command
 		logger         logging.Logger
 		outBuf         bytes.Buffer
 		mockController *gomock.Controller
@@ -39,7 +39,7 @@ func testRegisterBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 		mockClient = testmocks.NewMockPackClient(mockController)
 		cfg = config.Config{}
 
-		command = commands.RegisterBuildpack(logger, cfg, mockClient)
+		cmd = commands.BuildpackRegister(logger, cfg, mockClient)
 	})
 
 	it.After(func() {})
@@ -47,19 +47,13 @@ func testRegisterBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 	when("#RegisterBuildpackCommand", func() {
 		when("no image is provided", func() {
 			it("fails to run", func() {
-				err := command.Execute()
+				err := cmd.Execute()
 				h.AssertError(t, err, "accepts 1 arg")
 			})
 		})
 
 		when("image name is provided", func() {
-			var (
-				buildpackImage string
-			)
-
-			it.Before(func() {
-				buildpackImage = "buildpack/image"
-			})
+			var buildpackImage = "buildpack/image"
 
 			it("should work for required args", func() {
 				opts := pack.RegisterBuildpackOptions{
@@ -73,8 +67,8 @@ func testRegisterBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 					RegisterBuildpack(gomock.Any(), opts).
 					Return(nil)
 
-				command.SetArgs([]string{buildpackImage})
-				h.AssertNil(t, command.Execute())
+				cmd.SetArgs([]string{buildpackImage})
+				h.AssertNil(t, cmd.Execute())
 			})
 
 			when("config.toml exists", func() {
@@ -89,7 +83,7 @@ func testRegisterBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 							},
 						},
 					}
-					command = commands.RegisterBuildpack(logger, cfg, mockClient)
+					cmd = commands.BuildpackRegister(logger, cfg, mockClient)
 					opts := pack.RegisterBuildpackOptions{
 						ImageName: buildpackImage,
 						Type:      "github",
@@ -101,18 +95,18 @@ func testRegisterBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 						RegisterBuildpack(gomock.Any(), opts).
 						Return(nil)
 
-					command.SetArgs([]string{buildpackImage})
-					h.AssertNil(t, command.Execute())
+					cmd.SetArgs([]string{buildpackImage})
+					h.AssertNil(t, cmd.Execute())
 				})
 
 				it("should handle config errors", func() {
 					cfg = config.Config{
 						DefaultRegistryName: "missing registry",
 					}
-					command = commands.RegisterBuildpack(logger, cfg, mockClient)
-					command.SetArgs([]string{buildpackImage})
+					cmd = commands.BuildpackRegister(logger, cfg, mockClient)
+					cmd.SetArgs([]string{buildpackImage})
 
-					err := command.Execute()
+					err := cmd.Execute()
 					h.AssertNotNil(t, err)
 				})
 			})
@@ -144,9 +138,9 @@ func testRegisterBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 					RegisterBuildpack(gomock.Any(), opts).
 					Return(nil)
 
-				command = commands.RegisterBuildpack(logger, cfg, mockClient)
-				command.SetArgs([]string{buildpackImage, "--buildpack-registry", buildpackRegistry})
-				h.AssertNil(t, command.Execute())
+				cmd = commands.BuildpackRegister(logger, cfg, mockClient)
+				cmd.SetArgs([]string{buildpackImage, "--buildpack-registry", buildpackRegistry})
+				h.AssertNil(t, cmd.Execute())
 			})
 		})
 	})

--- a/internal/commands/buildpack_test.go
+++ b/internal/commands/buildpack_test.go
@@ -1,0 +1,53 @@
+package commands_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/commands"
+	"github.com/buildpacks/pack/internal/commands/fakes"
+	"github.com/buildpacks/pack/internal/commands/testmocks"
+	"github.com/buildpacks/pack/internal/config"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestBuildpackCommand(t *testing.T) {
+	spec.Run(t, "BuildpackCommand", testBuildpackCommand, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func testBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
+	var (
+		cmd    *cobra.Command
+		logger logging.Logger
+		outBuf bytes.Buffer
+	)
+
+	it.Before(func() {
+		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+		mockController := gomock.NewController(t)
+		mockClient := testmocks.NewMockPackClient(mockController)
+		cmd = commands.NewBuildpackCommand(logger, config.Config{}, mockClient, fakes.NewFakePackageConfigReader())
+		cmd.SetOut(logging.GetWriterForLevel(logger, logging.InfoLevel))
+	})
+
+	when("buildpack", func() {
+		it("prints help text", func() {
+			cmd.SetArgs([]string{})
+			h.AssertNil(t, cmd.Execute())
+			output := outBuf.String()
+			h.AssertContains(t, output, "Interact with buildpacks")
+			h.AssertContains(t, output, "Usage:")
+			for _, command := range []string{"package", "register", "yank"} {
+				h.AssertContains(t, output, command)
+				h.AssertNotContains(t, output, command+"-buildpack")
+			}
+		})
+	})
+}

--- a/internal/commands/buildpack_yank.go
+++ b/internal/commands/buildpack_yank.go
@@ -1,25 +1,30 @@
 package commands
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"github.com/buildpacks/pack"
-	"github.com/buildpacks/pack/internal/style"
-
 	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/logging"
 )
 
-// Deprecated: Use yank instead
-func YankBuildpack(logger logging.Logger, cfg config.Config, client PackClient) *cobra.Command {
+type BuildpackYankFlags struct {
+	BuildpackRegistry string
+	Undo              bool
+}
+
+func BuildpackYank(logger logging.Logger, cfg config.Config, client PackClient) *cobra.Command {
 	var flags BuildpackYankFlags
 
 	cmd := &cobra.Command{
-		Use:     "yank-buildpack <buildpack-id-and-version>",
-		Hidden:  true,
+		Use:     "yank <buildpack-id-and-version>",
 		Args:    cobra.ExactArgs(1),
 		Short:   prependExperimental("Yank the buildpack from the registry"),
-		Example: "pack yank-buildpack my-buildpack@0.0.1",
+		Example: "pack yank my-buildpack@0.0.1",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			buildpackIDVersion := args[0]
 
@@ -49,7 +54,16 @@ func YankBuildpack(logger logging.Logger, cfg config.Config, client PackClient) 
 	}
 	cmd.Flags().StringVarP(&flags.BuildpackRegistry, "buildpack-registry", "r", "", "Buildpack Registry name")
 	cmd.Flags().BoolVarP(&flags.Undo, "undo", "u", false, "undo previously yanked buildpack")
-	AddHelpFlag(cmd, "yank-buildpack")
+	AddHelpFlag(cmd, "yank")
 
 	return cmd
+}
+
+func parseIDVersion(buildpackIDVersion string) (string, string, error) {
+	parts := strings.Split(buildpackIDVersion, "@")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid buildpack id@version %s", style.Symbol(buildpackIDVersion))
+	}
+
+	return parts[0], parts[1], nil
 }

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -30,7 +30,7 @@ func PackageBuildpack(logger logging.Logger, cfg config.Config, client Buildpack
 			"and they can be included in the configs used in `pack create-builder` and `pack package-buildpack`. For more " +
 			"on how to package a buildpack, see: https://buildpacks.io/docs/buildpack-author-guide/package-a-buildpack/.",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			logger.Warn("Command 'pack package-buildpack' has been deprecated, please use 'pack buildpack package' instead")
+			deprecationWarning(logger, "package-buildpack", "buildpack package")
 
 			if err := validateBuildpackPackageFlags(&flags); err != nil {
 				return err

--- a/internal/commands/register_buildpack.go
+++ b/internal/commands/register_buildpack.go
@@ -22,6 +22,7 @@ func RegisterBuildpack(logger logging.Logger, cfg config.Config, client PackClie
 		Short:   prependExperimental("Register the buildpack to a registry"),
 		Example: "pack register-buildpack my-buildpack",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			deprecationWarning(logger, "register-buildpack", "buildpack register")
 			registry, err := config.GetRegistry(cfg, flags.BuildpackRegistry)
 			if err != nil {
 				return err

--- a/internal/commands/yank_buildpack.go
+++ b/internal/commands/yank_buildpack.go
@@ -21,6 +21,7 @@ func YankBuildpack(logger logging.Logger, cfg config.Config, client PackClient) 
 		Short:   prependExperimental("Yank the buildpack from the registry"),
 		Example: "pack yank-buildpack my-buildpack@0.0.1",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			deprecationWarning(logger, "yank-buildpack", "buildpack yank")
 			buildpackIDVersion := args[0]
 
 			registry, err := config.GetRegistry(cfg, flags.BuildpackRegistry)


### PR DESCRIPTION
* Deprecate package_buildpack in favor of buildpack package
* Deprecate register_buildpack in favor of buildpack register
* Deprecate yank_buildpack in favor of buildpack yank
* Make necessary changes to ensure acceptance tests are run (especially for OS)

Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This PR deprecates `pack package-buildpack`, `pack register_buildpack`, and `pack yank_buildpack` in favor of a new `buildpack` command, with 3 further subcommands:
* `package`
* `register`
* `yank`

It completely renames the new `pack pull-buildpack` (#935) to `pack buildpack pull`

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
### `pack help`
![image](https://user-images.githubusercontent.com/7035673/101134375-ef7a1a00-3612-11eb-9ad4-9e4381079f41.png)

#### After
### `pack help`
![image](https://user-images.githubusercontent.com/7035673/101134409-002a9000-3613-11eb-8983-69ec84f8403e.png)

### `pack help buildpack`
![image](https://user-images.githubusercontent.com/7035673/101134415-03258080-3613-11eb-8ebd-b8267fb2056c.png)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->
- Should this change be documented?
    - [x] Yes

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
Resolves #918 
Relates to #597