### PR TITLE
Add pack config default-builder subcommand

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -167,16 +167,16 @@ func testWithoutSpecificBuilderRequirement(
 		})
 	})
 
-	when("set-default-builder", func() {
-		it("sets the default-stack-id in ~/.pack/config.toml", func() {
-			builderName := "paketobuildpacks/builder:base"
-			output := pack.RunSuccessfully("set-default-builder", builderName)
-
-			assertions.NewOutputAssertionManager(t, output).ReportsSettingDefaultBuilder(builderName)
-		})
-	})
-
 	when("pack config", func() {
+		when("default-builder", func() {
+			it("sets the default builder in ~/.pack/config.toml", func() {
+				builderName := "paketobuildpacks/builder:base"
+				output := pack.RunSuccessfully("config", "default-builder", builderName)
+
+				assertions.NewOutputAssertionManager(t, output).ReportsSettingDefaultBuilder(builderName)
+			})
+		})
+
 		when("trusted-builders", func() {
 			it("prints list of trusted builders", func() {
 				output := pack.RunSuccessfully("config", "trusted-builders")
@@ -573,7 +573,11 @@ func testWithoutSpecificBuilderRequirement(
 
 		when("default builder is set", func() {
 			it("redacts default builder", func() {
-				pack.RunSuccessfully("set-default-builder", "paketobuildpacks/builder:base")
+				if pack.Supports("config default-builder") {
+					pack.RunSuccessfully("config", "default-builder", "paketobuildpacks/builder:base")
+				} else {
+					pack.RunSuccessfully("set-default-builder", "paketobuildpacks/builder:base")
+				}
 
 				output := pack.RunSuccessfully("report")
 
@@ -592,7 +596,11 @@ func testWithoutSpecificBuilderRequirement(
 			})
 
 			it("explicit mode doesn't redact", func() {
-				pack.RunSuccessfully("set-default-builder", "paketobuildpacks/builder:base")
+				if pack.Supports("config default-builder") {
+					pack.RunSuccessfully("config", "default-builder", "paketobuildpacks/builder:base")
+				} else {
+					pack.RunSuccessfully("set-default-builder", "paketobuildpacks/builder:base")
+				}
 
 				output := pack.RunSuccessfully("report", "--explicit")
 
@@ -913,7 +921,11 @@ func testAcceptance(
 					var usingCreator bool
 
 					it.Before(func() {
-						pack.JustRunSuccessfully("set-default-builder", builderName)
+						if pack.Supports("config default-builder") {
+							pack.RunSuccessfully("config", "default-builder", builderName)
+						} else {
+							pack.RunSuccessfully("set-default-builder", builderName)
+						}
 
 						if pack.Supports("config trusted-builders add") {
 							pack.JustRunSuccessfully("config", "trusted-builders", "add", builderName)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -84,7 +84,7 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	rootCmd.AddCommand(commands.SuggestStacks(logger))
 
 	rootCmd.AddCommand(commands.Version(logger, pack.Version))
-	rootCmd.AddCommand(commands.Report(logger, pack.Version))
+	rootCmd.AddCommand(commands.Report(logger, pack.Version, cfgPath))
 
 	if cfg.Experimental {
 		rootCmd.AddCommand(commands.AddBuildpackRegistry(logger, cfg, cfgPath))
@@ -102,7 +102,7 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 
 	rootCmd.AddCommand(commands.CompletionCommand(logger, packHome))
 
-	rootCmd.AddCommand(commands.NewConfigCommand(logger, cfg, cfgPath))
+	rootCmd.AddCommand(commands.NewConfigCommand(logger, cfg, cfgPath, &packClient))
 	rootCmd.AddCommand(commands.NewStackCommand(logger))
 	rootCmd.AddCommand(commands.NewBuilderCommand(logger, cfg, &packClient))
 

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -9,16 +9,17 @@ import (
 	"github.com/buildpacks/pack/logging"
 )
 
-func NewConfigCommand(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
+func NewConfigCommand(logger logging.Logger, cfg config.Config, cfgPath string, client PackClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Interact with Pack's configuration",
 		RunE:  nil,
 	}
 
-	cmd.AddCommand(trustedBuilder(logger, cfg, cfgPath))
-	cmd.AddCommand(ConfigRunImagesMirrors(logger, cfg, cfgPath))
+	cmd.AddCommand(ConfigDefaultBuilder(logger, cfg, cfgPath, client))
 	cmd.AddCommand(ConfigExperimental(logger, cfg, cfgPath))
+	cmd.AddCommand(ConfigTrustedBuilder(logger, cfg, cfgPath))
+	cmd.AddCommand(ConfigRunImagesMirrors(logger, cfg, cfgPath))
 
 	if cfg.Experimental {
 		cmd.AddCommand(ConfigRegistries(logger, cfg, cfgPath))

--- a/internal/commands/config_default_builder.go
+++ b/internal/commands/config_default_builder.go
@@ -1,0 +1,91 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
+)
+
+var suggestedBuilderString = "For suggested builders, run `pack builder suggest`."
+
+func ConfigDefaultBuilder(logger logging.Logger, cfg config.Config, cfgPath string, client PackClient) *cobra.Command {
+	var unset bool
+
+	cmd := &cobra.Command{
+		Use:   "default-builder",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "List, set and unset the default builder used by other commands",
+		Long: "List, set, and unset the default builder used by other commands.\n\n" +
+			"* To list your default builder, run `pack config default-builder`.\n" +
+			"* To set your default builder, run `pack config default-builder <builder-name>`.\n" +
+			"* To unset your default builder, run `pack config default-builder --unset`.\n\n" +
+			suggestedBuilderString,
+		Example: "pack config default-builder cnbs/sample-builder:bionic",
+		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			switch {
+			case unset:
+				if cfg.DefaultBuilder == "" {
+					logger.Info("No default builder was set")
+				} else {
+					oldBuilder := cfg.DefaultBuilder
+					cfg.DefaultBuilder = ""
+					if err := config.Write(cfg, cfgPath); err != nil {
+						return errors.Wrapf(err, "failed to write to config at %s", cfgPath)
+					}
+					logger.Infof("Successfully unset default builder %s", style.Symbol(oldBuilder))
+				}
+			case len(args) == 0:
+				if cfg.DefaultBuilder != "" {
+					logger.Infof("The current default builder is %s", style.Symbol(cfg.DefaultBuilder))
+				} else {
+					logger.Infof("No default builder is set. \n\n%s", suggestedBuilderString)
+				}
+				return nil
+			default:
+				imageName := args[0]
+				if err := validateBuilderExists(logger, imageName, client); err != nil {
+					return errors.Wrapf(err, "validating that builder %s exists", style.Symbol(imageName))
+				}
+
+				cfg.DefaultBuilder = imageName
+				if err := config.Write(cfg, cfgPath); err != nil {
+					return errors.Wrapf(err, "failed to write to config at %s", cfgPath)
+				}
+				logger.Infof("Builder %s is now the default builder", style.Symbol(imageName))
+			}
+
+			return nil
+		}),
+	}
+
+	cmd.Flags().BoolVarP(&unset, "unset", "u", false, "Unset the current default builder")
+	AddHelpFlag(cmd, "config default-builder")
+	return cmd
+}
+
+func validateBuilderExists(logger logging.Logger, imageName string, client PackClient) error {
+	logger.Debug("Verifying local image...")
+	info, err := client.InspectBuilder(imageName, true)
+	if err != nil {
+		return err
+	}
+
+	if info == nil {
+		logger.Debug("Verifying remote image...")
+		info, err := client.InspectBuilder(imageName, false)
+		if err != nil {
+			return errors.Wrapf(err, "failed to inspect remote image %s", style.Symbol(imageName))
+		}
+
+		if info == nil {
+			return fmt.Errorf("builder %s not found", style.Symbol(imageName))
+		}
+	}
+
+	return nil
+}

--- a/internal/commands/config_default_builder_test.go
+++ b/internal/commands/config_default_builder_test.go
@@ -1,0 +1,204 @@
+package commands_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack"
+	"github.com/buildpacks/pack/internal/commands"
+	"github.com/buildpacks/pack/internal/commands/testmocks"
+	"github.com/buildpacks/pack/internal/config"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestConfigDefaultBuilder(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "ConfigDefaultBuilderCommand", testConfigDefaultBuilder, spec.Random(), spec.Report(report.Terminal{}))
+}
+
+func testConfigDefaultBuilder(t *testing.T, when spec.G, it spec.S) {
+	var (
+		cmd            *cobra.Command
+		logger         logging.Logger
+		outBuf         bytes.Buffer
+		mockController *gomock.Controller
+		mockClient     *testmocks.MockPackClient
+		tempPackHome   string
+		configPath     string
+	)
+
+	it.Before(func() {
+		var err error
+
+		mockController = gomock.NewController(t)
+		mockClient = testmocks.NewMockPackClient(mockController)
+		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		h.AssertNil(t, err)
+		configPath = filepath.Join(tempPackHome, "config.toml")
+		cmd = commands.ConfigDefaultBuilder(logger, config.Config{}, configPath, mockClient)
+	})
+
+	it.After(func() {
+		mockController.Finish()
+		h.AssertNil(t, os.RemoveAll(tempPackHome))
+	})
+
+	when("#ConfigDefaultBuilder", func() {
+		when("no args", func() {
+			it("lists current default builder if one is set", func() {
+				cmd = commands.ConfigDefaultBuilder(logger, config.Config{DefaultBuilder: "some/builder"}, configPath, mockClient)
+				cmd.SetArgs([]string{})
+				h.AssertNil(t, cmd.Execute())
+				h.AssertContains(t, outBuf.String(), "some/builder")
+			})
+
+			it("suggests setting a builder if none is set", func() {
+				cmd.SetArgs([]string{})
+				h.AssertNil(t, cmd.Execute())
+				h.AssertContains(t, outBuf.String(), "No default builder is set.")
+				h.AssertContains(t, outBuf.String(), "run `pack builder suggest`")
+			})
+		})
+
+		when("unset", func() {
+			it("unsets current default builder", func() {
+				cfg := config.Config{DefaultBuilder: "some/builder"}
+				h.AssertNil(t, config.Write(cfg, configPath))
+				cmd = commands.ConfigDefaultBuilder(logger, cfg, configPath, mockClient)
+				cmd.SetArgs([]string{"--unset"})
+				err := cmd.Execute()
+				h.AssertNil(t, err)
+				cfg, err = config.Read(configPath)
+				h.AssertNil(t, err)
+				h.AssertEq(t, cfg.DefaultBuilder, "")
+				h.AssertContains(t, outBuf.String(), fmt.Sprintf("Successfully unset default builder %s", style.Symbol("some/builder")))
+			})
+
+			it("clarifies if no builder was set", func() {
+				cmd.SetArgs([]string{"--unset"})
+				h.AssertNil(t, cmd.Execute())
+				h.AssertContains(t, outBuf.String(), "No default builder was set")
+			})
+
+			it("gives clear error if unable to write to config", func() {
+				h.AssertNil(t, ioutil.WriteFile(configPath, []byte("some-data"), 0001))
+				cmd = commands.ConfigDefaultBuilder(logger, config.Config{DefaultBuilder: "some/builder"}, configPath, mockClient)
+				cmd.SetArgs([]string{"--unset"})
+				err := cmd.Execute()
+				h.AssertError(t, err, "failed to write to config at "+configPath)
+			})
+		})
+
+		when("set", func() {
+			when("valid builder is provider", func() {
+				when("in local", func() {
+					var imageName = "some/image"
+
+					it("sets default builder", func() {
+						mockClient.EXPECT().InspectBuilder(imageName, true).Return(&pack.BuilderInfo{
+							Stack: "test.stack.id",
+						}, nil)
+
+						cmd.SetArgs([]string{imageName})
+						h.AssertNil(t, cmd.Execute())
+						h.AssertContains(t, outBuf.String(), fmt.Sprintf("Builder '%s' is now the default builder", imageName))
+
+						cfg, err := config.Read(configPath)
+						h.AssertNil(t, err)
+						h.AssertEq(t, cfg.DefaultBuilder, "some/image")
+					})
+
+					it("gives clear error if unable to write to config", func() {
+						h.AssertNil(t, ioutil.WriteFile(configPath, []byte("some-data"), 0001))
+						mockClient.EXPECT().InspectBuilder(imageName, true).Return(&pack.BuilderInfo{
+							Stack: "test.stack.id",
+						}, nil)
+						cmd = commands.ConfigDefaultBuilder(logger, config.Config{}, configPath, mockClient)
+						cmd.SetArgs([]string{imageName})
+						err := cmd.Execute()
+						h.AssertError(t, err, "failed to write to config at "+configPath)
+					})
+				})
+
+				when("in remote", func() {
+					it("sets default builder", func() {
+						imageName := "some/image"
+
+						localCall := mockClient.EXPECT().InspectBuilder(imageName, true).Return(nil, nil)
+
+						mockClient.EXPECT().InspectBuilder(imageName, false).Return(&pack.BuilderInfo{
+							Stack: "test.stack.id",
+						}, nil).After(localCall)
+
+						cmd.SetArgs([]string{imageName})
+						h.AssertNil(t, cmd.Execute())
+						h.AssertContains(t, outBuf.String(), fmt.Sprintf("Builder '%s' is now the default builder", imageName))
+					})
+
+					it("gives clear error if unable to inspect remote image", func() {
+						imageName := "some/image"
+
+						localCall := mockClient.EXPECT().InspectBuilder(imageName, true).Return(nil, nil)
+
+						mockClient.EXPECT().InspectBuilder(imageName, false).Return(&pack.BuilderInfo{
+							Stack: "test.stack.id",
+						}, pack.SoftError{}).After(localCall)
+
+						cmd.SetArgs([]string{imageName})
+						err := cmd.Execute()
+						h.AssertError(t, err, fmt.Sprintf("failed to inspect remote image %s", style.Symbol(imageName)))
+					})
+				})
+			})
+
+			when("invalid builder is provided", func() {
+				it("error is presented", func() {
+					imageName := "nonbuilder/image"
+
+					mockClient.EXPECT().InspectBuilder(imageName, true).Return(
+						nil,
+						fmt.Errorf("failed to inspect image %s", imageName))
+
+					cmd.SetArgs([]string{imageName})
+
+					h.AssertNotNil(t, cmd.Execute())
+					h.AssertContains(t, outBuf.String(), fmt.Sprintf("validating that builder %s exists", style.Symbol("nonbuilder/image")))
+				})
+			})
+
+			when("non-existent builder is provided", func() {
+				it("error is present", func() {
+					imageName := "nonexisting/image"
+
+					localCall := mockClient.EXPECT().InspectBuilder(imageName, true).Return(
+						nil,
+						nil)
+
+					mockClient.EXPECT().InspectBuilder(imageName, false).Return(
+						nil,
+						nil).After(localCall)
+
+					cmd.SetArgs([]string{imageName})
+
+					h.AssertNotNil(t, cmd.Execute())
+					h.AssertContains(t, outBuf.String(), "builder 'nonexisting/image' not found")
+				})
+			})
+		})
+	})
+}

--- a/internal/commands/config_test.go
+++ b/internal/commands/config_test.go
@@ -7,12 +7,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/heroku/color"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 	"github.com/spf13/cobra"
 
 	"github.com/buildpacks/pack/internal/commands"
+	"github.com/buildpacks/pack/internal/commands/testmocks"
 	"github.com/buildpacks/pack/internal/config"
 	ilogging "github.com/buildpacks/pack/internal/logging"
 	"github.com/buildpacks/pack/logging"
@@ -32,17 +34,21 @@ func testConfigCommand(t *testing.T, when spec.G, it spec.S) {
 		outBuf       bytes.Buffer
 		tempPackHome string
 		configPath   string
+		mockClient   *testmocks.MockPackClient
 	)
 
 	it.Before(func() {
 		var err error
+
+		mockController := gomock.NewController(t)
+		mockClient = testmocks.NewMockPackClient(mockController)
 
 		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
 		tempPackHome, err = ioutil.TempDir("", "pack-home")
 		h.AssertNil(t, err)
 		configPath = filepath.Join(tempPackHome, "config.toml")
 
-		command = commands.NewConfigCommand(logger, config.Config{Experimental: true}, configPath)
+		command = commands.NewConfigCommand(logger, config.Config{Experimental: true}, configPath, mockClient)
 		command.SetOut(logging.GetWriterForLevel(logger, logging.InfoLevel))
 	})
 
@@ -57,45 +63,17 @@ func testConfigCommand(t *testing.T, when spec.G, it spec.S) {
 			output := outBuf.String()
 			h.AssertContains(t, output, "Interact with Pack's configuration")
 			h.AssertContains(t, output, "Usage:")
-			for _, subcmd := range []string{"trusted-builders", "run-image-mirrors", "experimental", "registries"} {
-				h.AssertContains(t, output, subcmd)
+			for _, command := range []string{"trusted-builders", "run-image-mirrors", "default-builder", "experimental", "registries"} {
+				h.AssertContains(t, output, command)
 			}
 		})
 
 		it("doesn't print experimental commands if experimental not enabled", func() {
-			command = commands.NewConfigCommand(logger, config.Config{}, configPath)
+			command = commands.NewConfigCommand(logger, config.Config{}, configPath, mockClient)
 			command.SetArgs([]string{})
 			h.AssertNil(t, command.Execute())
 			output := outBuf.String()
 			h.AssertNotContains(t, output, "registries")
-		})
-	})
-
-	when("trusted-builders", func() {
-		it("prints list of trusted builders", func() {
-			command.SetArgs([]string{"trusted-builders"})
-			h.AssertNil(t, command.Execute())
-			h.AssertContainsAllInOrder(t,
-				outBuf,
-				"gcr.io/buildpacks/builder:v1",
-				"heroku/buildpacks:18",
-				"paketobuildpacks/builder:base",
-				"paketobuildpacks/builder:full",
-				"paketobuildpacks/builder:tiny",
-			)
-		})
-
-		it("works with alias of trusted-builders", func() {
-			command.SetArgs([]string{"trusted-builder"})
-			h.AssertNil(t, command.Execute())
-			h.AssertContainsAllInOrder(t,
-				outBuf,
-				"gcr.io/buildpacks/builder:v1",
-				"heroku/buildpacks:18",
-				"paketobuildpacks/builder:base",
-				"paketobuildpacks/builder:full",
-				"paketobuildpacks/builder:tiny",
-			)
 		})
 	})
 }

--- a/internal/commands/config_trusted_builder.go
+++ b/internal/commands/config_trusted_builder.go
@@ -15,7 +15,7 @@ func ConfigTrustedBuilder(logger logging.Logger, cfg config.Config, cfgPath stri
 	cmd := &cobra.Command{
 		Use:     "trusted-builders",
 		Short:   "Interact with trusted builders",
-		Aliases: []string{"trusted-builder"},
+		Aliases: []string{"trusted-builder", "trust-builder", "trust-builders"},
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			listTrustedBuilders(args, logger, cfg)
 			return nil

--- a/internal/commands/config_trusted_builder.go
+++ b/internal/commands/config_trusted_builder.go
@@ -11,7 +11,7 @@ import (
 	"github.com/buildpacks/pack/logging"
 )
 
-func trustedBuilder(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
+func ConfigTrustedBuilder(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "trusted-builders",
 		Short:   "Interact with trusted builders",

--- a/internal/commands/report.go
+++ b/internal/commands/report.go
@@ -13,11 +13,10 @@ import (
 
 	"github.com/buildpacks/pack/internal/build"
 	"github.com/buildpacks/pack/internal/builder"
-	"github.com/buildpacks/pack/internal/config"
 	"github.com/buildpacks/pack/logging"
 )
 
-func Report(logger logging.Logger, version string) *cobra.Command {
+func Report(logger logging.Logger, version, cfgPath string) *cobra.Command {
 	var explicit bool
 
 	cmd := &cobra.Command{
@@ -27,7 +26,7 @@ func Report(logger logging.Logger, version string) *cobra.Command {
 		Example: "pack report",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			var buf bytes.Buffer
-			err := generateOutput(&buf, version, explicit)
+			err := generateOutput(&buf, version, cfgPath, explicit)
 			if err != nil {
 				return err
 			}
@@ -43,7 +42,7 @@ func Report(logger logging.Logger, version string) *cobra.Command {
 	return cmd
 }
 
-func generateOutput(writer io.Writer, version string, explicit bool) error {
+func generateOutput(writer io.Writer, version, cfgPath string, explicit bool) error {
 	tpl := template.Must(template.New("").Parse(`Pack:
   Version:  {{ .Version }}
   OS/Arch:  {{ .OS }}/{{ .Arch }}
@@ -56,10 +55,8 @@ Config:
 {{ .Config -}}`))
 
 	configData := ""
-	if path, err := config.DefaultConfigPath(); err != nil {
-		configData = fmt.Sprintf("(error: %s)", err.Error())
-	} else if data, err := ioutil.ReadFile(path); err != nil {
-		configData = fmt.Sprintf("(no config file found at %s)", path)
+	if data, err := ioutil.ReadFile(cfgPath); err != nil {
+		configData = fmt.Sprintf("(no config file found at %s)", cfgPath)
 	} else {
 		var padded strings.Builder
 

--- a/internal/commands/set_default_builder.go
+++ b/internal/commands/set_default_builder.go
@@ -14,11 +14,13 @@ import (
 func SetDefaultBuilder(logger logging.Logger, cfg config.Config, client PackClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "set-default-builder <builder-name>",
+		Hidden:  true,
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "Set default builder used by other commands",
 		Long:    "Set default builder used by other commands.\n\n** For suggested builders simply leave builder name empty. **",
 		Example: "pack set-default-builder cnbs/sample-builder:bionic",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			deprecationWarning(logger, "set-default-builder", "config default-builder")
 			if len(args) < 1 || args[0] == "" {
 				logger.Infof("Usage:\n\t%s\n", cmd.UseLine())
 				suggestBuilders(logger, client)


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This command allows users to list, set, and unset a value for a default builder in the pack config, with the command having three forms: 
* `pack config default-builder` &rarr; lists the current default builder, or prints a clear message if there is none
* `pack config default-builder <some-builder>` &rarr; After validating the builder exists, either locally or in a remote registry, it is added to the pack config, with a success message printed
* `pack config default-builder --unset` &rarr; If there is a default builder configured, it will remove that from the config, and print a success message. If not, it will print a clear message, saying that there wasn't a builder set. 
 
As part of that, I added a deprecation warning to the existing `pack set-default-builder` command. I also slightly changed the behavior, so that instead of running `pack suggest-builder` (which has some latency) if no builder is set or the builder set isn't a valid builder, we just recommend that users can run `pack suggest-builder`.

Additionally, as part of this PR, I configured the `rebase` command to use dependency injection for the pack config path, given that my testing setup had caused issues with it in the current format. 

## Output
<!-- If applicable, please provide examples of the output changes. -->
#### After
```
$  out/pack set-default-builder
Warning: Command pack set-default-builder has been deprecated, please use pack config default-builder instead
Usage:
	pack set-default-builder <builder-name> [flags]
Suggested builders:
^C	Google:                gcr.io/buildpacks/builder:v1      Ubuntu 18 base image with buildpacks for .NET, Go, Java, Node.js, and Python
	Heroku:                heroku/buildpacks:18              heroku-18 base image with buildpacks for Ruby, Java, Node.js, Python, Golang, & PHP
	Paketo Buildpacks:     paketobuildpacks/builder:base     Ubuntu bionic base image with buildpacks for Java, NodeJS and Golang
	Paketo Buildpacks:     paketobuildpacks/builder:full     Ubuntu bionic base image with buildpacks for Java, .NET, NodeJS, Golang, PHP, HTTPD and NGINX
	Paketo Buildpacks:     paketobuildpacks/builder:tiny     Tiny base image (bionic build image, distroless run image) with buildpacks for Golang

Tip: Learn more about a specific builder with:
	pack inspect-builder <builder-image>
```
```
 $  out/pack config
Interact with Pack's configuration

Usage:
  pack config [command]

Available Commands:
  trusted-builders  Interact with trusted builders
  run-image-mirrors Interact with run image mirrors
  default-builder   List, set and unset the default builder used by other commands

Flags:
  -h, --help   Help for 'config'

Global Flags:
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output

Use "pack config [command] --help" for more information about a command.
```

```
$  out/pack config default-builder -h
List, set, and unset the default builder used by other commands.

* To list your default builder, run `pack config default-builder`.
* To set your default builder, run `pack config default-builder <builder-name>`.
* To unset your default builder, run `pack config default-builder --unset`.

For suggested builders, run `pack builder suggest`.

Usage:
  pack config default-builder [flags]

Examples:
pack config default-builder cnbs/sample-builder:bionic

Flags:
  -h, --help    Help for 'config default-builder'
  -u, --unset   Unset the current default builder

Global Flags:
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output
```
```
$  out/pack config default-builder
No default builder is set.

For suggested builders, run `pack builder suggest`.
```
```
$  out/pack config default-builder some/builder
ERROR: validating that builder some/builder exists: builder some/builder not found
```
```
$  out/pack config default-builder paketobuildpacks/builder:tiny
Builder paketobuildpacks/builder:tiny is now the default builder
```
```
$  out/pack config default-builder
The current default builder is paketobuildpacks/builder:tiny
```
```
$  out/pack config default-builder --unset
Successfully unset default builder
```
```
$  out/pack config default-builder
No default builder is set.

For suggested builders, run `pack builder suggest`.
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see #___

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #924 
Relates to #597 