### PR TITLE
Improve locator type detection

### DIFF
--- a/internal/buildpack/locator_type.go
+++ b/internal/buildpack/locator_type.go
@@ -86,7 +86,7 @@ func builderMatchFound(locator string, candidates []dist.BuildpackInfo) bool {
 func hasHostPortPrefix(locator string) bool {
 	if strings.Contains(locator, "/") {
 		prefix := strings.Split(locator, "/")[0]
-		if strings.Contains(prefix, ":") {
+		if strings.Contains(prefix, ":") || strings.Contains(prefix, ".") {
 			return true
 		}
 	}

--- a/internal/buildpack/locator_type_test.go
+++ b/internal/buildpack/locator_type_test.go
@@ -157,6 +157,10 @@ func testGetLocatorType(t *testing.T, when spec.G, it spec.S) {
 			locator:      "localhost:1234/example/package-cnb",
 			expectedType: buildpack.PackageLocator,
 		},
+		{
+			locator:      "dev.local/http-go-fn:latest",
+			expectedType: buildpack.PackageLocator,
+		},
 	} {
 		tc := tc
 


### PR DESCRIPTION
## Summary

Added a check for `.` when testing if a URI contains a hostname

## Output

N/A

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related

Resolves #968
