### PR TITLE
Add type/chore label to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "go"
+      - "type/chore"
 
   # Set update schedule for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -13,3 +17,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "github_actions"
+      - "type/chore"


### PR DESCRIPTION
* Currently, we look for that label when parsing our release notes. This adds it to our dependabot PRs, to reduce manual toil

Signed-off-by: David Freilich <dfreilich@vmware.com>
