### PR TITLE
Enable caching layers in image registry via `cache-image` flag

### DIFF
--- a/build.go
+++ b/build.go
@@ -103,6 +103,10 @@ type BuildOptions struct {
 	// Buildpacks may both read and overwrite these values.
 	Env map[string]string
 
+	// Option only valid if Publish is true
+	// Create an additional image that contains cache=true layers and push it to the registry.
+	CacheImage string
+
 	// Option passed directly to the lifecycle.
 	// If true, publishes Image directly to a registry.
 	// Assumes Image contains a valid registry with credentials
@@ -291,6 +295,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		Volumes:            processedVolumes,
 		DefaultProcessType: opts.DefaultProcessType,
 		FileFilter:         fileFilter,
+		CacheImage:         opts.CacheImage,
 	}
 
 	lifecycleVersion := ephemeralBuilder.LifecycleDescriptor().Info.Version

--- a/build_test.go
+++ b/build_test.go
@@ -638,6 +638,25 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("ImageCache option", func() {
+			it("passes it through to lifecycle", func() {
+				h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+					Image:      "some/app",
+					Builder:    defaultBuilderName,
+					CacheImage: "some-cache-image",
+				}))
+				h.AssertEq(t, fakeLifecycle.Opts.CacheImage, "some-cache-image")
+			})
+
+			it("defaults to false", func() {
+				h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+					Image:   "some/app",
+					Builder: defaultBuilderName,
+				}))
+				h.AssertEq(t, fakeLifecycle.Opts.CacheImage, "")
+			})
+		})
+
 		when("Buildpacks option", func() {
 			assertOrderEquals := func(content string) {
 				t.Helper()

--- a/internal/build/fakes/cache.go
+++ b/internal/build/fakes/cache.go
@@ -1,0 +1,35 @@
+package fakes
+
+import (
+	"context"
+
+	"github.com/buildpacks/pack/internal/cache"
+)
+
+type FakeCache struct {
+	ReturnForType  cache.Type
+	ReturnForClear error
+	ReturnForName  string
+
+	TypeCallCount  int
+	ClearCallCount int
+	NameCallCount  int
+}
+
+func NewFakeCache() *FakeCache {
+	return &FakeCache{}
+}
+
+func (f *FakeCache) Type() cache.Type {
+	f.TypeCallCount++
+	return f.ReturnForType
+}
+
+func (f *FakeCache) Clear(ctx context.Context) error {
+	f.ClearCallCount++
+	return f.ReturnForClear
+}
+func (f *FakeCache) Name() string {
+	f.NameCallCount++
+	return f.ReturnForName
+}

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -150,7 +150,7 @@ func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseF
 		}
 
 		l.logger.Info(style.Step("EXPORTING"))
-		return l.Export(ctx, l.opts.Image.String(), l.opts.RunImage, l.opts.Publish, l.opts.Network, launchCache, buildCache, l.opts.AdditionalTags, phaseFactory)
+		return l.Export(ctx, l.opts.Image.String(), l.opts.RunImage, l.opts.Publish, l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, phaseFactory)
 	}
 
 	return l.Create(

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/google/go-containerregistry/pkg/name"
-
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/auth"
 	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
 
 	"github.com/buildpacks/pack/internal/builder"
@@ -152,7 +151,6 @@ func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseF
 
 		l.logger.Info(style.Step("EXPORTING"))
 		return l.Export(ctx, l.opts.Image.String(), l.opts.RunImage, l.opts.Publish, l.opts.Network, launchCache, buildCache, l.opts.AdditionalTags, phaseFactory)
-
 	}
 
 	return l.Create(
@@ -409,7 +407,7 @@ func determineDefaultProcessType(platformAPI *api.Version, providedValue string)
 	return providedValue
 }
 
-func (l *LifecycleExecution) newExport(repoName, runImage string, publish bool, networkMode string, buildCache, launchCache Cache,additionalTags []string, phaseFactory PhaseFactory) (RunnerCleaner, error) {
+func (l *LifecycleExecution) newExport(repoName, runImage string, publish bool, networkMode string, buildCache, launchCache Cache, additionalTags []string, phaseFactory PhaseFactory) (RunnerCleaner, error) {
 	flags := []string{
 		"-cache-dir", l.mountPaths.cacheDir(),
 		"-layers", l.mountPaths.layersDir(),
@@ -471,7 +469,7 @@ func (l *LifecycleExecution) newExport(repoName, runImage string, publish bool, 
 	return phaseFactory.New(NewPhaseConfigProvider("exporter", l, opts...)), nil
 }
 
-func (l *LifecycleExecution) Export(ctx context.Context, repoName string, runImage string, publish bool, networkMode string, buildCache, launchCache Cache,additionalTags []string, phaseFactory PhaseFactory) error {
+func (l *LifecycleExecution) Export(ctx context.Context, repoName string, runImage string, publish bool, networkMode string, buildCache, launchCache Cache, additionalTags []string, phaseFactory PhaseFactory) error {
 	export, err := l.newExport(repoName, runImage, publish, networkMode, buildCache, launchCache, additionalTags, phaseFactory)
 	if err != nil {
 		return err

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -3,11 +3,14 @@ package build_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/buildpacks/pack/internal/cache"
 
 	"github.com/google/go-containerregistry/pkg/name"
 
@@ -179,9 +182,49 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				}
 			})
 		})
+
+		when("Error cases", func() {
+			when("passed invalid cache-image", func() {
+				it("fails", func() {
+					opts := build.LifecycleOptions{
+						Publish:      false,
+						ClearCache:   false,
+						RunImage:     "test",
+						Image:        imageName,
+						Builder:      fakeBuilder,
+						TrustBuilder: false,
+						UseCreator:   false,
+						CacheImage:   "%%%",
+					}
+
+					lifecycle, err := build.NewLifecycleExecution(logger, docker, opts)
+					h.AssertNil(t, err)
+
+					err = lifecycle.Run(context.Background(), func(execution *build.LifecycleExecution) build.PhaseFactory {
+						return fakePhaseFactory
+					})
+
+					h.AssertError(t, err, fmt.Sprintf("invalid cache image name: %s", "could not parse reference: %%!(NOVERB)"))
+				})
+			})
+		})
 	})
 
 	when("#Create", func() {
+		var (
+			fakeBuildCache  *fakes.FakeCache
+			fakeLaunchCache *fakes.FakeCache
+		)
+		it.Before(func() {
+			fakeBuildCache = fakes.NewFakeCache()
+			fakeBuildCache.ReturnForType = cache.Volume
+			fakeBuildCache.ReturnForName = "some-cache"
+
+			fakeLaunchCache = fakes.NewFakeCache()
+			fakeLaunchCache.ReturnForType = cache.Volume
+			fakeLaunchCache.ReturnForName = "some-launch-cache"
+		})
+
 		it("creates a phase and then run it", func() {
 			lifecycle := newTestLifecycleExec(t, false)
 			fakePhase := &fakes.FakePhase{}
@@ -194,8 +237,8 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				"test",
 				"test",
 				"test",
-				"test",
-				"test",
+				fakeBuildCache,
+				fakeLaunchCache,
 				[]string{},
 				[]string{},
 				fakePhaseFactory,
@@ -217,10 +260,10 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				false,
 				false,
 				expectedRunImage,
-				"test",
-				"test",
 				expectedRepoName,
 				"test",
+				fakeBuildCache,
+				fakeLaunchCache,
 				[]string{},
 				[]string{},
 				fakePhaseFactory,
@@ -251,9 +294,9 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				false,
 				"test",
 				"test",
-				"test",
-				"test",
 				expectedNetworkMode,
+				fakeBuildCache,
+				fakeLaunchCache,
 				[]string{},
 				[]string{},
 				fakePhaseFactory,
@@ -279,8 +322,8 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					"test",
 					"test",
 					"test",
-					"test",
-					"test",
+					fakeBuildCache,
+					fakeLaunchCache,
 					[]string{},
 					[]string{},
 					fakePhaseFactory,
@@ -311,8 +354,8 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					"test",
 					"test",
 					"test",
-					"test",
-					"test",
+					fakeBuildCache,
+					fakeLaunchCache,
 					[]string{},
 					[]string{},
 					fakePhaseFactory,
@@ -331,6 +374,45 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("using a cache image", func() {
+			it.Before(func() {
+				fakeBuildCache.ReturnForType = cache.Image
+				fakeBuildCache.ReturnForName = "some-cache-image"
+			})
+			it("configures the phase with the expected arguments", func() {
+				verboseLifecycle := newTestLifecycleExec(t, true)
+				fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+				err := verboseLifecycle.Create(
+					context.Background(),
+					false,
+					true,
+					"test",
+					"test",
+					"test",
+					fakeBuildCache,
+					fakeLaunchCache,
+					[]string{},
+					[]string{},
+					fakePhaseFactory,
+				)
+				h.AssertNil(t, err)
+
+				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+				h.AssertNotEq(t, lastCallIndex, -1)
+
+				configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+				h.AssertEq(t, configProvider.Name(), "creator")
+				h.AssertIncludeAllExpectedPatterns(t,
+					configProvider.ContainerConfig().Cmd,
+					[]string{"-skip-restore"},
+					[]string{"-cache-image", "some-cache-image"},
+				)
+
+				h.AssertSliceNotContains(t, configProvider.HostConfig().Binds, ":/cache")
+			})
+		})
+
 		when("additional tags are specified", func() {
 			it("configures phases with additional tags", func() {
 				lifecycle := newTestLifecycleExec(t, false)
@@ -344,8 +426,8 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					"test",
 					"test",
 					"test",
-					"test",
-					"test",
+					fakes.NewFakeCache(),
+					fakes.NewFakeCache(),
 					additionalTags,
 					[]string{},
 					fakePhaseFactory,
@@ -364,6 +446,20 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("publish", func() {
+			var (
+				fakeBuildCache  *fakes.FakeCache
+				fakeLaunchCache *fakes.FakeCache
+			)
+			it.Before(func() {
+				fakeBuildCache = fakes.NewFakeCache()
+				fakeBuildCache.ReturnForName = "some-cache"
+				fakeBuildCache.ReturnForType = cache.Volume
+
+				fakeLaunchCache = fakes.NewFakeCache()
+				fakeLaunchCache.ReturnForType = cache.Volume
+				fakeLaunchCache.ReturnForName = "some-launch-cache"
+			})
+
 			it("configures the phase with binds", func() {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
@@ -376,9 +472,9 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					false,
 					"test",
 					"test",
-					"some-cache",
 					"test",
-					"test",
+					fakeBuildCache,
+					fakeLaunchCache,
 					[]string{},
 					[]string{volumeMount},
 					fakePhaseFactory,
@@ -403,8 +499,8 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					"test",
 					"test",
 					"test",
-					"test",
-					"test",
+					fakeBuildCache,
+					fakeLaunchCache,
 					[]string{},
 					[]string{},
 					fakePhaseFactory,
@@ -428,10 +524,10 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					true,
 					false,
 					"test",
-					"test",
-					"test",
 					expectedRepos,
 					"test",
+					fakeBuildCache,
+					fakeLaunchCache,
 					[]string{},
 					[]string{},
 					fakePhaseFactory,
@@ -445,14 +541,68 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				h.AssertSliceContains(t, configProvider.ContainerConfig().Env, "CNB_REGISTRY_AUTH={}")
 			})
 
+			when("using a cache image", func() {
+				it.Before(func() {
+					fakeBuildCache.ReturnForType = cache.Image
+					fakeBuildCache.ReturnForName = "some-cache-image"
+				})
+
+				it("configures the phase with the expected arguments", func() {
+					verboseLifecycle := newTestLifecycleExec(t, true)
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+					err := verboseLifecycle.Create(
+						context.Background(),
+						true,
+						true,
+						"test",
+						"test",
+						"test",
+						fakeBuildCache,
+						fakeLaunchCache,
+						[]string{},
+						[]string{},
+						fakePhaseFactory,
+					)
+					h.AssertNil(t, err)
+
+					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+					h.AssertNotEq(t, lastCallIndex, -1)
+
+					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+					h.AssertEq(t, configProvider.Name(), "creator")
+					h.AssertIncludeAllExpectedPatterns(t,
+						configProvider.ContainerConfig().Cmd,
+						[]string{"-skip-restore"},
+						[]string{"-cache-image", "some-cache-image"},
+					)
+
+					h.AssertSliceNotContains(t, configProvider.HostConfig().Binds, ":/cache")
+				})
+			})
+
 			when("platform 0.3", func() {
+				var (
+					fakeBuildCache  *fakes.FakeCache
+					fakeLaunchCache *fakes.FakeCache
+				)
+				it.Before(func() {
+					fakeBuildCache = fakes.NewFakeCache()
+					fakeBuildCache.ReturnForName = "some-cache"
+					fakeBuildCache.ReturnForType = cache.Volume
+
+					fakeLaunchCache = fakes.NewFakeCache()
+					fakeLaunchCache.ReturnForType = cache.Volume
+					fakeLaunchCache.ReturnForName = "some-launch-cache"
+				})
+
 				it("doesn't hint at default process type", func() {
 					fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.3")}))
 					h.AssertNil(t, err)
 					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-					err = lifecycle.Export(context.Background(), "test", []string{}, "test", true, "test", "test", "test", fakePhaseFactory)
+					err = lifecycle.Export(context.Background(), "test", "test", true, "test", fakeBuildCache, fakeLaunchCache,[]string{}, fakePhaseFactory)
 					h.AssertNil(t, err)
 
 					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -470,7 +620,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-					err = lifecycle.Export(context.Background(), "test", []string{}, "test", true, "test", "test", "test", fakePhaseFactory)
+					err = lifecycle.Export(context.Background(), "test", "test", true, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 					h.AssertNil(t, err)
 
 					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -483,6 +633,19 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("publish is false", func() {
+			var (
+				fakeBuildCache  *fakes.FakeCache
+				fakeLaunchCache *fakes.FakeCache
+			)
+			it.Before(func() {
+				fakeBuildCache = fakes.NewFakeCache()
+				fakeBuildCache.ReturnForName = "some-cache"
+				fakeBuildCache.ReturnForType = cache.Volume
+
+				fakeLaunchCache = fakes.NewFakeCache()
+				fakeLaunchCache.ReturnForType = cache.Volume
+				fakeLaunchCache.ReturnForName = "some-launch-cache"
+			})
 			it("configures the phase with the expected arguments", func() {
 				verboseLifecycle := newTestLifecycleExec(t, true)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
@@ -494,8 +657,8 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					"test",
 					"test",
 					"test",
-					"test",
-					"test",
+					fakeBuildCache,
+					fakeLaunchCache,
 					[]string{},
 					[]string{},
 					fakePhaseFactory,
@@ -523,10 +686,10 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					false,
 					false,
 					"test",
-					"some-launch-cache",
-					"some-cache",
 					"test",
 					"test",
+					fakeBuildCache,
+					fakeLaunchCache,
 					[]string{},
 					[]string{},
 					fakePhaseFactory,
@@ -552,10 +715,10 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					false,
 					false,
 					"test",
-					"some-launch-cache",
-					"some-cache",
 					"test",
 					"test",
+					fakeBuildCache,
+					fakeLaunchCache,
 					[]string{},
 					[]string{volumeMount},
 					fakePhaseFactory,
@@ -576,7 +739,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-					err = lifecycle.Export(context.Background(), "test", []string{}, "test", false, "test", "test", "test", fakePhaseFactory)
+					err = lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 					h.AssertNil(t, err)
 
 					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -594,7 +757,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-					err = lifecycle.Export(context.Background(), "test", []string{}, "test", false, "test", "test", "test", fakePhaseFactory)
+					err = lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 					h.AssertNil(t, err)
 
 					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -676,12 +839,17 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#Analyze", func() {
+		var fakeCache *fakes.FakeCache
+		it.Before(func() {
+			fakeCache = fakes.NewFakeCache()
+			fakeCache.ReturnForType = cache.Volume
+		})
 		it("creates a phase and then runs it", func() {
 			lifecycle := newTestLifecycleExec(t, false)
 			fakePhase := &fakes.FakePhase{}
 			fakePhaseFactory := fakes.NewFakePhaseFactory(fakes.WhichReturnsForNew(fakePhase))
 
-			err := lifecycle.Analyze(context.Background(), "test", "test", "test", false, false, fakePhaseFactory)
+			err := lifecycle.Analyze(context.Background(), "test", "test", false, false, fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, fakePhase.CleanupCallCount, 1)
@@ -694,7 +862,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedRepoName := "some-repo-name"
 
-				err := lifecycle.Analyze(context.Background(), expectedRepoName, "test", "test", false, true, fakePhaseFactory)
+				err := lifecycle.Analyze(context.Background(), expectedRepoName, "test", false, true, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -712,7 +880,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedRepoName := "some-repo-name"
 
-				err := lifecycle.Analyze(context.Background(), expectedRepoName, "test", "test", false, false, fakePhaseFactory)
+				err := lifecycle.Analyze(context.Background(), expectedRepoName, "test", false, false, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -727,6 +895,53 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("using a cache image", func() {
+			var (
+				lifecycle        *build.LifecycleExecution
+				fakePhaseFactory *fakes.FakePhaseFactory
+				expectedRepoName = "some-repo-name"
+			)
+			it.Before(func() {
+				fakeCache.ReturnForType = cache.Image
+				fakeCache.ReturnForName = "some-cache-image"
+
+				lifecycle = newTestLifecycleExec(t, false)
+				fakePhaseFactory = fakes.NewFakePhaseFactory()
+			})
+			it("configures the phase with a build cache images", func() {
+				err := lifecycle.Analyze(context.Background(), expectedRepoName, "", false, false, fakeCache, fakePhaseFactory)
+				h.AssertNil(t, err)
+
+				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+				h.AssertNotEq(t, lastCallIndex, -1)
+
+				configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+				h.AssertEq(t, configProvider.Name(), "analyzer")
+				h.AssertSliceNotContains(t, configProvider.HostConfig().Binds, ":/cache")
+				h.AssertIncludeAllExpectedPatterns(t,
+					configProvider.ContainerConfig().Cmd,
+					[]string{"-cache-image", "some-cache-image"},
+				)
+				h.AssertIncludeAllExpectedPatterns(t,
+					configProvider.ContainerConfig().Cmd,
+					[]string{"-cache-dir", "/cache"},
+				)
+			})
+			when("clear-cache", func() {
+				it("cache is omitted from Analyze", func() {
+					err := lifecycle.Analyze(context.Background(), expectedRepoName, "", false, true, fakeCache, fakePhaseFactory)
+					h.AssertNil(t, err)
+
+					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+					h.AssertNotEq(t, lastCallIndex, -1)
+
+					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+					h.AssertEq(t, configProvider.Name(), "analyzer")
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-cache-image")
+				})
+			})
+		})
+
 		when("publish", func() {
 			it("runs the phase with the lifecycle image", func() {
 				lifecycle := newTestLifecycleExec(t, true, func(options *build.LifecycleOptions) {
@@ -734,7 +949,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				})
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := lifecycle.Analyze(context.Background(), "test", "test", "test", true, false, fakePhaseFactory)
+				err := lifecycle.Analyze(context.Background(), "test", "test", true, false, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -750,7 +965,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				lifecycle := newTestLifecycleExec(t, false, fakes.WithBuilder(fakeBuilder))
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err = lifecycle.Analyze(context.Background(), "test", "test", "test", true, false, fakePhaseFactory)
+				err = lifecycle.Analyze(context.Background(), "test", "test", true, false, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -767,7 +982,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				expectedRepos := "some-repo-name"
 				expectedNetworkMode := "some-network-mode"
 
-				err := lifecycle.Analyze(context.Background(), expectedRepos, "test", expectedNetworkMode, true, false, fakePhaseFactory)
+				err := lifecycle.Analyze(context.Background(), expectedRepos, expectedNetworkMode, true, false, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -782,7 +997,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := lifecycle.Analyze(context.Background(), "test", "test", "test", true, false, fakePhaseFactory)
+				err := lifecycle.Analyze(context.Background(), "test", "test", true, false, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -797,7 +1012,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedRepoName := "some-repo-name"
 
-				err := verboseLifecycle.Analyze(context.Background(), expectedRepoName, "test", "test", true, false, fakePhaseFactory)
+				err := verboseLifecycle.Analyze(context.Background(), expectedRepoName, "test", true, false, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -814,11 +1029,12 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("configures the phase with binds", func() {
+				fakeCache.ReturnForName = "some-cache"
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedBind := "some-cache:/cache"
 
-				err := lifecycle.Analyze(context.Background(), "test", "some-cache", "test", true, false, fakePhaseFactory)
+				err := lifecycle.Analyze(context.Background(), "test", "test", true, false, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -826,6 +1042,36 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 
 				configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
 				h.AssertSliceContains(t, configProvider.HostConfig().Binds, expectedBind)
+			})
+
+			when("using a cache image", func() {
+				it.Before(func() {
+					fakeCache.ReturnForName = "some-cache-image"
+					fakeCache.ReturnForType = cache.Image
+				})
+
+				it("configures the phase with a build cache images", func() {
+					lifecycle := newTestLifecycleExec(t, false)
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+					expectedRepoName := "some-repo-name"
+
+					err := lifecycle.Analyze(context.Background(), expectedRepoName, "test", true, false, fakeCache, fakePhaseFactory)
+					h.AssertNil(t, err)
+
+					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+					h.AssertNotEq(t, lastCallIndex, -1)
+
+					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+					h.AssertSliceNotContains(t, configProvider.HostConfig().Binds, ":/cache")
+					h.AssertIncludeAllExpectedPatterns(t,
+						configProvider.ContainerConfig().Cmd,
+						[]string{"-cache-image", "some-cache-image"},
+					)
+					h.AssertIncludeAllExpectedPatterns(t,
+						configProvider.ContainerConfig().Cmd,
+						[]string{"-cache-dir", "/cache"},
+					)
+				})
 			})
 		})
 
@@ -836,7 +1082,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				})
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := lifecycle.Analyze(context.Background(), "test", "test", "test", false, false, fakePhaseFactory)
+				err := lifecycle.Analyze(context.Background(), "test", "test", false, false, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -852,7 +1098,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				lifecycle := newTestLifecycleExec(t, false, fakes.WithBuilder(fakeBuilder))
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err = lifecycle.Analyze(context.Background(), "test", "test", "test", false, false, fakePhaseFactory)
+				err = lifecycle.Analyze(context.Background(), "test", "test", false, false, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -867,7 +1113,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := lifecycle.Analyze(context.Background(), "test", "test", "test", false, false, fakePhaseFactory)
+				err := lifecycle.Analyze(context.Background(), "test", "test", false, false, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -883,7 +1129,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedRepoName := "some-repo-name"
 
-				err := verboseLifecycle.Analyze(context.Background(), expectedRepoName, "test", "test", false, true, fakePhaseFactory)
+				err := verboseLifecycle.Analyze(context.Background(), expectedRepoName, "test", false, true, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -905,7 +1151,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedNetworkMode := "some-network-mode"
 
-				err := lifecycle.Analyze(context.Background(), "test", "test", expectedNetworkMode, false, false, fakePhaseFactory)
+				err := lifecycle.Analyze(context.Background(), "test", expectedNetworkMode, false, false, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -916,11 +1162,12 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("configures the phase with binds", func() {
+				fakeCache.ReturnForName = "some-cache"
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedBind := "some-cache:/cache"
 
-				err := lifecycle.Analyze(context.Background(), "test", "some-cache", "test", false, true, fakePhaseFactory)
+				err := lifecycle.Analyze(context.Background(), "test", "test", false, true, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -933,13 +1180,19 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#Restore", func() {
+		var fakeCache *fakes.FakeCache
+		it.Before(func() {
+			fakeCache = fakes.NewFakeCache()
+			fakeCache.ReturnForName = "some-cache"
+			fakeCache.ReturnForType = cache.Volume
+		})
 		it("runs the phase with the lifecycle image", func() {
 			lifecycle := newTestLifecycleExec(t, true, func(options *build.LifecycleOptions) {
 				options.LifecycleImage = "some-lifecycle-image"
 			})
 			fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-			err := lifecycle.Restore(context.Background(), "test", "test", fakePhaseFactory)
+			err := lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -955,7 +1208,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			lifecycle := newTestLifecycleExec(t, false, fakes.WithBuilder(fakeBuilder))
 			fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-			err = lifecycle.Restore(context.Background(), "test", "test", fakePhaseFactory)
+			err = lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -971,7 +1224,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			fakePhase := &fakes.FakePhase{}
 			fakePhaseFactory := fakes.NewFakePhaseFactory(fakes.WhichReturnsForNew(fakePhase))
 
-			err := lifecycle.Restore(context.Background(), "test", "test", fakePhaseFactory)
+			err := lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, fakePhase.CleanupCallCount, 1)
@@ -982,7 +1235,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			lifecycle := newTestLifecycleExec(t, false)
 			fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-			err := lifecycle.Restore(context.Background(), "test", "test", fakePhaseFactory)
+			err := lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -996,7 +1249,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			verboseLifecycle := newTestLifecycleExec(t, true)
 			fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-			err := verboseLifecycle.Restore(context.Background(), "test", "test", fakePhaseFactory)
+			err := verboseLifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1017,7 +1270,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			fakePhaseFactory := fakes.NewFakePhaseFactory()
 			expectedNetworkMode := "some-network-mode"
 
-			err := lifecycle.Restore(context.Background(), "test", expectedNetworkMode, fakePhaseFactory)
+			err := lifecycle.Restore(context.Background(), expectedNetworkMode, fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1032,7 +1285,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			fakePhaseFactory := fakes.NewFakePhaseFactory()
 			expectedBind := "some-cache:/cache"
 
-			err := lifecycle.Restore(context.Background(), "some-cache", "test", fakePhaseFactory)
+			err := lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1040,6 +1293,34 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 
 			configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
 			h.AssertSliceContains(t, configProvider.HostConfig().Binds, expectedBind)
+		})
+		when("using cache image", func() {
+			var (
+				lifecycle        *build.LifecycleExecution
+				fakePhaseFactory *fakes.FakePhaseFactory
+			)
+
+			it.Before(func() {
+				fakeCache.ReturnForType = cache.Image
+				fakeCache.ReturnForName = "some-cache-image"
+
+				lifecycle = newTestLifecycleExec(t, false)
+				fakePhaseFactory = fakes.NewFakePhaseFactory()
+			})
+			it("configures the phase with a cache image", func() {
+				err := lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
+				h.AssertNil(t, err)
+
+				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+				h.AssertNotEq(t, lastCallIndex, -1)
+
+				configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+				h.AssertSliceNotContains(t, configProvider.HostConfig().Binds, ":/cache")
+				h.AssertIncludeAllExpectedPatterns(t,
+					configProvider.ContainerConfig().Cmd,
+					[]string{"-cache-image", "some-cache-image"},
+				)
+			})
 		})
 	})
 
@@ -1111,12 +1392,27 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#Export", func() {
+		var (
+			fakeBuildCache  *fakes.FakeCache
+			fakeLaunchCache *fakes.FakeCache
+		)
+
+		it.Before(func() {
+			fakeBuildCache = fakes.NewFakeCache()
+			fakeBuildCache.ReturnForType = cache.Volume
+			fakeBuildCache.ReturnForName = "some-cache"
+
+			fakeLaunchCache = fakes.NewFakeCache()
+			fakeLaunchCache.ReturnForType = cache.Volume
+			fakeLaunchCache.ReturnForName = "some-launch-cache"
+		})
+
 		it("creates a phase and then runs it", func() {
 			lifecycle := newTestLifecycleExec(t, false)
 			fakePhase := &fakes.FakePhase{}
 			fakePhaseFactory := fakes.NewFakePhaseFactory(fakes.WhichReturnsForNew(fakePhase))
 
-			err := lifecycle.Export(context.Background(), "test", []string{}, "test", false, "test", "test", "test", fakePhaseFactory)
+			err := lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache,[]string{}, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, fakePhase.CleanupCallCount, 1)
@@ -1129,7 +1425,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			expectedRepoName := "some-repo-name"
 			expectedRunImage := "some-run-image"
 
-			err := verboseLifecycle.Export(context.Background(), expectedRepoName, []string{}, expectedRunImage, false, "test", "test", "test", fakePhaseFactory)
+			err := verboseLifecycle.Export(context.Background(), expectedRepoName, expectedRunImage, false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1156,7 +1452,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				expectedRunImage := "some-run-image"
 				additionalTags := []string{"additional-tag-1", "additional-tag-2"}
 
-				err := verboseLifecycle.Export(context.Background(), expectedRepoName, additionalTags, expectedRunImage, false, "test", "test", "test", fakePhaseFactory)
+				err := verboseLifecycle.Export(context.Background(), expectedRepoName, expectedRunImage, false, "test", fakes.NewFakeCache(), fakes.NewFakeCache(), additionalTags, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1176,6 +1472,35 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("using cache image", func() {
+			it.Before(func() {
+				fakeBuildCache.ReturnForType = cache.Image
+				fakeBuildCache.ReturnForName = "some-cache-image"
+			})
+
+			it("configures phase with cache image", func() {
+				verboseLifecycle := newTestLifecycleExec(t, true)
+				fakePhaseFactory := fakes.NewFakePhaseFactory()
+				expectedRepoName := "some-repo-name"
+				expectedRunImage := "some-run-image"
+
+				err := verboseLifecycle.Export(context.Background(), expectedRepoName, expectedRunImage, false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
+				h.AssertNil(t, err)
+
+				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+				h.AssertNotEq(t, lastCallIndex, -1)
+
+				configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+				h.AssertEq(t, configProvider.Name(), "exporter")
+
+				h.AssertSliceNotContains(t, configProvider.HostConfig().Binds, ":/cache")
+				h.AssertIncludeAllExpectedPatterns(t,
+					configProvider.ContainerConfig().Cmd,
+					[]string{"-cache-image", "some-cache-image"},
+				)
+			})
+		})
+
 		when("publish", func() {
 			it("runs the phase with the lifecycle image", func() {
 				lifecycle := newTestLifecycleExec(t, true, func(options *build.LifecycleOptions) {
@@ -1183,7 +1508,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				})
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := lifecycle.Export(context.Background(), "test", []string{}, "test", true, "test", "test", "test", fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), "test", "test", true, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1199,7 +1524,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				lifecycle := newTestLifecycleExec(t, false, fakes.WithBuilder(fakeBuilder))
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err = lifecycle.Export(context.Background(), "test", []string{}, "test", true, "test", "test", "test", fakePhaseFactory)
+				err = lifecycle.Export(context.Background(), "test", "test", true, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1215,7 +1540,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedRepos := []string{"some-repo-name", "some-run-image"}
 
-				err := lifecycle.Export(context.Background(), expectedRepos[0], []string{}, expectedRepos[1], true, "test", "test", "test", fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), expectedRepos[0], expectedRepos[1], true, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1229,7 +1554,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := lifecycle.Export(context.Background(), "test", []string{}, "test", true, "test", "test", "test", fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), "test", "test", true, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1244,7 +1569,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedNetworkMode := "some-network-mode"
 
-				err := lifecycle.Export(context.Background(), "test", []string{}, "test", true, "test", "test", expectedNetworkMode, fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), "test", "test", true, expectedNetworkMode, fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1259,7 +1584,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedBind := "some-cache:/cache"
 
-				err := lifecycle.Export(context.Background(), "test", []string{}, "test", true, "test", "some-cache", "test", fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), "test", "test", true, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1274,7 +1599,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedBinds := []string{"some-cache:/cache", "some-launch-cache:/launch-cache"}
 
-				err := lifecycle.Export(context.Background(), "test", []string{}, "test", false, "some-launch-cache", "some-cache", "test", fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1294,7 +1619,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedDefaultProc := []string{"-process-type", "test-process"}
 
-				err := lifecycle.Export(context.Background(), "test", []string{}, "test", true, "test", "test", "test", fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), "test", "test", true, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1304,6 +1629,35 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				h.AssertIncludeAllExpectedPatterns(t, configProvider.ContainerConfig().Cmd, expectedDefaultProc)
 			})
 
+			when("using cache image and publishing", func() {
+				it.Before(func() {
+					fakeBuildCache.ReturnForType = cache.Image
+					fakeBuildCache.ReturnForName = "some-cache-image"
+				})
+
+				it("configures phase with cache image", func() {
+					verboseLifecycle := newTestLifecycleExec(t, true)
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+					expectedRepoName := "some-repo-name"
+					expectedRunImage := "some-run-image"
+
+					err := verboseLifecycle.Export(context.Background(), expectedRepoName, expectedRunImage, true, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
+					h.AssertNil(t, err)
+
+					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+					h.AssertNotEq(t, lastCallIndex, -1)
+
+					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+					h.AssertEq(t, configProvider.Name(), "exporter")
+
+					h.AssertSliceNotContains(t, configProvider.HostConfig().Binds, ":/cache")
+					h.AssertIncludeAllExpectedPatterns(t,
+						configProvider.ContainerConfig().Cmd,
+						[]string{"-cache-image", "some-cache-image"},
+					)
+				})
+			})
+
 			when("platform 0.3", func() {
 				it("doesn't hint at default process type", func() {
 					fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.3")}))
@@ -1311,7 +1665,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-					err = lifecycle.Export(context.Background(), "test", []string{}, "test", true, "test", "test", "test", fakePhaseFactory)
+					err = lifecycle.Export(context.Background(), "test", "test", true, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 					h.AssertNil(t, err)
 
 					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1329,7 +1683,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-					err = lifecycle.Export(context.Background(), "test", []string{}, "test", true, "test", "test", "test", fakePhaseFactory)
+					err = lifecycle.Export(context.Background(), "test", "test", true, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 					h.AssertNil(t, err)
 
 					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1348,7 +1702,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				})
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := lifecycle.Export(context.Background(), "test", []string{}, "test", false, "test", "test", "test", fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1364,7 +1718,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				lifecycle := newTestLifecycleExec(t, false, fakes.WithBuilder(fakeBuilder))
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err = lifecycle.Export(context.Background(), "test", []string{}, "test", false, "test", "test", "test", fakePhaseFactory)
+				err = lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1379,7 +1733,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := lifecycle.Export(context.Background(), "test", []string{}, "test", false, "test", "test", "test", fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1394,7 +1748,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				verboseLifecycle := newTestLifecycleExec(t, true)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := verboseLifecycle.Export(context.Background(), "test", []string{}, "test", false, "test", "test", "test", fakePhaseFactory)
+				err := verboseLifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1414,7 +1768,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedNetworkMode := "some-network-mode"
 
-				err := lifecycle.Export(context.Background(), "test", []string{}, "test", false, "test", "test", expectedNetworkMode, fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), "test", "test", false, expectedNetworkMode, fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1429,7 +1783,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedBinds := []string{"some-cache:/cache", "some-launch-cache:/launch-cache"}
 
-				err := lifecycle.Export(context.Background(), "test", []string{}, "test", false, "some-launch-cache", "some-cache", "test", fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1444,7 +1798,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedBinds := []string{"some-cache:/cache", "some-launch-cache:/launch-cache"}
 
-				err := lifecycle.Export(context.Background(), "test", []string{}, "test", false, "some-launch-cache", "some-cache", "test", fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1464,7 +1818,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				expectedDefaultProc := []string{"-process-type", "test-process"}
 
-				err := lifecycle.Export(context.Background(), "test", []string{}, "test", false, "test", "test", "test", fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1481,7 +1835,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-					err = lifecycle.Export(context.Background(), "test", []string{}, "test", false, "test", "test", "test", fakePhaseFactory)
+					err = lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 					h.AssertNil(t, err)
 
 					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1499,7 +1853,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-					err = lifecycle.Export(context.Background(), "test", []string{}, "test", false, "test", "test", "test", fakePhaseFactory)
+					err = lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache,  []string{},fakePhaseFactory)
 					h.AssertNil(t, err)
 
 					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -602,7 +602,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-					err = lifecycle.Export(context.Background(), "test", "test", true, "test", fakeBuildCache, fakeLaunchCache,[]string{}, fakePhaseFactory)
+					err = lifecycle.Export(context.Background(), "test", "test", true, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 					h.AssertNil(t, err)
 
 					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1412,7 +1412,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			fakePhase := &fakes.FakePhase{}
 			fakePhaseFactory := fakes.NewFakePhaseFactory(fakes.WhichReturnsForNew(fakePhase))
 
-			err := lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache,[]string{}, fakePhaseFactory)
+			err := lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, fakePhase.CleanupCallCount, 1)
@@ -1853,7 +1853,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					lifecycle := newTestLifecycleExec(t, true, fakes.WithBuilder(fakeBuilder))
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-					err = lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache,  []string{},fakePhaseFactory)
+					err = lifecycle.Export(context.Background(), "test", "test", false, "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 					h.AssertNil(t, err)
 
 					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -5,6 +5,8 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/buildpacks/pack/internal/cache"
+
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/docker/docker/client"
@@ -39,6 +41,7 @@ type LifecycleExecutor struct {
 type Cache interface {
 	Name() string
 	Clear(context.Context) error
+	Type() cache.Type
 }
 
 func init() {
@@ -55,6 +58,7 @@ type LifecycleOptions struct {
 	Publish            bool
 	TrustBuilder       bool
 	UseCreator         bool
+	CacheImage         string
 	HTTPProxy          string
 	HTTPSProxy         string
 	NoProxy            string

--- a/internal/build/phase_config_provider.go
+++ b/internal/build/phase_config_provider.go
@@ -86,6 +86,10 @@ func (p *PhaseConfigProvider) InfoWriter() io.Writer {
 	return p.infoWriter
 }
 
+func NullOp() PhaseConfigProviderOperation {
+	return func(provider *PhaseConfigProvider) {}
+}
+
 func WithArgs(args ...string) PhaseConfigProviderOperation {
 	return func(provider *PhaseConfigProvider) {
 		provider.ctrConf.Cmd = append(provider.ctrConf.Cmd, args...)

--- a/internal/cache/consts.go
+++ b/internal/cache/consts.go
@@ -1,0 +1,8 @@
+package cache
+
+const (
+	Image Type = iota
+	Volume
+)
+
+type Type int

--- a/internal/cache/image_cache.go
+++ b/internal/cache/image_cache.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/docker/docker/api/types"
-
 	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/name"
 )

--- a/internal/cache/image_cache.go
+++ b/internal/cache/image_cache.go
@@ -2,10 +2,9 @@ package cache
 
 import (
 	"context"
-	"crypto/sha256"
-	"fmt"
 
 	"github.com/docker/docker/api/types"
+
 	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/name"
 )
@@ -16,9 +15,8 @@ type ImageCache struct {
 }
 
 func NewImageCache(imageRef name.Reference, dockerClient client.CommonAPIClient) *ImageCache {
-	sum := sha256.Sum256([]byte(imageRef.Name()))
 	return &ImageCache{
-		image:  fmt.Sprintf("pack-cache-%x", sum[:6]),
+		image:  imageRef.Name(),
 		docker: dockerClient,
 	}
 }
@@ -27,6 +25,7 @@ func (c *ImageCache) Name() string {
 	return c.image
 }
 
+// No-op as we should not delete remote images, these should be dealt with by managers of the registry
 func (c *ImageCache) Clear(ctx context.Context) error {
 	_, err := c.docker.ImageRemove(ctx, c.Name(), types.ImageRemoveOptions{
 		Force: true,
@@ -35,4 +34,8 @@ func (c *ImageCache) Clear(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+func (c *ImageCache) Type() Type {
+	return Image
 }

--- a/internal/cache/image_cache.go
+++ b/internal/cache/image_cache.go
@@ -24,7 +24,6 @@ func (c *ImageCache) Name() string {
 	return c.image
 }
 
-// No-op as we should not delete remote images, these should be dealt with by managers of the registry
 func (c *ImageCache) Clear(ctx context.Context) error {
 	_, err := c.docker.ImageRemove(ctx, c.Name(), types.ImageRemoveOptions{
 		Force: true,

--- a/internal/cache/image_cache_test.go
+++ b/internal/cache/image_cache_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/buildpacks/imgutil/local"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-
 	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/heroku/color"

--- a/internal/cache/volume_cache.go
+++ b/internal/cache/volume_cache.go
@@ -5,10 +5,10 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	"github.com/buildpacks/pack/internal/paths"
-
 	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/name"
+
+	"github.com/buildpacks/pack/internal/paths"
 )
 
 type VolumeCache struct {

--- a/internal/cache/volume_cache.go
+++ b/internal/cache/volume_cache.go
@@ -5,10 +5,10 @@ import (
 	"crypto/sha256"
 	"fmt"
 
+	"github.com/buildpacks/pack/internal/paths"
+
 	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/name"
-
-	"github.com/buildpacks/pack/internal/paths"
 )
 
 type VolumeCache struct {
@@ -36,4 +36,8 @@ func (c *VolumeCache) Clear(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+func (c *VolumeCache) Type() Type {
+	return Volume
 }

--- a/internal/cache/volume_cache_test.go
+++ b/internal/cache/volume_cache_test.go
@@ -29,15 +29,14 @@ func TestVolumeCache(t *testing.T) {
 }
 
 func testCache(t *testing.T, when spec.G, it spec.S) {
+	var dockerClient client.CommonAPIClient
+
+	it.Before(func() {
+		var err error
+		dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
+		h.AssertNil(t, err)
+	})
 	when("#NewVolumeCache", func() {
-		var dockerClient client.CommonAPIClient
-
-		it.Before(func() {
-			var err error
-			dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
-			h.AssertNil(t, err)
-		})
-
 		it("adds suffix to calculated name", func() {
 			ref, err := name.ParseReference("my/repo", name.WeakValidation)
 			h.AssertNil(t, err)
@@ -157,6 +156,16 @@ func testCache(t *testing.T, when spec.G, it spec.S) {
 				err := subject.Clear(ctx)
 				h.AssertNil(t, err)
 			})
+		})
+	})
+
+	when("#Type", func() {
+		it("returns the cache type", func() {
+			ref, err := name.ParseReference("my/repo", name.WeakValidation)
+			h.AssertNil(t, err)
+			subject := cache.NewVolumeCache(ref, "some-suffix", dockerClient)
+			expected := cache.Volume
+			h.AssertEq(t, subject.Type(), expected)
 		})
 	})
 }

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -148,7 +148,6 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringVar(&buildFlags.Policy, "pull-policy", "", `Pull policy to use. Accepted values are always, never, and if-not-present. (default "always")`)
 	cmd.Flags().StringSliceVarP(&buildFlags.AdditionalTags, "tag", "t", nil, "Additional tags to push the output image to."+multiValueHelp("tag"))
 	cmd.Flags().StringVar(&buildFlags.CacheImage, "cache-image", "", `Cache build layers in remote registry. Requires --publish`)
-
 }
 
 func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackClient, logger logging.Logger) error {

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -22,6 +22,7 @@ type BuildFlags struct {
 	Publish            bool
 	ClearCache         bool
 	TrustBuilder       bool
+	CacheImage         string
 	AppPath            string
 	Builder            string
 	Registry           string
@@ -113,6 +114,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				DefaultProcessType:       flags.DefaultProcessType,
 				ProjectDescriptorBaseDir: filepath.Dir(actualDescriptorPath),
 				ProjectDescriptor:        descriptor,
+				CacheImage:         flags.CacheImage,
 			}); err != nil {
 				return errors.Wrap(err, "failed to build")
 			}
@@ -145,6 +147,8 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringVarP(&buildFlags.DefaultProcessType, "default-process", "D", "", `Set the default process type. (default "web")`)
 	cmd.Flags().StringVar(&buildFlags.Policy, "pull-policy", "", `Pull policy to use. Accepted values are always, never, and if-not-present. (default "always")`)
 	cmd.Flags().StringSliceVarP(&buildFlags.AdditionalTags, "tag", "t", nil, "Additional tags to push the output image to."+multiValueHelp("tag"))
+	cmd.Flags().StringVar(&buildFlags.CacheImage, "cache-image", "", `Cache build layers in remote registry. Requires --publish`)
+
 }
 
 func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackClient, logger logging.Logger) error {
@@ -155,6 +159,10 @@ func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackCli
 
 	if flags.Registry != "" && !cfg.Experimental {
 		return pack.NewExperimentError("Support for buildpack registries is currently experimental.")
+	}
+
+	if flags.CacheImage != "" && !flags.Publish {
+		return errors.New("cache-image flag requires the publish flag")
 	}
 
 	return nil

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -114,7 +114,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				DefaultProcessType:       flags.DefaultProcessType,
 				ProjectDescriptorBaseDir: filepath.Dir(actualDescriptorPath),
 				ProjectDescriptor:        descriptor,
-				CacheImage:         flags.CacheImage,
+				CacheImage:               flags.CacheImage,
 			}); err != nil {
 				return errors.Wrap(err, "failed to build")
 			}

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -287,6 +287,30 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("a cache-image passed", func() {
+			when("--publish is not used", func() {
+				it("errors", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithCacheImage("some-cache-image")).
+						Return(nil)
+
+					command.SetArgs([]string{"--builder", "my-builder", "image", "--cache-image", "some-cache-image"})
+					err := command.Execute()
+					h.AssertError(t, err, "cache-image flag requires the publish flag")
+				})
+			})
+			when("--publish is used", func() {
+				it("succeeds", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithCacheImage("some-cache-image")).
+						Return(nil)
+
+					command.SetArgs([]string{"--builder", "my-builder", "image", "--cache-image", "some-cache-image", "--publish"})
+					h.AssertNil(t, command.Execute())
+				})
+			})
+		})
+
 		when("env vars are passed as flags", func() {
 			var (
 				tmpVar   = "tmpVar"
@@ -531,6 +555,15 @@ func EqBuildOptionsWithPullPolicy(policy pubcfg.PullPolicy) gomock.Matcher {
 		description: fmt.Sprintf("PullPolicy=%s", policy),
 		equals: func(o pack.BuildOptions) bool {
 			return o.PullPolicy == policy
+		},
+	}
+}
+
+func EqBuildOptionsWithCacheImage(cacheImage string) gomock.Matcher {
+	return buildOptionsMatcher{
+		description: fmt.Sprintf("CacheImage=%s", cacheImage),
+		equals: func(o pack.BuildOptions) bool {
+			return o.CacheImage == cacheImage
 		},
 	}
 }

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -509,7 +509,7 @@ func RunE(cmd *exec.Cmd) (string, error) {
 func PullImageWithAuth(dockerCli client.CommonAPIClient, ref, registryAuth string) error {
 	rc, err := dockerCli.ImagePull(context.Background(), ref, dockertypes.ImagePullOptions{RegistryAuth: registryAuth})
 	if err != nil {
-		return nil
+		return err
 	}
 	if _, err := io.Copy(ioutil.Discard, rc); err != nil {
 		return err


### PR DESCRIPTION
## Summary
Adds a `--cache-image <cache-image-name>` flag that will push all `cache=true` layers to the `cache-image-name` image. This PR only supports pushing to a remote registry (so the `--publish` flag must be used as well).

the `cache-image` will allow subsequent rebuild to fetch these layers and speed up rebuilds.

Note that only remote cache images are supported at this time. (Local support would need a lifecycle change)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see https://github.com/buildpacks/docs/issues/266
    - [ ] No

## Related
This change will through some errors ( though they will not impact program execution ) until [this](https://github.com/buildpacks/lifecycle/commit/c0e33588c4a40640ac228622b6114921e9cd73fc) lifecycle PR is included in a release. 

Resolves #491 
Resolves #166


## Validation Steps
To validate this PR you will need to 
1) build a up to date version of the lifecycle
  - clone the `github.com/buildpacks/lifecycle` repository & run a `git pull` (make sure you are on the `main` branch)
  - build a version of the lifecycle by running `LIFECYCLE_VERSION=0.9.4 make build-image-linux` inside of the lifecycle repository
2) create a custom builder
  - Use the following example `builder.toml` file at the bottom of this comment
  - replace the `uri = "<uri>"` under the `lifecycle` heading with `uri = "<path to the lifecycle-repo/out/lifecycle-v0.9.4+linux.x86-64.tgz>"`
  -  run `pack create-builder builder-test --config builder.toml --pull-policy if-not-present` to create a builder
3) trust the created builder so that we can use the `--publish` flag when testing
  - run `pack add-trusted-builder builder-test`
4) run a registry locally
  - run a local registry with `docker run -e REGISTRY_STORAGE_DELETE_ENABLED=true -d -p 5000:5000 --restart always --name registry registry:2`
5) run a pack build with the local registry
  - recommend using the `https://github.com/paketo-buildpacks/samples/java/maven` sample application for building.
  - if on a OSX system substitute `localhost` for `docker.for.mac.localhost` in the below command.
  - `./out/pack build localhost:5000/test/maven-example -p <path/to/app> --publish --cache-image localhost:5000/test/maven-example.cache --builder  tag-builder-test`
6) Rebuild and observer that the `restorer` pulls cache layers from the previous cache image
  - run  `./out/pack build localhost:5000/test/maven-example2 -p <path/to/app> --publish --cache-image localhost:5000/test/maven-example.cache --builder  tag-builder-test`


## Validation notes
If during steps `5` and `6` above we build and push to the `dockerhub` repository, our upload will time out with the following error: 
```
Adding cache layer 'paketo-buildpacks/maven:cache'
Warning: Failed to export cache: committing cache: saving image 'index.docker.io/donthedinosaur/some-java-image.build:latest': failed to write image to the following tags: [index.docker.io/donthedinosaur/some-java-image.build:latest: PATCH https://index.docker.io/v2/donthedinosaur/some-java-image.build/blobs/uploads/21145335-2d37-4b98-8c76-2e2ff3a0f6cc?_state=REDACTED: unexpected status code 504 Gateway Timeout: <html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

]
```



##### Builder.toml file to copy
```
description = "Test image for pack PR970"

[[buildpacks]]
  image = "gcr.io/paketo-buildpacks/dotnet-core:0.0.9"
  version = "0.0.9"

[[buildpacks]]
  image = "gcr.io/paketo-buildpacks/go:0.2.8"
  version = "0.2.8"

[[buildpacks]]
  image = "gcr.io/paketo-buildpacks/java-native-image:4.5.0"
  version = "4.5.0"

[[buildpacks]]
  image = "gcr.io/paketo-buildpacks/java:4.5.0"
  version = "4.5.0"

[[buildpacks]]
  image = "gcr.io/paketo-buildpacks/nginx:0.0.194"
  version = "0.0.194"

[[buildpacks]]
  image = "gcr.io/paketo-buildpacks/nodejs:0.0.10"
  version = "0.0.10"

[[buildpacks]]
  image = "gcr.io/paketo-buildpacks/procfile:3.0.0"
  version = "3.0.0"

[[buildpacks]]
  image = "gcr.io/paketo-buildpacks/ruby:0.1.7"
  version = "0.1.7"

[lifecycle]
  version = "0.10.1"

[[order]]

  [[order.group]]
    id = "paketo-buildpacks/ruby"
    version = "0.1.7"

[[order]]

  [[order.group]]
    id = "paketo-buildpacks/dotnet-core"
    version = "0.0.9"

[[order]]

  [[order.group]]
    id = "paketo-buildpacks/nodejs"
    version = "0.0.10"

[[order]]

  [[order.group]]
    id = "paketo-buildpacks/go"
    version = "0.2.8"

[[order]]

  [[order.group]]
    id = "paketo-buildpacks/nginx"
    version = "0.0.194"

[[order]]

  [[order.group]]
    id = "paketo-buildpacks/java-native-image"
    version = "4.5.0"

[[order]]

  [[order.group]]
    id = "paketo-buildpacks/java"
    version = "4.5.0"

[[order]]

  [[order.group]]
    id = "paketo-buildpacks/procfile"
    version = "3.0.0"

[stack]
  id = "io.buildpacks.stacks.bionic"
  build-image = "docker.io/paketobuildpacks/build:1.0.7-base-cnb"
  run-image = "index.docker.io/paketobuildpacks/run:base-cnb"
  run-image-mirrors = ["gcr.io/paketo-buildpacks/run:base-cnb"]



```
