### PR TITLE
Add config registries subcommand

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -22,6 +22,7 @@ type ConfigurableLogger interface {
 	WantVerbose(f bool)
 }
 
+//nolint:staticcheck
 // NewPackCommand generates a Pack command
 func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	cobra.EnableCommandSorting = false
@@ -69,27 +70,17 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 
 	rootCmd.AddCommand(commands.InspectImage(logger, imagewriter.NewFactory(), cfg, &packClient))
 	rootCmd.AddCommand(commands.InspectBuildpack(logger, &cfg, &packClient))
-	//nolint:staticcheck
 	rootCmd.AddCommand(commands.SetRunImagesMirrors(logger, cfg))
 
 	rootCmd.AddCommand(commands.SetDefaultBuilder(logger, cfg, &packClient))
 	rootCmd.AddCommand(commands.InspectBuilder(logger, cfg, &packClient, builderwriter.NewFactory()))
 
-	//nolint:staticcheck
 	rootCmd.AddCommand(commands.SuggestBuilders(logger, &packClient))
-	//nolint:staticcheck
 	rootCmd.AddCommand(commands.TrustBuilder(logger, cfg))
-	//nolint:staticcheck
 	rootCmd.AddCommand(commands.UntrustBuilder(logger, cfg))
-	//nolint:staticcheck
 	rootCmd.AddCommand(commands.ListTrustedBuilders(logger, cfg))
-	//nolint:staticcheck
 	rootCmd.AddCommand(commands.CreateBuilder(logger, cfg, &packClient))
-
-	//nolint:staticcheck
 	rootCmd.AddCommand(commands.PackageBuildpack(logger, cfg, &packClient, buildpackage.NewConfigReader()))
-
-	//nolint:staticcheck
 	rootCmd.AddCommand(commands.SuggestStacks(logger))
 
 	rootCmd.AddCommand(commands.Version(logger, pack.Version))
@@ -98,11 +89,9 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	if cfg.Experimental {
 		rootCmd.AddCommand(commands.AddBuildpackRegistry(logger, cfg, cfgPath))
 		rootCmd.AddCommand(commands.ListBuildpackRegistries(logger, cfg))
-		//nolint:staticcheck
 		rootCmd.AddCommand(commands.RegisterBuildpack(logger, cfg, &packClient))
 		rootCmd.AddCommand(commands.SetDefaultRegistry(logger, cfg, cfgPath))
 		rootCmd.AddCommand(commands.RemoveRegistry(logger, cfg, cfgPath))
-		//nolint:staticcheck
 		rootCmd.AddCommand(commands.YankBuildpack(logger, cfg, &packClient))
 	}
 

--- a/internal/commands/add_registry.go
+++ b/internal/commands/add_registry.go
@@ -1,20 +1,13 @@
 package commands
 
 import (
-	"strings"
-
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-
-	"github.com/buildpacks/pack/internal/slices"
-	"github.com/buildpacks/pack/internal/stringset"
-	"github.com/buildpacks/pack/internal/style"
-	"github.com/buildpacks/pack/registry"
 
 	"github.com/buildpacks/pack/internal/config"
 	"github.com/buildpacks/pack/logging"
 )
 
+// Deprecated: Use config registries add instead
 func AddBuildpackRegistry(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
 	var (
 		setDefault   bool
@@ -29,53 +22,19 @@ func AddBuildpackRegistry(logger logging.Logger, cfg config.Config, cfgPath stri
 		Long: "A Buildpack Registry is a (still experimental) place to publish, store, and discover buildpacks. " +
 			"Users can add buildpacks registries using add-registry, and publish/yank buildpacks from it, as well as use those buildpacks when building applications.",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			deprecationWarning(logger, "add-registry", "config registries add")
 			newRegistry := config.Registry{
 				Name: args[0],
 				URL:  args[1],
 				Type: registryType,
 			}
 
-			if newRegistry.Name == config.OfficialRegistryName {
-				return errors.Errorf("%s is a reserved registry, please provide a different name",
-					style.Symbol(config.OfficialRegistryName))
-			}
-
-			err := addRegistry(newRegistry, setDefault, cfg, cfgPath)
-			if err != nil {
-				return err
-			}
-
-			logger.Infof("Successfully added %s to buildpack registries", style.Symbol(newRegistry.Name))
-
-			return nil
+			return addRegistryToConfig(logger, newRegistry, setDefault, cfg, cfgPath)
 		}),
 	}
 	cmd.Flags().BoolVar(&setDefault, "default", false, "Set this buildpack registry as the default")
 	cmd.Flags().StringVar(&registryType, "type", "github", "Type of buildpack registry [git|github]")
-	AddHelpFlag(cmd, "add-buildpack-registry")
+	AddHelpFlag(cmd, "add-registry")
 
 	return cmd
-}
-
-func addRegistry(newRegistry config.Registry, setDefault bool, cfg config.Config, cfgPath string) error {
-	if _, ok := stringset.FromSlice(registry.Types)[newRegistry.Type]; !ok {
-		return errors.Errorf(
-			"%s is not a valid type. Supported types are: %s.",
-			style.Symbol(newRegistry.Type),
-			strings.Join(slices.MapString(registry.Types, style.Symbol), ", "))
-	}
-
-	for _, r := range cfg.Registries {
-		if r.Name == newRegistry.Name {
-			return errors.Errorf(
-				"Buildpack registry %s already exists.",
-				style.Symbol(newRegistry.Name))
-		}
-	}
-
-	if setDefault {
-		cfg.DefaultRegistryName = newRegistry.Name
-	}
-	cfg.Registries = append(cfg.Registries, newRegistry)
-	return config.Write(cfg, cfgPath)
 }

--- a/internal/commands/add_registry_test.go
+++ b/internal/commands/add_registry_test.go
@@ -62,6 +62,7 @@ func testAddRegistryCommand(t *testing.T, when spec.G, it spec.S) {
 				assert.Equal(cfg.Registries[0].Type, "github")
 				assert.Equal(cfg.Registries[0].URL, "https://github.com/buildpacks/registry-index/")
 				assert.Equal(cfg.DefaultRegistryName, "")
+				assert.Contains(outBuf.String(), "been deprecated, please use 'pack config registries add' instead")
 			})
 		})
 

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -20,6 +20,10 @@ func NewConfigCommand(logger logging.Logger, cfg config.Config, cfgPath string) 
 	cmd.AddCommand(ConfigRunImagesMirrors(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigExperimental(logger, cfg, cfgPath))
 
+	if cfg.Experimental {
+		cmd.AddCommand(ConfigRegistries(logger, cfg, cfgPath))
+	}
+
 	AddHelpFlag(cmd, "config")
 	return cmd
 }

--- a/internal/commands/config_registries.go
+++ b/internal/commands/config_registries.go
@@ -1,0 +1,173 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/internal/slices"
+	"github.com/buildpacks/pack/internal/stringset"
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
+	"github.com/buildpacks/pack/registry"
+)
+
+var (
+	bpRegistryExplanation = "A Buildpack Registry is a (still experimental) place to publish, store, and discover buildpacks. "
+)
+
+var (
+	setDefault   bool
+	registryType string
+)
+
+func ConfigRegistries(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "registries",
+		Aliases: []string{"registry", "registreis"},
+		Short:   prependExperimental("Interact with registries"),
+		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			listRegistries(args, logger, cfg)
+			return nil
+		}),
+	}
+
+	addCmd := generateAdd("registries", logger, cfg, cfgPath, addRegistry)
+	addCmd.Args = cobra.ExactArgs(2)
+	addCmd.Example = "pack config registries add my-registry https://github.com/buildpacks/my-registry"
+	addCmd.Short = prependExperimental(addCmd.Short)
+	addCmd.Long = bpRegistryExplanation + "Users can add registries from the config by using registries remove, and publish/yank buildpacks from it, as well as use those buildpacks when building applications."
+	addCmd.Flags().BoolVar(&setDefault, "default", false, "Set this buildpack registry as the default")
+	addCmd.Flags().StringVar(&registryType, "type", "github", "Type of buildpack registry [git|github]")
+	cmd.AddCommand(addCmd)
+
+	rmCmd := generateRemove("registries", logger, cfg, cfgPath, removeRegistry)
+	rmCmd.Example = "pack config registries remove myregistry"
+	rmCmd.Short = prependExperimental(rmCmd.Short)
+	rmCmd.Long = bpRegistryExplanation + "Users can remove registries from the config by using `pack config registries remove <registry>`"
+	cmd.AddCommand(rmCmd)
+
+	listCmd := generateListCmd("registries", logger, cfg, listRegistries)
+	listCmd.Example = "pack config registries list"
+	listCmd.Short = prependExperimental(listCmd.Short)
+	listCmd.Long = bpRegistryExplanation + "List Registries saved in the pack config.\n\nShow the registries that are either added by default or have been explicitly added by using `pack config registries add`"
+	cmd.AddCommand(listCmd)
+
+	cmd.AddCommand(ConfigRegistriesDefault(logger, cfg, cfgPath))
+
+	AddHelpFlag(cmd, "registries")
+	return cmd
+}
+
+func addRegistry(args []string, logger logging.Logger, cfg config.Config, cfgPath string) error {
+	newRegistry := config.Registry{
+		Name: args[0],
+		URL:  args[1],
+		Type: registryType,
+	}
+
+	return addRegistryToConfig(logger, newRegistry, setDefault, cfg, cfgPath)
+}
+
+func addRegistryToConfig(logger logging.Logger, newRegistry config.Registry, setDefault bool, cfg config.Config, cfgPath string) error {
+	if newRegistry.Name == config.OfficialRegistryName {
+		return errors.Errorf("%s is a reserved registry, please provide a different name",
+			style.Symbol(config.OfficialRegistryName))
+	}
+
+	if _, ok := stringset.FromSlice(registry.Types)[newRegistry.Type]; !ok {
+		return errors.Errorf("%s is not a valid type. Supported types are: %s.",
+			style.Symbol(newRegistry.Type),
+			strings.Join(slices.MapString(registry.Types, style.Symbol), ", "))
+	}
+
+	if registriesContains(config.GetRegistries(cfg), newRegistry.Name) {
+		return errors.Errorf("Buildpack registry %s already exists.",
+			style.Symbol(newRegistry.Name))
+	}
+
+	if setDefault {
+		cfg.DefaultRegistryName = newRegistry.Name
+	}
+	cfg.Registries = append(cfg.Registries, newRegistry)
+	if err := config.Write(cfg, cfgPath); err != nil {
+		return errors.Wrapf(err, "writing config to %s", cfgPath)
+	}
+
+	logger.Infof("Successfully added %s to registries", style.Symbol(newRegistry.Name))
+	return nil
+}
+
+func removeRegistry(args []string, logger logging.Logger, cfg config.Config, cfgPath string) error {
+	registryName := args[0]
+
+	if registryName == config.OfficialRegistryName {
+		return errors.Errorf("%s is a reserved registry name, please provide a different registry",
+			style.Symbol(config.OfficialRegistryName))
+	}
+
+	index := findRegistryIndex(cfg.Registries, registryName)
+	if index < 0 {
+		return errors.Errorf("registry %s does not exist", style.Symbol(registryName))
+	}
+
+	cfg.Registries = removeBPRegistry(index, cfg.Registries)
+	if cfg.DefaultRegistryName == registryName {
+		cfg.DefaultRegistryName = config.OfficialRegistryName
+	}
+
+	if err := config.Write(cfg, cfgPath); err != nil {
+		return errors.Wrapf(err, "writing config to %s", cfgPath)
+	}
+
+	logger.Infof("Successfully removed %s from registries", style.Symbol(registryName))
+	return nil
+}
+
+func listRegistries(args []string, logger logging.Logger, cfg config.Config) {
+	for _, currRegistry := range config.GetRegistries(cfg) {
+		isDefaultRegistry := (currRegistry.Name == cfg.DefaultRegistryName) ||
+			(currRegistry.Name == config.OfficialRegistryName && cfg.DefaultRegistryName == "")
+
+		logger.Info(fmtRegistry(
+			currRegistry,
+			isDefaultRegistry,
+			logger.IsVerbose()))
+	}
+	logging.Tip(logger, "Run %s to add additional registries", style.Symbol("pack config registries add"))
+}
+
+// Local private funcs
+func fmtRegistry(registry config.Registry, isDefaultRegistry, isVerbose bool) string {
+	registryOutput := fmt.Sprintf("  %s", registry.Name)
+	if isDefaultRegistry {
+		registryOutput = fmt.Sprintf("* %s", registry.Name)
+	}
+	if isVerbose {
+		registryOutput = fmt.Sprintf("%-12s %s", registryOutput, registry.URL)
+	}
+
+	return registryOutput
+}
+
+func registriesContains(registries []config.Registry, registry string) bool {
+	return findRegistryIndex(registries, registry) != -1
+}
+
+func findRegistryIndex(registries []config.Registry, registryName string) int {
+	for index, r := range registries {
+		if r.Name == registryName {
+			return index
+		}
+	}
+
+	return -1
+}
+
+func removeBPRegistry(index int, registries []config.Registry) []config.Registry {
+	registries[index] = registries[len(registries)-1]
+	return registries[:len(registries)-1]
+}

--- a/internal/commands/config_registries_default.go
+++ b/internal/commands/config_registries_default.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
+)
+
+func ConfigRegistriesDefault(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
+	var unset bool
+
+	cmd := &cobra.Command{
+		Use:     "default <name>",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   prependExperimental("Set default registry"),
+		Example: "pack config registries default myregistry",
+		Long: bpRegistryExplanation + "\n\nYou can use this command to list, set, and unset a default registry, which will be used when looking for buildpacks:" +
+			"* To list your default registry, run `pack config registries default`.\n" +
+			"* To set your default registry, run `pack config registries default <registry-name>`.\n" +
+			"* To unset your default registry, run `pack config registries default --unset`.\n" +
+			fmt.Sprintf("Unsetting the default registry will reset the default-registry to be the official buildpacks registry, %s", style.Symbol(config.DefaultRegistry().URL)),
+		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			switch {
+			case unset:
+				if cfg.DefaultRegistryName == "" || cfg.DefaultRegistryName == config.OfficialRegistryName {
+					return errors.Errorf("Registry %s is a protected registry, and can be replaced as a default registry, but not removed entirely. "+
+						"To add a new registry and set as default, run `pack config registries add <registry-name> <registry-url> --default.\n"+
+						"To set an existing registry as default, call `pack config registries default <registry-name>`", style.Symbol(config.OfficialRegistryName))
+				}
+				oldRegistry := cfg.DefaultRegistryName
+				cfg.DefaultRegistryName = ""
+				if err := config.Write(cfg, cfgPath); err != nil {
+					return errors.Wrapf(err, "writing config to %s", cfgPath)
+				}
+				logger.Infof("Successfully unset default registry %s", style.Symbol(oldRegistry))
+				logger.Infof("Default registry has been set to %s", style.Symbol(config.OfficialRegistryName))
+			case len(args) == 0: //list
+				if cfg.DefaultRegistryName == "" {
+					cfg.DefaultRegistryName = config.OfficialRegistryName
+				}
+				logger.Infof("The current default registry is %s", style.Symbol(cfg.DefaultRegistryName))
+			default: // set
+				registryName := args[0]
+				if !registriesContains(config.GetRegistries(cfg), registryName) {
+					return errors.Errorf("no registry with the name %s exists", style.Symbol(registryName))
+				}
+
+				if cfg.DefaultRegistryName != registryName {
+					cfg.DefaultRegistryName = registryName
+					err := config.Write(cfg, cfgPath)
+					if err != nil {
+						return errors.Wrapf(err, "writing config to %s", cfgPath)
+					}
+				}
+
+				logger.Infof("Successfully set %s as the default registry", style.Symbol(registryName))
+			}
+
+			return nil
+		}),
+	}
+
+	cmd.Flags().BoolVarP(&unset, "unset", "u", false, "Unset the current default registry, and set it to the official buildpacks registry")
+	AddHelpFlag(cmd, "default")
+	return cmd
+}

--- a/internal/commands/config_registries_default_test.go
+++ b/internal/commands/config_registries_default_test.go
@@ -1,0 +1,148 @@
+package commands_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpacks/pack/internal/commands"
+	"github.com/buildpacks/pack/internal/config"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/internal/style"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestConfigRegistriesDefault(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+
+	spec.Run(t, "ConfigRegistriesDefaultCommand", testConfigRegistriesDefaultCommand, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func testConfigRegistriesDefaultCommand(t *testing.T, when spec.G, it spec.S) {
+	when("#ConfigRegistriesDefault", func() {
+		var (
+			tmpDir     string
+			configFile string
+			outBuf     bytes.Buffer
+			logger     = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+			assert     = h.NewAssertionManager(t)
+		)
+
+		it.Before(func() {
+			var err error
+			tmpDir, err = ioutil.TempDir("", "pack-home-*")
+			assert.Nil(err)
+
+			configFile = filepath.Join(tmpDir, "config.toml")
+		})
+
+		it.After(func() {
+			_ = os.RemoveAll(tmpDir)
+		})
+
+		when("list", func() {
+			it("returns official if none is set", func() {
+				command := commands.ConfigRegistriesDefault(logger, config.Config{}, configFile)
+				command.SetArgs([]string{})
+				assert.Succeeds(command.Execute())
+
+				assert.Contains(outBuf.String(), "official")
+			})
+
+			it("returns the default registry if one is set", func() {
+				command := commands.ConfigRegistriesDefault(logger, config.Config{DefaultRegistryName: "some-registry"}, configFile)
+				command.SetArgs([]string{})
+				assert.Succeeds(command.Execute())
+
+				assert.Contains(outBuf.String(), "some-registry")
+			})
+		})
+
+		when("set default", func() {
+			it("should set the default registry", func() {
+				cfg := config.Config{
+					Registries: []config.Registry{
+						{
+							Name: "myregistry",
+							URL:  "https://github.com/buildpacks/registry-index",
+							Type: "github",
+						},
+					},
+				}
+				command := commands.ConfigRegistriesDefault(logger, cfg, configFile)
+				command.SetArgs([]string{"myregistry"})
+				assert.Succeeds(command.Execute())
+
+				cfg, err := config.Read(configFile)
+				assert.Nil(err)
+
+				assert.Equal(cfg.DefaultRegistryName, "myregistry")
+			})
+
+			it("should fail if no corresponding registry exists", func() {
+				command := commands.ConfigRegistriesDefault(logger, config.Config{}, configFile)
+				command.SetArgs([]string{"myregistry"})
+				assert.Error(command.Execute())
+
+				output := outBuf.String()
+				assert.Contains(output, "no registry with the name 'myregistry' exists")
+			})
+
+			it("returns clear error if fails to write", func() {
+				assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+				cfg := config.Config{
+					Registries: []config.Registry{
+						{
+							Name: "myregistry",
+							URL:  "https://github.com/buildpacks/registry-index",
+							Type: "github",
+						},
+					},
+				}
+				command := commands.ConfigRegistriesDefault(logger, cfg, configFile)
+				command.SetArgs([]string{"myregistry"})
+				assert.ErrorContains(command.Execute(), "writing config to")
+			})
+		})
+
+		when("--unset", func() {
+			it("should unset the default registry, if set", func() {
+				command := commands.ConfigRegistriesDefault(logger, config.Config{DefaultRegistryName: "some-registry"}, configFile)
+				command.SetArgs([]string{"--unset"})
+				assert.Nil(command.Execute())
+
+				cfg, err := config.Read(configFile)
+				assert.Nil(err)
+				assert.Equal(cfg.DefaultRegistryName, "")
+				assert.Contains(outBuf.String(), fmt.Sprintf("Successfully unset default registry %s", style.Symbol("some-registry")))
+			})
+
+			it("should return an error if official registry is being unset", func() {
+				command := commands.ConfigRegistriesDefault(logger, config.Config{DefaultRegistryName: config.OfficialRegistryName}, configFile)
+				command.SetArgs([]string{"--unset"})
+				assert.ErrorContains(command.Execute(), fmt.Sprintf("Registry %s is a protected registry", style.Symbol(config.OfficialRegistryName)))
+			})
+
+			it("should return a clear message if no registry is set", func() {
+				command := commands.ConfigRegistriesDefault(logger, config.Config{}, configFile)
+				command.SetArgs([]string{"--unset"})
+				assert.ErrorContains(command.Execute(), fmt.Sprintf("Registry %s is a protected registry", style.Symbol(config.OfficialRegistryName)))
+			})
+
+			it("returns clear error if fails to write", func() {
+				assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+				command := commands.ConfigRegistriesDefault(logger, config.Config{DefaultRegistryName: "some-registry"}, configFile)
+				command.SetArgs([]string{"--unset"})
+				assert.ErrorContains(command.Execute(), "writing config to")
+			})
+		})
+	})
+}

--- a/internal/commands/config_registries_test.go
+++ b/internal/commands/config_registries_test.go
@@ -1,0 +1,340 @@
+package commands_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/commands"
+	"github.com/buildpacks/pack/internal/config"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestConfigRegistries(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "ConfigRegistriesCommand", testConfigRegistries, spec.Random(), spec.Report(report.Terminal{}))
+}
+
+func testConfigRegistries(t *testing.T, when spec.G, it spec.S) {
+	var (
+		cmd               *cobra.Command
+		logger            logging.Logger
+		cfgWithRegistries config.Config
+		outBuf            bytes.Buffer
+		tempPackHome      string
+		configPath        string
+		assert            = h.NewAssertionManager(t)
+	)
+
+	it.Before(func() {
+		var err error
+
+		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		assert.Nil(err)
+		configPath = filepath.Join(tempPackHome, "config.toml")
+
+		cmd = commands.ConfigRegistries(logger, config.Config{}, configPath)
+		cmd.SetOut(logging.GetWriterForLevel(logger, logging.InfoLevel))
+
+		cfgWithRegistries = config.Config{
+			DefaultRegistryName: "private registry",
+			Registries: []config.Registry{
+				{
+					Name: "public registry",
+					Type: "github",
+					URL:  "https://github.com/buildpacks/public-registry",
+				},
+				{
+					Name: "private registry",
+					Type: "github",
+					URL:  "https://github.com/buildpacks/private-registry",
+				},
+				{
+					Name: "personal registry",
+					Type: "github",
+					URL:  "https://github.com/buildpacks/personal-registry",
+				},
+			},
+		}
+	})
+
+	it.After(func() {
+		assert.Nil(os.RemoveAll(tempPackHome))
+	})
+
+	when("-h", func() {
+		it("prints help text", func() {
+			cmd.SetArgs([]string{"-h"})
+			assert.Nil(cmd.Execute())
+			output := outBuf.String()
+			assert.Contains(output, "Interact with registries")
+			assert.Contains(output, "Usage:")
+			for _, command := range []string{"add", "remove", "list", "default"} {
+				assert.Contains(output, command)
+			}
+		})
+	})
+
+	when("no args", func() {
+		it("calls list", func() {
+			logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+			cfgWithRegistries = config.Config{
+				DefaultRegistryName: "private registry",
+				Registries: []config.Registry{
+					{
+						Name: "public registry",
+						Type: "github",
+						URL:  "https://github.com/buildpacks/public-registry",
+					},
+					{
+						Name: "private registry",
+						Type: "github",
+						URL:  "https://github.com/buildpacks/private-registry",
+					},
+					{
+						Name: "personal registry",
+						Type: "github",
+						URL:  "https://github.com/buildpacks/personal-registry",
+					},
+				},
+			}
+			cmd = commands.ConfigRegistries(logger, cfgWithRegistries, configPath)
+			cmd.SetArgs([]string{})
+
+			assert.Nil(cmd.Execute())
+			assert.Contains(outBuf.String(), "public registry")
+			assert.Contains(outBuf.String(), "* private registry")
+			assert.Contains(outBuf.String(), "personal registry")
+		})
+	})
+
+	when("list", func() {
+		var args = []string{"list"}
+		it.Before(func() {
+			logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+			cmd = commands.ConfigRegistries(logger, cfgWithRegistries, configPath)
+			cmd.SetArgs(args)
+		})
+
+		it("should list all registries", func() {
+			assert.Nil(cmd.Execute())
+
+			assert.Contains(outBuf.String(), "public registry")
+			assert.Contains(outBuf.String(), "* private registry")
+			assert.Contains(outBuf.String(), "personal registry")
+		})
+
+		it("should list registries in verbose mode", func() {
+			logger = ilogging.NewLogWithWriters(&outBuf, &outBuf, ilogging.WithVerbose())
+			cmd = commands.ConfigRegistries(logger, cfgWithRegistries, configPath)
+			cmd.SetArgs(args)
+			assert.Nil(cmd.Execute())
+
+			assert.Contains(outBuf.String(), "public registry")
+			assert.Contains(outBuf.String(), "https://github.com/buildpacks/public-registry")
+
+			assert.Contains(outBuf.String(), "* private registry")
+			assert.Contains(outBuf.String(), "https://github.com/buildpacks/private-registry")
+
+			assert.Contains(outBuf.String(), "personal registry")
+			assert.Contains(outBuf.String(), "https://github.com/buildpacks/personal-registry")
+
+			assert.Contains(outBuf.String(), "official")
+			assert.Contains(outBuf.String(), "https://github.com/buildpacks/registry-index")
+		})
+
+		it("should indicate official as the default registry by default", func() {
+			cfgWithRegistries.DefaultRegistryName = ""
+			cmd = commands.ConfigRegistries(logger, cfgWithRegistries, configPath)
+			cmd.SetArgs(args)
+
+			assert.Nil(cmd.Execute())
+
+			assert.Contains(outBuf.String(), "* official")
+			assert.Contains(outBuf.String(), "public registry")
+			assert.Contains(outBuf.String(), "private registry")
+			assert.Contains(outBuf.String(), "personal registry")
+		})
+
+		it("should use official when no registries are defined", func() {
+			cmd = commands.ConfigRegistries(logger, config.Config{}, configPath)
+			cmd.SetArgs(args)
+
+			assert.Nil(cmd.Execute())
+
+			assert.Contains(outBuf.String(), "* official")
+		})
+	})
+
+	when("add", func() {
+		var (
+			args = []string{"add", "bp", "https://github.com/buildpacks/registry-index/"}
+		)
+
+		when("add buildpack registry", func() {
+			it("adds to registry list", func() {
+				cmd.SetArgs(args)
+				assert.Succeeds(cmd.Execute())
+
+				cfg, err := config.Read(configPath)
+				assert.Nil(err)
+				assert.Equal(len(cfg.Registries), 1)
+				assert.Equal(cfg.Registries[0].Name, "bp")
+				assert.Equal(cfg.Registries[0].Type, "github")
+				assert.Equal(cfg.Registries[0].URL, "https://github.com/buildpacks/registry-index/")
+				assert.Equal(cfg.DefaultRegistryName, "")
+			})
+		})
+
+		when("default is true", func() {
+			it("sets newly added registry as the default", func() {
+				cmd.SetArgs(append(args, "--default"))
+				assert.Succeeds(cmd.Execute())
+
+				cfg, err := config.Read(configPath)
+				assert.Nil(err)
+				assert.Equal(len(cfg.Registries), 1)
+				assert.Equal(cfg.Registries[0].Name, "bp")
+				assert.Equal(cfg.DefaultRegistryName, "bp")
+			})
+		})
+
+		when("validation", func() {
+			it("fails with missing args", func() {
+				cmd.SetOut(ioutil.Discard)
+				cmd.SetArgs([]string{"add"})
+				err := cmd.Execute()
+				assert.ErrorContains(err, "accepts 2 arg")
+			})
+
+			it("should validate type", func() {
+				cmd.SetArgs(append(args, "--type=bogus"))
+				assert.Error(cmd.Execute())
+
+				output := outBuf.String()
+				assert.Contains(output, "'bogus' is not a valid type. Supported types are: 'git', 'github'.")
+			})
+
+			it("should throw error when registry already exists", func() {
+				command := commands.ConfigRegistries(logger, config.Config{
+					Registries: []config.Registry{
+						{
+							Name: "bp",
+							Type: "github",
+							URL:  "https://github.com/buildpacks/registry-index/",
+						},
+					},
+				}, configPath)
+				command.SetArgs(args)
+				assert.Error(command.Execute())
+
+				output := outBuf.String()
+				assert.Contains(output, "Buildpack registry 'bp' already exists.")
+			})
+
+			it("should throw error when registry name is official", func() {
+				cmd.SetOut(logging.GetWriterForLevel(logger, logging.InfoLevel))
+				cmd.SetErr(&outBuf)
+				cmd.SetArgs([]string{"add", "official", "https://github.com/buildpacks/registry-index/", "--type=github"})
+
+				assert.Error(cmd.Execute())
+
+				output := outBuf.String()
+				assert.Contains(output, "'official' is a reserved registry, please provide a different name")
+			})
+
+			it("returns clear error if fails to write", func() {
+				assert.Nil(ioutil.WriteFile(configPath, []byte("something"), 0001))
+				cmd.SetArgs(args)
+				assert.ErrorContains(cmd.Execute(), "writing config to")
+			})
+		})
+	})
+
+	when("remove", func() {
+		it.Before(func() {
+			cmd = commands.ConfigRegistries(logger, cfgWithRegistries, configPath)
+		})
+
+		it("should remove the registry", func() {
+			cmd.SetArgs([]string{"remove", "public registry"})
+			assert.Succeeds(cmd.Execute())
+
+			newCfg, err := config.Read(configPath)
+			assert.Nil(err)
+
+			assert.Equal(newCfg, config.Config{
+				DefaultRegistryName: "private registry",
+				Registries: []config.Registry{
+					{
+						Name: "personal registry",
+						Type: "github",
+						URL:  "https://github.com/buildpacks/personal-registry",
+					},
+					{
+						Name: "private registry",
+						Type: "github",
+						URL:  "https://github.com/buildpacks/private-registry",
+					},
+				},
+			})
+		})
+
+		it("should remove the registry and matching default registry name", func() {
+			cmd.SetArgs([]string{"remove", "private registry"})
+			assert.Succeeds(cmd.Execute())
+
+			newCfg, err := config.Read(configPath)
+			assert.Nil(err)
+
+			assert.Equal(newCfg, config.Config{
+				DefaultRegistryName: config.OfficialRegistryName,
+				Registries: []config.Registry{
+					{
+						Name: "public registry",
+						Type: "github",
+						URL:  "https://github.com/buildpacks/public-registry",
+					},
+					{
+						Name: "personal registry",
+						Type: "github",
+						URL:  "https://github.com/buildpacks/personal-registry",
+					},
+				},
+			})
+		})
+
+		it("should return error when registry does NOT already exist", func() {
+			cmd.SetArgs([]string{"remove", "missing-registry"})
+			assert.Error(cmd.Execute())
+
+			output := outBuf.String()
+			assert.Contains(output, "registry 'missing-registry' does not exist")
+		})
+
+		it("should throw error when registry name is official", func() {
+			cmd.SetArgs([]string{"remove", "official"})
+			assert.Error(cmd.Execute())
+
+			output := outBuf.String()
+			assert.Contains(output, "'official' is a reserved registry name, please provide a different registry")
+		})
+
+		it("returns clear error if fails to write", func() {
+			assert.Nil(ioutil.WriteFile(configPath, []byte("something"), 0001))
+			cmd.SetArgs([]string{"remove", "public registry"})
+			assert.ErrorContains(cmd.Execute(), "writing config to")
+		})
+	})
+}

--- a/internal/commands/config_test.go
+++ b/internal/commands/config_test.go
@@ -42,7 +42,7 @@ func testConfigCommand(t *testing.T, when spec.G, it spec.S) {
 		h.AssertNil(t, err)
 		configPath = filepath.Join(tempPackHome, "config.toml")
 
-		command = commands.NewConfigCommand(logger, config.Config{}, configPath)
+		command = commands.NewConfigCommand(logger, config.Config{Experimental: true}, configPath)
 		command.SetOut(logging.GetWriterForLevel(logger, logging.InfoLevel))
 	})
 
@@ -57,9 +57,17 @@ func testConfigCommand(t *testing.T, when spec.G, it spec.S) {
 			output := outBuf.String()
 			h.AssertContains(t, output, "Interact with Pack's configuration")
 			h.AssertContains(t, output, "Usage:")
-			for _, command := range []string{"trusted-builders", "run-image-mirrors", "experimental"} {
-				h.AssertContains(t, output, command)
+			for _, subcmd := range []string{"trusted-builders", "run-image-mirrors", "experimental", "registries"} {
+				h.AssertContains(t, output, subcmd)
 			}
+		})
+
+		it("doesn't print experimental commands if experimental not enabled", func() {
+			command = commands.NewConfigCommand(logger, config.Config{}, configPath)
+			command.SetArgs([]string{})
+			h.AssertNil(t, command.Execute())
+			output := outBuf.String()
+			h.AssertNotContains(t, output, "registries")
 		})
 	})
 

--- a/internal/commands/list_registries.go
+++ b/internal/commands/list_registries.go
@@ -1,16 +1,13 @@
 package commands
 
 import (
-	"fmt"
-
-	"github.com/buildpacks/pack/internal/style"
-
 	"github.com/spf13/cobra"
 
 	"github.com/buildpacks/pack/internal/config"
 	"github.com/buildpacks/pack/logging"
 )
 
+// Deprecated: Use config registries list instead
 func ListBuildpackRegistries(logger logging.Logger, cfg config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list-registries",
@@ -18,32 +15,12 @@ func ListBuildpackRegistries(logger logging.Logger, cfg config.Config) *cobra.Co
 		Short:   prependExperimental("List buildpack registries"),
 		Example: "pack list-registries",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			for _, registry := range config.GetRegistries(cfg) {
-				isDefaultRegistry := (registry.Name == cfg.DefaultRegistryName) ||
-					(registry.Name == config.OfficialRegistryName && cfg.DefaultRegistryName == "")
-
-				logger.Info(fmtRegistry(
-					registry,
-					isDefaultRegistry,
-					logger.IsVerbose()))
-			}
-			logging.Tip(logger, "Run %s to add additional registries", style.Symbol("pack add-buildpack-registry"))
+			deprecationWarning(logger, "list-registries", "config registries list")
+			listRegistries(args, logger, cfg)
 
 			return nil
 		}),
 	}
 
 	return cmd
-}
-
-func fmtRegistry(registry config.Registry, isDefaultRegistry, isVerbose bool) string {
-	registryOutput := fmt.Sprintf("  %s", registry.Name)
-	if isDefaultRegistry {
-		registryOutput = fmt.Sprintf("* %s", registry.Name)
-	}
-	if isVerbose {
-		registryOutput = fmt.Sprintf("%-12s %s", registryOutput, registry.URL)
-	}
-
-	return registryOutput
 }

--- a/internal/commands/list_registries_test.go
+++ b/internal/commands/list_registries_test.go
@@ -56,20 +56,23 @@ func testListRegistriesCommand(t *testing.T, when spec.G, it spec.S) {
 			},
 		}
 		command = commands.ListBuildpackRegistries(logger, cfg)
+		command.SetArgs([]string{})
 	})
 
 	when("#ListBuildpackRegistries", func() {
 		it("should list all registries", func() {
 			h.AssertNil(t, command.Execute())
 
+			h.AssertContains(t, outBuf.String(), "has been deprecated, please use 'pack config registries list'")
 			h.AssertContains(t, outBuf.String(), "public registry")
 			h.AssertContains(t, outBuf.String(), "* private registry")
 			h.AssertContains(t, outBuf.String(), "personal registry")
 		})
 
 		it("should list registries in verbose mode", func() {
-			logger := ilogging.NewLogWithWriters(&outBuf, &outBuf, ilogging.WithVerbose())
+			logger = ilogging.NewLogWithWriters(&outBuf, &outBuf, ilogging.WithVerbose())
 			command = commands.ListBuildpackRegistries(logger, cfg)
+			command.SetArgs([]string{})
 
 			h.AssertNil(t, command.Execute())
 
@@ -87,10 +90,9 @@ func testListRegistriesCommand(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("should indicate official as the default registry by default", func() {
-			logger := ilogging.NewLogWithWriters(&outBuf, &outBuf)
 			cfg.DefaultRegistryName = ""
-
 			command = commands.ListBuildpackRegistries(logger, cfg)
+			command.SetArgs([]string{})
 
 			h.AssertNil(t, command.Execute())
 
@@ -101,10 +103,9 @@ func testListRegistriesCommand(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("should use official when no registries are defined", func() {
-			logger := ilogging.NewLogWithWriters(&outBuf, &outBuf)
 			cfg.DefaultRegistryName = ""
-
 			command = commands.ListBuildpackRegistries(logger, config.Config{})
+			command.SetArgs([]string{})
 
 			h.AssertNil(t, command.Execute())
 

--- a/internal/commands/remove_registry.go
+++ b/internal/commands/remove_registry.go
@@ -1,68 +1,25 @@
 package commands
 
 import (
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/buildpacks/pack/internal/config"
-	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/logging"
 )
 
+// Deprecated: Use config registries remove instead
 func RemoveRegistry(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
-	var (
-		registryName string
-	)
-
 	cmd := &cobra.Command{
 		Use:     "remove-registry <name>",
 		Args:    cobra.ExactArgs(1),
 		Short:   prependExperimental("Remove registry"),
 		Example: "pack remove-registry myregistry",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			registryName = args[0]
-
-			if registryName == config.OfficialRegistryName {
-				return errors.Errorf("%s is a reserved registry name, please provide a different registry",
-					style.Symbol(config.OfficialRegistryName))
-			}
-
-			index := findRegistryIndex(registryName, cfg.Registries)
-			if index < 0 {
-				return errors.Errorf("registry %s does not exist", style.Symbol(registryName))
-			}
-
-			updatedRegistries := removeRegistry(index, cfg.Registries)
-			cfg.Registries = updatedRegistries
-
-			if cfg.DefaultRegistryName == registryName {
-				cfg.DefaultRegistryName = config.OfficialRegistryName
-			}
-			config.Write(cfg, cfgPath)
-
-			logger.Infof("Successfully removed %s from registries", style.Symbol(registryName))
-
-			return nil
+			deprecationWarning(logger, "remove-registry", "config registries remove")
+			return removeRegistry(args, logger, cfg, cfgPath)
 		}),
 	}
 
 	AddHelpFlag(cmd, "remove-registry")
-
 	return cmd
-}
-
-func findRegistryIndex(registryName string, registries []config.Registry) int {
-	for index, r := range registries {
-		if r.Name == registryName {
-			return index
-		}
-	}
-
-	return -1
-}
-
-func removeRegistry(index int, registries []config.Registry) []config.Registry {
-	registries[index] = registries[len(registries)-1]
-
-	return registries[:len(registries)-1]
 }

--- a/internal/commands/remove_registry_test.go
+++ b/internal/commands/remove_registry_test.go
@@ -83,6 +83,7 @@ func testRemoveRegistryCommand(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			})
+			assert.Contains(outBuf.String(), "been deprecated, please use 'pack config registries remove' instead")
 		})
 
 		it("should remove the registry and matching default registry name", func() {

--- a/internal/commands/set_default_registry.go
+++ b/internal/commands/set_default_registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildpacks/pack/logging"
 )
 
+// Deprecated: Use `pack config registries default` instead
 func SetDefaultRegistry(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
 	var (
 		registryName string
@@ -20,8 +21,9 @@ func SetDefaultRegistry(logger logging.Logger, cfg config.Config, cfgPath string
 		Short:   prependExperimental("Set default registry"),
 		Example: "pack set-default-registry myregistry",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			deprecationWarning(logger, "set-default-registry", "config registries default")
 			registryName = args[0]
-			if !containsRegistry(config.GetRegistries(cfg), registryName) {
+			if !registriesContains(config.GetRegistries(cfg), registryName) {
 				return errors.Errorf("no registry with the name %s exists", style.Symbol(registryName))
 			}
 
@@ -41,14 +43,4 @@ func SetDefaultRegistry(logger logging.Logger, cfg config.Config, cfgPath string
 	AddHelpFlag(cmd, "set-default-registry")
 
 	return cmd
-}
-
-func containsRegistry(registries []config.Registry, registry string) bool {
-	for _, r := range registries {
-		if r.Name == registry {
-			return true
-		}
-	}
-
-	return false
 }

--- a/internal/commands/set_default_registry_test.go
+++ b/internal/commands/set_default_registry_test.go
@@ -64,6 +64,7 @@ func testSetDefaultRegistryCommand(t *testing.T, when spec.G, it spec.S) {
 			assert.Nil(err)
 
 			assert.Equal(cfg.DefaultRegistryName, "myregistry")
+			assert.Contains(outBuf.String(), "has been deprecated, please use 'pack config registries default'")
 		})
 
 		it("should fail if no corresponding registry exists", func() {


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
Deprecate add-registry, list_registries, remove_registry, and set_default_registry in favor of:
* `pack config registries add`
* `pack config registries remove`
* `pack config registries list`
* `pack config registries default [<registry>|--unset]`

## Output
<!-- If applicable, please provide examples of the output changes. -->

### Before
![Screen Shot 2020-12-23 at 4 28 06 PM](https://user-images.githubusercontent.com/7035673/103007386-fb833880-453b-11eb-8179-1c0613958ffe.png)

### After
#### `pack config -h`
```
$  out/pack config -h
Interact with Pack's configuration

Usage:
  pack config [command]

Available Commands:
  trusted-builders  Interact with trusted builders
  run-image-mirrors Interact with run image mirrors
  experimental      Print and set the current 'experimental' value from the config
  registries        (experimental) Interact with registries

Flags:
  -h, --help   Help for 'config'

Global Flags:
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output

Use "pack config [command] --help" for more information about a command.
```

#### `pack config registries -h`
```
$  out/pack config registries -h
(experimental) Interact with registries

Usage:
  pack config registries [flags]
  pack config registries [command]

Aliases:
  registries, registry, registreis

Available Commands:
  add         (experimental) Add a registries
  remove      (experimental) Remove a registries
  list        (experimental) List registries
  default     (experimental) Set default registry

Flags:
  -h, --help   Help for 'registries'

Global Flags:
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output

Use "pack config registries [command] --help" for more information about a command.
```

#### Deprecation Warnings
```
 $  out/pack list-registries
Warning: Command pack list-registries has been deprecated, please use pack config registries list instead
* official
Tip: Run pack add-buildpack-registry to add additional registries
$  out/pack add-registry othername https://github.com/buildpacks/registry-index/
Warning: Command pack add-registry has been deprecated, please use pack config registries add instead
Successfully added othername to registries
 $  out/pack set-default-registry othername
Warning: Command pack set-default-registry has been deprecated, please use pack config registries default instead
Successfully set othername as the default registry
$  out/pack remove-registry othername
Warning: Command pack remove-registry has been deprecated, please use pack config registries remove instead
Successfully removed othername from registries
```

#### `pack config registries list`
```
$  out/pack config registries list
* othername
  official
Tip: Run pack add-buildpack-registry to add additional registries
```

#### `pack config registries add`
```
$  out/pack config registries add othername https://github.com/buildpacks/registry-index
Successfully added othername to registries
```

#### `pack config registries remove`
```
$  out/pack config registries remove othername
Successfully removed othername from registries
```

#### `pack config registries default`
```
$  out/pack config registries default
The current default registry is othername
```

#### `pack config registries default <registry>`
```
$  out/pack config registries default official
Successfully set official as the default registry
```

#### `pack config registries default --unset`
When default is `official`
```
$  out/pack config registries default --unset
ERROR: Registry official is a protected registry, and can be replaced as a default registry, but not removed entirely. To add a new registry and set as default, run `pack config registries add <registry-name> <registry-url> --default.
To set an existing registry as default, call `pack config registries default <registry-name>`
```

When default isn't `official`
```
$  out/pack config registries default --unset
Successfully unset default registry othername
Default registry has been set to official
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
Resolves #923 
Relates to #597 
