### PR TITLE
Add codecov for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,16 @@ jobs:
           file: ./out/tests/coverage-unit.txt
           flags: unit,os_${{ matrix.os }}
           fail_ci_if_error: true
+          verbose: true
+      - name: Prepare Codecov
+        if: matrix.os == 'windows'
+        uses: crazy-max/ghaction-chocolatey@v1
+        with:
+          args: install codecov -y
+      - name: run Codecov
+        if: matrix.os == 'windows'
+        run: |
+          codecov.exe -f ./out/tests/coverage-unit.txt -v --flag os_windows
       - name: Build
         run: make build
         env:


### PR DESCRIPTION
~This is a draft PR (not an actual draft, in order to run actions and get the codecov result we are trying for), to see whether we can find any more information on our codecov failures using the verbose flag. It was requested on the codecov forums [here](https://community.codecov.io/t/uploading-on-windows-has-silent-failure/2266/7)~

After working through the codecov forum suggestions, we are using the [codecov.exe](https://github.com/codecov/codecov-exe) uploader for Windows, which seems to work as it should. 

## Related:
Resolves #906
Is an extension of #944, which I can't reopen because I've force-pushed this branch to be up-to-date with `origin/main`