### PR TITLE
Add  pack config experimental subcommand

### DIFF
--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -173,12 +173,16 @@ func (i *PackInvoker) Version() string {
 func (i *PackInvoker) EnableExperimental() {
 	i.testObject.Helper()
 
-	err := ioutil.WriteFile(
-		filepath.Join(i.home, "config.toml"),
-		[]byte("experimental=true"),
-		os.ModePerm,
-	)
-	i.assert.Nil(err)
+	if i.Supports("config experimental") {
+		i.JustRunSuccessfully("config", "experimental", "true")
+	} else {
+		err := ioutil.WriteFile(
+			filepath.Join(i.home, "config.toml"),
+			[]byte("experimental=true"),
+			os.ModePerm,
+		)
+		i.assert.Nil(err)
+	}
 }
 
 // supports returns whether or not the executor's pack binary supports a

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -18,6 +18,7 @@ func NewConfigCommand(logger logging.Logger, cfg config.Config, cfgPath string) 
 
 	cmd.AddCommand(trustedBuilder(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigRunImagesMirrors(logger, cfg, cfgPath))
+	cmd.AddCommand(ConfigExperimental(logger, cfg, cfgPath))
 
 	AddHelpFlag(cmd, "config")
 	return cmd

--- a/internal/commands/config_experimental.go
+++ b/internal/commands/config_experimental.go
@@ -1,0 +1,54 @@
+package commands
+
+import (
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
+)
+
+func ConfigExperimental(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "experimental [<true | false>]",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "Print and set the current 'experimental' value from the config",
+		Long: "Experimental features in pack are gated, and require you adding setting `experimental=true` to the Pack Config, either manually, or using this command.\n\n" +
+			"* Running `pack config experimental` prints whether experimental features are currently enabled.\n" +
+			"* Running `pack config experimental <true | false>` enables or disables experimental features.",
+		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			switch {
+			case len(args) == 0:
+				if cfg.Experimental {
+					logger.Infof("Experimental features are enabled! To turn them off, run `pack config experimental false`")
+				} else {
+					logger.Info("Experimental features aren't currently enabled. To enable them, run `pack config experimental true`")
+				}
+			default:
+				val, err := strconv.ParseBool(args[0])
+				if err != nil {
+					return errors.Wrapf(err, "invalid value %s provided", style.Symbol(args[0]))
+				}
+				cfg.Experimental = val
+
+				if err = config.Write(cfg, cfgPath); err != nil {
+					return errors.Wrap(err, "writing to config")
+				}
+
+				if cfg.Experimental {
+					logger.Info("Experimental features enabled!")
+				} else {
+					logger.Info("Experimental features disabled")
+				}
+			}
+
+			return nil
+		}),
+	}
+
+	AddHelpFlag(cmd, "experimental")
+	return cmd
+}

--- a/internal/commands/config_experimental_test.go
+++ b/internal/commands/config_experimental_test.go
@@ -1,0 +1,105 @@
+package commands_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/commands"
+	"github.com/buildpacks/pack/internal/config"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestConfigExperimental(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "ConfigExperimentalCommand", testConfigExperimental, spec.Random(), spec.Report(report.Terminal{}))
+}
+
+func testConfigExperimental(t *testing.T, when spec.G, it spec.S) {
+	var (
+		cmd          *cobra.Command
+		logger       logging.Logger
+		outBuf       bytes.Buffer
+		tempPackHome string
+		configPath   string
+	)
+
+	it.Before(func() {
+		var err error
+
+		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		h.AssertNil(t, err)
+		configPath = filepath.Join(tempPackHome, "config.toml")
+
+		cmd = commands.ConfigExperimental(logger, config.Config{}, configPath)
+		cmd.SetOut(logging.GetWriterForLevel(logger, logging.InfoLevel))
+	})
+
+	it.After(func() {
+		h.AssertNil(t, os.RemoveAll(tempPackHome))
+	})
+
+	when("#ConfigExperimental", func() {
+		when("list values", func() {
+			it("prints a clear message if false", func() {
+				cmd.SetArgs([]string{})
+				h.AssertNil(t, cmd.Execute())
+				output := outBuf.String()
+				h.AssertContains(t, output, "Experimental features aren't currently enabled")
+			})
+
+			it("prints a clear message if true", func() {
+				cmd = commands.ConfigExperimental(logger, config.Config{Experimental: true}, configPath)
+				cmd.SetArgs([]string{})
+				h.AssertNil(t, cmd.Execute())
+				output := outBuf.String()
+				h.AssertContains(t, output, "Experimental features are enabled!")
+			})
+		})
+
+		when("set", func() {
+			it("sets true if provided", func() {
+				cmd.SetArgs([]string{"true"})
+				h.AssertNil(t, cmd.Execute())
+				output := outBuf.String()
+				h.AssertContains(t, output, "Experimental features enabled")
+				cfg, err := config.Read(configPath)
+				h.AssertNil(t, err)
+				h.AssertEq(t, cfg.Experimental, true)
+			})
+
+			it("sets false if provided", func() {
+				cmd.SetArgs([]string{"false"})
+				h.AssertNil(t, cmd.Execute())
+				output := outBuf.String()
+				h.AssertContains(t, output, "Experimental features disabled")
+				cfg, err := config.Read(configPath)
+				h.AssertNil(t, err)
+				h.AssertEq(t, cfg.Experimental, false)
+			})
+
+			it("returns error if invalid value provided", func() {
+				cmd.SetArgs([]string{"disable-me"})
+				h.AssertError(t, cmd.Execute(), fmt.Sprintf("invalid value %s provided", style.Symbol("disable-me")))
+				//output := outBuf.String()
+				//h.AssertContains(t, output, "Experimental features disabled.")
+				cfg, err := config.Read(configPath)
+				h.AssertNil(t, err)
+				h.AssertEq(t, cfg.Experimental, false)
+			})
+		})
+	})
+}

--- a/internal/commands/config_test.go
+++ b/internal/commands/config_test.go
@@ -57,7 +57,7 @@ func testConfigCommand(t *testing.T, when spec.G, it spec.S) {
 			output := outBuf.String()
 			h.AssertContains(t, output, "Interact with Pack's configuration")
 			h.AssertContains(t, output, "Usage:")
-			for _, command := range []string{"trusted-builders", "run-image-mirrors"} {
+			for _, command := range []string{"trusted-builders", "run-image-mirrors", "experimental"} {
 				h.AssertContains(t, output, command)
 			}
 		})


### PR DESCRIPTION
This allows users to explain whether experimental features are enabled or not, and set it true or false.

Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->
```
 $  out/pack config experimental
Experimental features are enabled! To turn them off, run `pack config experimental false`
```
```
$  out/pack config experimental -h
Experimental features in pack are gated, and require you adding setting `experimental=true` to the Pack Config, either manually, or using this command.

* Running `pack config experimental` prints whether experimental features are currently enabled.
* Running `pack config experimental <true | false>` enables or disables experimental features.

Usage:
  pack config experimental [<true | false>] [flags]

Flags:
  -h, --help   Help for 'experimental'

Global Flags:
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output
```
```
$  out/pack config experimental true
Experimental features enabled!
```
```
$  out/pack config experimental false
Experimental features disabled
```
```
$  out/pack config experimental
Experimental features aren't currently enabled. To enable them, run `pack config experimental true`
```
```
$  out/pack config experimental true
Experimental features enabled!
```
```
$  out/pack config experimental trueish
ERROR: invalid value trueish provided: strconv.ParseBool: parsing "trueish": invalid syntax
```
```
ERROR  $  out/pack config experimental
Experimental features are enabled! To turn them off, run `pack config experimental false`
```
## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see https://github.com/buildpacks/docs/issues/141

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
Resolves #983 
Relates to #597 