### PR TITLE
Add run-image-mirrors to config subcommand

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -896,7 +896,11 @@ func testAcceptance(
 						localRunImageMirror := registryConfig.RepoName("pack-test/run-mirror")
 						assert.Succeeds(dockerCli.ImageTag(context.TODO(), runImage, localRunImageMirror))
 						defer h.DockerRmi(dockerCli, localRunImageMirror)
-						pack.JustRunSuccessfully("set-run-image-mirrors", runImage, "-m", localRunImageMirror)
+						if pack.Supports("config run-image-mirrors") {
+							pack.JustRunSuccessfully("config", "run-image-mirrors", "add", runImage, "-m", localRunImageMirror)
+						} else {
+							pack.JustRunSuccessfully("set-run-image-mirrors", runImage, "-m", localRunImageMirror)
+						}
 
 						t.Log("rebuild")
 						output = pack.RunSuccessfully(
@@ -1899,9 +1903,14 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 					})
 
 					it("displays nested Detection Order groups", func() {
-						output := pack.RunSuccessfully(
-							"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1",
-						)
+						var output string
+						if pack.Supports("config run-image-mirrors") {
+							output = pack.RunSuccessfully(
+								"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
+						} else {
+							output = pack.RunSuccessfully(
+								"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
+						}
 						assert.Equal(output, "Run Image 'pack-test/run' configured with mirror 'some-registry.com/pack-test/run1'\n")
 
 						output = pack.RunSuccessfully("inspect-builder", builderName)
@@ -1936,9 +1945,14 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 					})
 
 					it("provides nested detection output up to depth", func() {
-						output := pack.RunSuccessfully(
-							"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1",
-						)
+						var output string
+						if pack.Supports("config run-image-mirrors") {
+							output = pack.RunSuccessfully(
+								"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
+						} else {
+							output = pack.RunSuccessfully(
+								"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
+						}
 						assert.Equal(output, "Run Image 'pack-test/run' configured with mirror 'some-registry.com/pack-test/run1'\n")
 
 						depth := "2"
@@ -1984,9 +1998,15 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 								"inspect-builder output format is not yet implemented",
 							)
 
-							output := pack.RunSuccessfully(
-								"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1",
-							)
+							var output string
+							if pack.Supports("config run-image-mirrors") {
+								output = pack.RunSuccessfully(
+									"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
+							} else {
+								output = pack.RunSuccessfully(
+									"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
+							}
+
 							assert.Equal(output, "Run Image 'pack-test/run' configured with mirror 'some-registry.com/pack-test/run1'\n")
 
 							output = pack.RunSuccessfully("inspect-builder", builderName, "--output", "toml")
@@ -2026,9 +2046,15 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 								"inspect-builder output format is not yet implemented",
 							)
 
-							output := pack.RunSuccessfully(
-								"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1",
-							)
+							var output string
+							if pack.Supports("config run-image-mirrors") {
+								output = pack.RunSuccessfully(
+									"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
+							} else {
+								output = pack.RunSuccessfully(
+									"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
+							}
+
 							assert.Equal(output, "Run Image 'pack-test/run' configured with mirror 'some-registry.com/pack-test/run1'\n")
 
 							output = pack.RunSuccessfully("inspect-builder", builderName, "--output", "yaml")
@@ -2068,9 +2094,15 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 								"inspect-builder output format is not yet implemented",
 							)
 
-							output := pack.RunSuccessfully(
-								"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1",
-							)
+							var output string
+							if pack.Supports("config run-image-mirrors") {
+								output = pack.RunSuccessfully(
+									"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
+							} else {
+								output = pack.RunSuccessfully(
+									"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
+							}
+
 							assert.Equal(output, "Run Image 'pack-test/run' configured with mirror 'some-registry.com/pack-test/run1'\n")
 
 							output = pack.RunSuccessfully("inspect-builder", builderName, "--output", "json")
@@ -2109,9 +2141,17 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 				})
 
 				it("displays configuration for a builder (local and remote)", func() {
-					output := pack.RunSuccessfully(
-						"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1",
-					)
+					var output string
+					if pack.Supports("config run-image-mirrors") {
+						output = pack.RunSuccessfully(
+							"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1",
+						)
+					} else {
+						output = pack.RunSuccessfully(
+							"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1",
+						)
+					}
+
 					assert.Equal(output, "Run Image 'pack-test/run' configured with mirror 'some-registry.com/pack-test/run1'\n")
 
 					output = pack.RunSuccessfully("inspect-builder", builderName)
@@ -2152,9 +2192,15 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 						pack.JustRunSuccessfully("trust-builder", builderName)
 					}
 
-					pack.JustRunSuccessfully(
-						"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1",
-					)
+					if pack.Supports("config run-image-mirrors") {
+						pack.JustRunSuccessfully(
+							"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1",
+						)
+					} else {
+						pack.JustRunSuccessfully(
+							"set-run-image-mirrors", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1",
+						)
+					}
 
 					output := pack.RunSuccessfully("inspect-builder", builderName)
 
@@ -2283,7 +2329,11 @@ include = [ "*.jar", "media/mountain.jpg", "media/person.png" ]
 						it.Before(func() {
 							localRunImageMirror = registryConfig.RepoName("run-after/" + h.RandString(10))
 							buildRunImage(localRunImageMirror, "local-mirror-after-1", "local-mirror-after-2")
-							pack.JustRunSuccessfully("set-run-image-mirrors", runImage, "-m", localRunImageMirror)
+							if pack.Supports("config run-image-mirrors") {
+								pack.JustRunSuccessfully("config", "run-image-mirrors", "add", runImage, "-m", localRunImageMirror)
+							} else {
+								pack.JustRunSuccessfully("set-run-image-mirrors", runImage, "-m", localRunImageMirror)
+							}
 						})
 
 						it.After(func() {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -69,6 +69,7 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 
 	rootCmd.AddCommand(commands.InspectImage(logger, imagewriter.NewFactory(), cfg, &packClient))
 	rootCmd.AddCommand(commands.InspectBuildpack(logger, &cfg, &packClient))
+	//nolint:staticcheck
 	rootCmd.AddCommand(commands.SetRunImagesMirrors(logger, cfg))
 
 	rootCmd.AddCommand(commands.SetDefaultBuilder(logger, cfg, &packClient))

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -17,6 +17,7 @@ func NewConfigCommand(logger logging.Logger, cfg config.Config, cfgPath string) 
 	}
 
 	cmd.AddCommand(trustedBuilder(logger, cfg, cfgPath))
+	cmd.AddCommand(ConfigRunImagesMirrors(logger, cfg, cfgPath))
 	return cmd
 }
 
@@ -48,14 +49,14 @@ func generateRemove(cmdName string, logger logging.Logger, cfg config.Config, cf
 	return cmd
 }
 
-type listFunc func(logger logging.Logger, cfg config.Config)
+type listFunc func(args []string, logger logging.Logger, cfg config.Config)
 
 func generateListCmd(cmdName string, logger logging.Logger, cfg config.Config, listFunc listFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: fmt.Sprintf("List %s", cmdName),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			listFunc(logger, cfg)
+			listFunc(args, logger, cfg)
 			return nil
 		}),
 	}

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -18,6 +18,8 @@ func NewConfigCommand(logger logging.Logger, cfg config.Config, cfgPath string) 
 
 	cmd.AddCommand(trustedBuilder(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigRunImagesMirrors(logger, cfg, cfgPath))
+
+	AddHelpFlag(cmd, "config")
 	return cmd
 }
 
@@ -54,6 +56,7 @@ type listFunc func(args []string, logger logging.Logger, cfg config.Config)
 func generateListCmd(cmdName string, logger logging.Logger, cfg config.Config, listFunc listFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
+		Args:  cobra.MaximumNArgs(1),
 		Short: fmt.Sprintf("List %s", cmdName),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			listFunc(args, logger, cfg)

--- a/internal/commands/config_run_image_mirrors.go
+++ b/internal/commands/config_run_image_mirrors.go
@@ -1,0 +1,148 @@
+package commands
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/internal/stringset"
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
+)
+
+var mirrors []string
+
+func ConfigRunImagesMirrors(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "run-image-mirrors",
+		Args: cobra.MaximumNArgs(3),
+		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			listRunImageMirror(args, logger, cfg)
+			return nil
+		}),
+	}
+
+	addCmd := generateAdd(cmd.Use, logger, cfg, cfgPath, addRunImageMirror)
+	addCmd.Long = "Set mirrors to other repositories for a given run image"
+	addCmd.Example = "pack set-run-image-mirrors cnbs/sample-stack-run:bionic --mirror index.docker.io/cnbs/sample-stack-run:bionic"
+	addCmd.Flags().StringSliceVarP(&mirrors, "mirror", "m", nil, "Run image mirror"+multiValueHelp("mirror"))
+	cmd.AddCommand(addCmd)
+
+	rmCmd := generateRemove(cmd.Use, logger, cfg, cfgPath, removeRunImageMirror)
+	rmCmd.Flags().StringSliceVarP(&mirrors, "mirror", "m", nil, "Run image mirror"+multiValueHelp("mirror"))
+	cmd.AddCommand(rmCmd)
+
+	listCmd := generateListCmd(cmd.Use, logger, cfg, listRunImageMirror)
+	cmd.AddCommand(listCmd)
+
+	AddHelpFlag(cmd, "run-image-mirrors")
+	return cmd
+}
+
+func addRunImageMirror(args []string, logger logging.Logger, cfg config.Config, cfgPath string) error {
+	runImage := args[0]
+	if len(mirrors) == 0 {
+		logger.Infof("No run image mirrors were provided. To remove a run image mirror, use `pack config run-image-mirrors remove`")
+		return nil
+	}
+
+	newMirrors := mirrors
+	for _, image := range cfg.RunImages {
+		if image.Image == runImage {
+			newMirrors = append(newMirrors, image.Mirrors...)
+			break
+		}
+	}
+
+	cfg = config.SetRunImageMirrors(cfg, runImage, dedupAndSortSlice(newMirrors))
+	if err := config.Write(cfg, cfgPath); err != nil {
+		return errors.Wrapf(err, "failed to write to %s", cfgPath)
+	}
+
+	for _, mirror := range mirrors {
+		logger.Infof("Run Image %s configured with mirror %s", style.Symbol(runImage), style.Symbol(mirror))
+	}
+	return nil
+}
+
+func removeRunImageMirror(args []string, logger logging.Logger, cfg config.Config, cfgPath string) error {
+	image := args[0]
+
+	idx := -1
+	for i, runImage := range cfg.RunImages {
+		if runImage.Image == image {
+			idx = i
+		}
+	}
+
+	if idx == -1 || len(cfg.RunImages) == 0 {
+		// Run Image wasn't found
+		logger.Infof("No run image mirrors have been set for %s", style.Symbol(image))
+		return nil
+	}
+
+	if len(mirrors) == 0 {
+		lastImageIdx := len(cfg.RunImages) - 1
+		cfg.RunImages[idx] = cfg.RunImages[lastImageIdx]
+		cfg.RunImages = cfg.RunImages[:lastImageIdx]
+	} else {
+		mirrorsMap := stringset.FromSlice(mirrors)
+		var newMirrors []string
+		for _, currMirror := range cfg.RunImages[idx].Mirrors {
+			if _, ok := mirrorsMap[currMirror]; !ok {
+				newMirrors = append(newMirrors, currMirror)
+			}
+		}
+
+		cfg = config.SetRunImageMirrors(cfg, image, newMirrors)
+	}
+
+	if err := config.Write(cfg, cfgPath); err != nil {
+		return errors.Wrapf(err, "failed to write to %s", cfgPath)
+	}
+	return nil
+}
+
+func listRunImageMirror(args []string, logger logging.Logger, cfg config.Config) {
+	var (
+		reqImage string
+		found    = false
+	)
+
+	if len(args) > 0 {
+		reqImage = args[0]
+	}
+
+	logger.Info("Run Image Mirrors:")
+	for _, runImage := range cfg.RunImages {
+		if (reqImage != "" && runImage.Image == reqImage) || reqImage == "" {
+			found = true
+			logger.Info("Run Image Mirrors:")
+			logger.Infof("  %s:", style.Symbol(runImage.Image))
+			for _, mirror := range runImage.Mirrors {
+				logger.Infof("    %s", mirror)
+			}
+		}
+	}
+
+	if !found {
+		suffix := ""
+		if reqImage != "" {
+			suffix = fmt.Sprintf("for %s", style.Symbol(reqImage))
+		}
+		logger.Infof("No run image mirrors have been set %s", suffix)
+	}
+}
+
+func dedupAndSortSlice(slice []string) []string {
+	set := stringset.FromSlice(slice)
+	var newSlice []string
+	for s := range set {
+		newSlice = append(newSlice, s)
+	}
+	sort.Strings(newSlice)
+	return newSlice
+}

--- a/internal/commands/config_run_image_mirrors.go
+++ b/internal/commands/config_run_image_mirrors.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -17,25 +18,34 @@ var mirrors []string
 
 func ConfigRunImagesMirrors(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  "run-image-mirrors",
-		Args: cobra.MaximumNArgs(3),
+		Use:   "run-image-mirrors",
+		Short: "Interact with run image mirrors",
+		Args:  cobra.MaximumNArgs(3),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			listRunImageMirror(args, logger, cfg)
 			return nil
 		}),
 	}
 
-	addCmd := generateAdd(cmd.Use, logger, cfg, cfgPath, addRunImageMirror)
+	addCmd := generateAdd("mirror for a run image", logger, cfg, cfgPath, addRunImageMirror)
+	addCmd.Use = "add <image> [-m <mirror...]"
 	addCmd.Long = "Set mirrors to other repositories for a given run image"
-	addCmd.Example = "pack set-run-image-mirrors cnbs/sample-stack-run:bionic --mirror index.docker.io/cnbs/sample-stack-run:bionic"
+	addCmd.Example = "pack config run-image-mirrors add cnbs/sample-stack-run:bionic --mirror index.docker.io/cnbs/sample-stack-run:bionic --mirror gcr.io/cnbs/sample-stack-run:bionic"
 	addCmd.Flags().StringSliceVarP(&mirrors, "mirror", "m", nil, "Run image mirror"+multiValueHelp("mirror"))
 	cmd.AddCommand(addCmd)
 
-	rmCmd := generateRemove(cmd.Use, logger, cfg, cfgPath, removeRunImageMirror)
+	rmCmd := generateRemove("mirror for a run image", logger, cfg, cfgPath, removeRunImageMirror)
+	rmCmd.Use = "remove <image> [-m <mirror...]"
+	rmCmd.Long = "Remove mirrors for a given run image. If specific mirrors are passed, they will be removed. " +
+		"If no mirrors are provided, all mirrors for the given run image will be removed from the config."
+	rmCmd.Example = "pack config run-image-mirrors remove cnbs/sample-stack-run:bionic"
 	rmCmd.Flags().StringSliceVarP(&mirrors, "mirror", "m", nil, "Run image mirror"+multiValueHelp("mirror"))
 	cmd.AddCommand(rmCmd)
 
 	listCmd := generateListCmd(cmd.Use, logger, cfg, listRunImageMirror)
+	listCmd.Long = "List all run image mirrors. If a run image is provided, it will return "
+	listCmd.Use = "list [<run-image>]"
+	listCmd.Example = "pack config run-image-mirrors list"
 	cmd.AddCommand(listCmd)
 
 	AddHelpFlag(cmd, "run-image-mirrors")
@@ -45,7 +55,7 @@ func ConfigRunImagesMirrors(logger logging.Logger, cfg config.Config, cfgPath st
 func addRunImageMirror(args []string, logger logging.Logger, cfg config.Config, cfgPath string) error {
 	runImage := args[0]
 	if len(mirrors) == 0 {
-		logger.Infof("No run image mirrors were provided. To remove a run image mirror, use `pack config run-image-mirrors remove`")
+		logger.Infof("No run image mirrors were provided.")
 		return nil
 	}
 
@@ -84,25 +94,31 @@ func removeRunImageMirror(args []string, logger logging.Logger, cfg config.Confi
 		return nil
 	}
 
-	if len(mirrors) == 0 {
+	mirrorsMap := stringset.FromSlice(mirrors)
+	var newMirrors []string
+	for _, currMirror := range cfg.RunImages[idx].Mirrors {
+		if _, ok := mirrorsMap[currMirror]; !ok {
+			newMirrors = append(newMirrors, currMirror)
+		}
+	}
+
+	if len(newMirrors) == 0 || len(mirrors) == 0 {
 		lastImageIdx := len(cfg.RunImages) - 1
 		cfg.RunImages[idx] = cfg.RunImages[lastImageIdx]
 		cfg.RunImages = cfg.RunImages[:lastImageIdx]
 	} else {
-		mirrorsMap := stringset.FromSlice(mirrors)
-		var newMirrors []string
-		for _, currMirror := range cfg.RunImages[idx].Mirrors {
-			if _, ok := mirrorsMap[currMirror]; !ok {
-				newMirrors = append(newMirrors, currMirror)
-			}
-		}
-
 		cfg = config.SetRunImageMirrors(cfg, image, newMirrors)
 	}
 
 	if err := config.Write(cfg, cfgPath); err != nil {
 		return errors.Wrapf(err, "failed to write to %s", cfgPath)
 	}
+	if len(mirrors) == 0 {
+		logger.Infof("Removed all run image mirrors for %s", style.Symbol(image))
+	} else {
+		logger.Infof("Removed mirrors %s for %s", strings.Join(mirrors, ", "), style.Symbol(image))
+	}
+
 	return nil
 }
 
@@ -116,14 +132,14 @@ func listRunImageMirror(args []string, logger logging.Logger, cfg config.Config)
 		reqImage = args[0]
 	}
 
-	logger.Info("Run Image Mirrors:")
+	buf := strings.Builder{}
+	buf.WriteString("Run Image Mirrors:\n")
 	for _, runImage := range cfg.RunImages {
 		if (reqImage != "" && runImage.Image == reqImage) || reqImage == "" {
 			found = true
-			logger.Info("Run Image Mirrors:")
-			logger.Infof("  %s:", style.Symbol(runImage.Image))
+			buf.WriteString(fmt.Sprintf("  %s:\n", style.Symbol(runImage.Image)))
 			for _, mirror := range runImage.Mirrors {
-				logger.Infof("    %s", mirror)
+				buf.WriteString(fmt.Sprintf("    %s\n", mirror))
 			}
 		}
 	}
@@ -134,6 +150,8 @@ func listRunImageMirror(args []string, logger logging.Logger, cfg config.Config)
 			suffix = fmt.Sprintf("for %s", style.Symbol(reqImage))
 		}
 		logger.Infof("No run image mirrors have been set %s", suffix)
+	} else {
+		logger.Info(buf.String())
 	}
 }
 

--- a/internal/commands/config_run_image_mirrors_test.go
+++ b/internal/commands/config_run_image_mirrors_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/heroku/color"
@@ -85,9 +86,10 @@ func testConfigRunImageMirrorsCommand(t *testing.T, when spec.G, it spec.S) {
 			cmd.SetArgs([]string{})
 			h.AssertNil(t, cmd.Execute())
 			output := outBuf.String()
-			h.AssertContains(t, output, runImage)
-			h.AssertContains(t, output, testMirror1)
-			h.AssertContains(t, output, testMirror2)
+			h.AssertEq(t, strings.TrimSpace(output), `Run Image Mirrors:
+  'test/image':
+    example.com/some/run1
+    example.com/some/run2`)
 		})
 	})
 
@@ -174,6 +176,14 @@ func testConfigRunImageMirrorsCommand(t *testing.T, when spec.G, it spec.S) {
 					Image:   runImage,
 					Mirrors: []string{testMirror1},
 				}})
+			})
+
+			it("removes the image if all mirrors are removed", func() {
+				cmd.SetArgs([]string{"remove", runImage, "-m", testMirror1, "-m", testMirror2})
+				h.AssertNil(t, cmd.Execute())
+				cfg, err := config.Read(configPath)
+				h.AssertNil(t, err)
+				h.AssertEq(t, cfg.RunImages, []config.RunImage{})
 			})
 		})
 

--- a/internal/commands/config_run_image_mirrors_test.go
+++ b/internal/commands/config_run_image_mirrors_test.go
@@ -1,0 +1,258 @@
+package commands_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/commands"
+	"github.com/buildpacks/pack/internal/config"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestConfigRunImageMirrors(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "ConfigRunImageMirrorsCommand", testConfigRunImageMirrorsCommand, spec.Random(), spec.Report(report.Terminal{}))
+}
+
+func testConfigRunImageMirrorsCommand(t *testing.T, when spec.G, it spec.S) {
+	var (
+		cmd          *cobra.Command
+		logger       logging.Logger
+		outBuf       bytes.Buffer
+		tempPackHome string
+		configPath   string
+		runImage     = "test/image"
+		testMirror1  = "example.com/some/run1"
+		testMirror2  = "example.com/some/run2"
+		testCfg      = config.Config{
+			Experimental: true,
+			RunImages: []config.RunImage{{
+				Image:   runImage,
+				Mirrors: []string{testMirror1, testMirror2},
+			}},
+		}
+		expandedCfg = config.Config{
+			Experimental: true,
+			RunImages: append(testCfg.RunImages, config.RunImage{
+				Image:   "new-image",
+				Mirrors: []string{"some-mirror1", "some-mirror2"},
+			}),
+		}
+	)
+
+	it.Before(func() {
+		var err error
+		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		h.AssertNil(t, err)
+		configPath = filepath.Join(tempPackHome, "config.toml")
+
+		cmd = commands.ConfigRunImagesMirrors(logger, testCfg, configPath)
+		cmd.SetOut(logging.GetWriterForLevel(logger, logging.InfoLevel))
+	})
+
+	it.After(func() {
+		h.AssertNil(t, os.RemoveAll(tempPackHome))
+	})
+
+	when("-h", func() {
+		it("prints available commands", func() {
+			cmd.SetArgs([]string{"-h"})
+			h.AssertNil(t, cmd.Execute())
+			output := outBuf.String()
+			h.AssertContains(t, output, "Usage:")
+			for _, command := range []string{"add", "remove", "list"} {
+				h.AssertContains(t, output, command)
+			}
+		})
+	})
+
+	when("no arguments", func() {
+		it("lists run image mirrors", func() {
+			cmd.SetArgs([]string{})
+			h.AssertNil(t, cmd.Execute())
+			output := outBuf.String()
+			h.AssertContains(t, output, runImage)
+			h.AssertContains(t, output, testMirror1)
+			h.AssertContains(t, output, testMirror2)
+		})
+	})
+
+	when("add", func() {
+		when("no run image is specified", func() {
+			it("fails to run", func() {
+				cmd.SetArgs([]string{"add"})
+				err := cmd.Execute()
+				h.AssertError(t, err, "accepts 1 arg")
+			})
+		})
+
+		when("config path doesn't exist", func() {
+			it("fails to run", func() {
+				fakePath := filepath.Join(tempPackHome, "not-exist.toml")
+				h.AssertNil(t, ioutil.WriteFile(fakePath, []byte("something"), 0001))
+				cmd = commands.ConfigRunImagesMirrors(logger, config.Config{}, fakePath)
+				cmd.SetArgs([]string{"add", runImage, "-m", testMirror1})
+
+				err := cmd.Execute()
+				h.AssertError(t, err, "failed to write to")
+			})
+		})
+
+		when("mirrors are provided", func() {
+			it("adds them as mirrors to the config", func() {
+				cmd.SetArgs([]string{"add", runImage, "-m", testMirror1, "-m", testMirror2})
+				h.AssertNil(t, cmd.Execute())
+				cfg, err := config.Read(configPath)
+				h.AssertNil(t, err)
+				h.AssertEq(t, cfg, testCfg)
+				//This ensures that there are no dups
+				h.AssertEq(t, len(cfg.RunImages[0].Mirrors), 2)
+			})
+		})
+
+		when("no mirrors are provided", func() {
+			it("preserves old mirrors, and prints helpful message", func() {
+				cmd.SetArgs([]string{"add", runImage})
+				h.AssertNil(t, cmd.Execute())
+				h.AssertContains(t, outBuf.String(), "No run image mirrors were provided")
+			})
+		})
+	})
+
+	when("remove", func() {
+		when("no run image is specified", func() {
+			it("fails to run", func() {
+				cmd.SetArgs([]string{"remove"})
+				err := cmd.Execute()
+				h.AssertError(t, err, "accepts 1 arg")
+			})
+		})
+
+		when("run image provided isn't present", func() {
+			it("prints a clear message", func() {
+				fakeImage := "not-set-image"
+				cmd.SetArgs([]string{"remove", fakeImage})
+				h.AssertNil(t, cmd.Execute())
+				output := outBuf.String()
+				h.AssertContains(t, output, fmt.Sprintf("No run image mirrors have been set for %s", style.Symbol(fakeImage)))
+			})
+		})
+
+		when("config path doesn't exist", func() {
+			it("fails to run", func() {
+				fakePath := filepath.Join(tempPackHome, "not-exist.toml")
+				h.AssertNil(t, ioutil.WriteFile(fakePath, []byte("something"), 0001))
+				cmd = commands.ConfigRunImagesMirrors(logger, testCfg, fakePath)
+				cmd.SetArgs([]string{"remove", runImage, "-m", testMirror1})
+
+				err := cmd.Execute()
+				h.AssertError(t, err, "failed to write to")
+			})
+		})
+
+		when("mirrors are provided", func() {
+			it("removes them for the given run image", func() {
+				cmd.SetArgs([]string{"remove", runImage, "-m", testMirror2})
+				h.AssertNil(t, cmd.Execute())
+				cfg, err := config.Read(configPath)
+				h.AssertNil(t, err)
+				h.AssertEq(t, cfg.RunImages, []config.RunImage{{
+					Image:   runImage,
+					Mirrors: []string{testMirror1},
+				}})
+			})
+		})
+
+		when("no mirrors are provided", func() {
+			it("removes all mirrors for the given run image", func() {
+				cmd.SetArgs([]string{"remove", runImage})
+				h.AssertNil(t, cmd.Execute())
+
+				cfg, err := config.Read(configPath)
+				h.AssertNil(t, err)
+				h.AssertEq(t, cfg.Experimental, testCfg.Experimental)
+				h.AssertEq(t, cfg.RunImages, []config.RunImage{})
+			})
+
+			it("preserves all mirrors aside from the given run image", func() {
+				cmd = commands.ConfigRunImagesMirrors(logger, expandedCfg, configPath)
+				cmd.SetArgs([]string{"remove", runImage})
+				h.AssertNil(t, cmd.Execute())
+
+				cfg, err := config.Read(configPath)
+				h.AssertNil(t, err)
+				h.AssertEq(t, cfg.Experimental, testCfg.Experimental)
+				h.AssertNotEq(t, cfg.RunImages, []config.RunImage{})
+				h.AssertEq(t, cfg.RunImages, []config.RunImage{expandedCfg.RunImages[1]})
+			})
+		})
+	})
+
+	when("list", func() {
+		when("mirrors were previously set", func() {
+			it("lists run image mirrors", func() {
+				cmd.SetArgs([]string{"list"})
+				h.AssertNil(t, cmd.Execute())
+				output := outBuf.String()
+				h.AssertContains(t, output, runImage)
+				h.AssertContains(t, output, testMirror1)
+				h.AssertContains(t, output, testMirror2)
+			})
+		})
+
+		when("no run image mirrors were set", func() {
+			it("prints a clear message", func() {
+				cmd = commands.ConfigRunImagesMirrors(logger, config.Config{}, configPath)
+				cmd.SetArgs([]string{"list"})
+				h.AssertNil(t, cmd.Execute())
+				output := outBuf.String()
+				h.AssertNotContains(t, output, runImage)
+				h.AssertNotContains(t, output, testMirror1)
+
+				h.AssertContains(t, output, "No run image mirrors have been set")
+			})
+		})
+
+		when("run image provided", func() {
+			when("mirrors are set", func() {
+				it("returns image mirrors", func() {
+					cmd = commands.ConfigRunImagesMirrors(logger, expandedCfg, configPath)
+					cmd.SetArgs([]string{"list", "new-image"})
+					h.AssertNil(t, cmd.Execute())
+					output := outBuf.String()
+					h.AssertNotContains(t, output, runImage)
+					h.AssertNotContains(t, output, testMirror1)
+					h.AssertContains(t, output, "new-image")
+					h.AssertContains(t, output, "some-mirror1")
+					h.AssertContains(t, output, "some-mirror2")
+				})
+			})
+
+			when("mirrors aren't set", func() {
+				it("prints a clear message", func() {
+					fakeImage := "not-set-image"
+					cmd.SetArgs([]string{"list", fakeImage})
+					h.AssertNil(t, cmd.Execute())
+					output := outBuf.String()
+					h.AssertNotContains(t, output, runImage)
+					h.AssertNotContains(t, output, testMirror1)
+					h.AssertContains(t, output, fmt.Sprintf("No run image mirrors have been set for %s", style.Symbol(fakeImage)))
+				})
+			})
+		})
+	})
+}

--- a/internal/commands/config_test.go
+++ b/internal/commands/config_test.go
@@ -57,6 +57,9 @@ func testConfigCommand(t *testing.T, when spec.G, it spec.S) {
 			output := outBuf.String()
 			h.AssertContains(t, output, "Interact with Pack's configuration")
 			h.AssertContains(t, output, "Usage:")
+			for _, command := range []string{"trusted-builders", "run-image-mirrors"} {
+				h.AssertContains(t, output, command)
+			}
 		})
 	})
 

--- a/internal/commands/config_trusted_builder.go
+++ b/internal/commands/config_trusted_builder.go
@@ -17,7 +17,7 @@ func trustedBuilder(logger logging.Logger, cfg config.Config, cfgPath string) *c
 		Short:   "Interact with trusted builders",
 		Aliases: []string{"trusted-builder"},
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			listTrustedBuilders(logger, cfg)
+			listTrustedBuilders(args, logger, cfg)
 			return nil
 		}),
 	}
@@ -36,6 +36,8 @@ func trustedBuilder(logger logging.Logger, cfg config.Config, cfgPath string) *c
 	listCmd.Long = "List Trusted Builders.\n\nShow the builders that are either trusted by default or have been explicitly trusted locally using `trust-builder`"
 	listCmd.Example = "pack config trusted-builders list"
 	cmd.AddCommand(listCmd)
+
+	AddHelpFlag(cmd, "trusted-builders")
 	return cmd
 }
 
@@ -90,7 +92,7 @@ func removeTrustedBuilder(args []string, logger logging.Logger, cfg config.Confi
 	return nil
 }
 
-func listTrustedBuilders(logger logging.Logger, cfg config.Config) {
+func listTrustedBuilders(args []string, logger logging.Logger, cfg config.Config) {
 	logger.Info("Trusted Builders:")
 
 	var trustedBuilders []string

--- a/internal/commands/list_registries_test.go
+++ b/internal/commands/list_registries_test.go
@@ -22,7 +22,7 @@ func TestListRegistries(t *testing.T) {
 	color.Disable(true)
 	defer color.Disable(false)
 
-	spec.Run(t, "Commands", testListRegistriesCommand, spec.Parallel(), spec.Report(report.Terminal{}))
+	spec.Run(t, "ListRegistriesCommand", testListRegistriesCommand, spec.Parallel(), spec.Report(report.Terminal{}))
 }
 
 func testListRegistriesCommand(t *testing.T, when spec.G, it spec.S) {

--- a/internal/commands/list_trusted_builders.go
+++ b/internal/commands/list_trusted_builders.go
@@ -17,7 +17,7 @@ func ListTrustedBuilders(logger logging.Logger, cfg config.Config) *cobra.Comman
 		Hidden:  true,
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			deprecationWarning(logger, "list-trusted-builders", "config trusted-builders list")
-			listTrustedBuilders(logger, cfg)
+			listTrustedBuilders(args, logger, cfg)
 			return nil
 		}),
 	}

--- a/internal/commands/set_run_image_mirrors.go
+++ b/internal/commands/set_run_image_mirrors.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildpacks/pack/logging"
 )
 
+// Deprecated: Use `pack config run-image-mirrors add` instead
 // SetRunImagesMirrors sets run image mirros for a given run image
 func SetRunImagesMirrors(logger logging.Logger, cfg config.Config) *cobra.Command {
 	var mirrors []string
@@ -16,6 +17,7 @@ func SetRunImagesMirrors(logger logging.Logger, cfg config.Config) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:     "set-run-image-mirrors <run-image-name> --mirror <run-image-mirror>",
 		Args:    cobra.ExactArgs(1),
+		Hidden:  true,
 		Short:   "Set mirrors to other repositories for a given run image",
 		Example: "pack set-run-image-mirrors cnbs/sample-stack-run:bionic --mirror index.docker.io/cnbs/sample-stack-run:bionic",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This adds a new subcommand `run-image-mirrors` to the `pack config` subcommand, with 3 further commands:
* `pack config run-image-mirrors add`
* `pack config run-image-mirrors remove`
* `pack config run-image-mirrors list`

This maps and hides `pack set-run-image-mirrors`

I changed the behavior for `pack set-run-image-mirrors`/`pack config run-image-mirrors add`. Formerly, it overwrote the previously set values for the `runImage` you want to save. Now, we append, dedup and sort the mirrors. (I thought that it made more sense, but not a hill I will 👊  on)

I debated adding explicit acceptance tests for the methods, but since they are self-contained, I felt that they were well covered through the unit tests. 

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #922 
Relates to #597
