### PR TITLE
Reorder commands, and hide deprecated commands"

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -66,15 +66,18 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	commands.AddHelpFlag(rootCmd, "pack")
 
 	rootCmd.AddCommand(commands.Build(logger, cfg, &packClient))
+	rootCmd.AddCommand(commands.NewBuilderCommand(logger, cfg, &packClient))
+	rootCmd.AddCommand(commands.NewBuildpackCommand(logger, cfg, &packClient, buildpackage.NewConfigReader()))
+	rootCmd.AddCommand(commands.NewConfigCommand(logger, cfg, cfgPath, &packClient))
 	rootCmd.AddCommand(commands.Rebase(logger, cfg, &packClient))
+	rootCmd.AddCommand(commands.NewStackCommand(logger))
 
 	rootCmd.AddCommand(commands.InspectImage(logger, imagewriter.NewFactory(), cfg, &packClient))
 	rootCmd.AddCommand(commands.InspectBuildpack(logger, &cfg, &packClient))
-	rootCmd.AddCommand(commands.SetRunImagesMirrors(logger, cfg))
-
-	rootCmd.AddCommand(commands.SetDefaultBuilder(logger, cfg, &packClient))
 	rootCmd.AddCommand(commands.InspectBuilder(logger, cfg, &packClient, builderwriter.NewFactory()))
 
+	rootCmd.AddCommand(commands.SetDefaultBuilder(logger, cfg, &packClient))
+	rootCmd.AddCommand(commands.SetRunImagesMirrors(logger, cfg))
 	rootCmd.AddCommand(commands.SuggestBuilders(logger, &packClient))
 	rootCmd.AddCommand(commands.TrustBuilder(logger, cfg))
 	rootCmd.AddCommand(commands.UntrustBuilder(logger, cfg))
@@ -82,9 +85,6 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	rootCmd.AddCommand(commands.CreateBuilder(logger, cfg, &packClient))
 	rootCmd.AddCommand(commands.PackageBuildpack(logger, cfg, &packClient, buildpackage.NewConfigReader()))
 	rootCmd.AddCommand(commands.SuggestStacks(logger))
-
-	rootCmd.AddCommand(commands.Version(logger, pack.Version))
-	rootCmd.AddCommand(commands.Report(logger, pack.Version, cfgPath))
 
 	if cfg.Experimental {
 		rootCmd.AddCommand(commands.AddBuildpackRegistry(logger, cfg, cfgPath))
@@ -101,12 +101,8 @@ func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	}
 
 	rootCmd.AddCommand(commands.CompletionCommand(logger, packHome))
-
-	rootCmd.AddCommand(commands.NewConfigCommand(logger, cfg, cfgPath, &packClient))
-	rootCmd.AddCommand(commands.NewStackCommand(logger))
-	rootCmd.AddCommand(commands.NewBuilderCommand(logger, cfg, &packClient))
-
-	rootCmd.AddCommand(commands.NewBuildpackCommand(logger, cfg, &packClient, buildpackage.NewConfigReader()))
+	rootCmd.AddCommand(commands.Report(logger, pack.Version, cfgPath))
+	rootCmd.AddCommand(commands.Version(logger, pack.Version))
 
 	rootCmd.Version = pack.Version
 	rootCmd.SetVersionTemplate(`{{.Version}}{{"\n"}}`)

--- a/internal/commands/add_registry.go
+++ b/internal/commands/add_registry.go
@@ -17,6 +17,7 @@ func AddBuildpackRegistry(logger logging.Logger, cfg config.Config, cfgPath stri
 	cmd := &cobra.Command{
 		Use:     "add-registry <name> <url>",
 		Args:    cobra.ExactArgs(2),
+		Hidden:  true,
 		Short:   prependExperimental("Add buildpack registry to your pack config file"),
 		Example: "pack add-registry my-registry https://github.com/buildpacks/my-registry",
 		Long: "A Buildpack Registry is a (still experimental) place to publish, store, and discover buildpacks. " +

--- a/internal/commands/list_registries.go
+++ b/internal/commands/list_registries.go
@@ -12,6 +12,7 @@ func ListBuildpackRegistries(logger logging.Logger, cfg config.Config) *cobra.Co
 	cmd := &cobra.Command{
 		Use:     "list-registries",
 		Args:    cobra.NoArgs,
+		Hidden:  true,
 		Short:   prependExperimental("List buildpack registries"),
 		Example: "pack list-registries",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {

--- a/internal/commands/remove_registry.go
+++ b/internal/commands/remove_registry.go
@@ -12,6 +12,7 @@ func RemoveRegistry(logger logging.Logger, cfg config.Config, cfgPath string) *c
 	cmd := &cobra.Command{
 		Use:     "remove-registry <name>",
 		Args:    cobra.ExactArgs(1),
+		Hidden:  true,
 		Short:   prependExperimental("Remove registry"),
 		Example: "pack remove-registry myregistry",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {

--- a/internal/commands/set_default_builder.go
+++ b/internal/commands/set_default_builder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildpacks/pack/logging"
 )
 
+// Deprecated: Use `pack config default-builder`
 func SetDefaultBuilder(logger logging.Logger, cfg config.Config, client PackClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "set-default-builder <builder-name>",

--- a/internal/commands/set_default_registry.go
+++ b/internal/commands/set_default_registry.go
@@ -18,6 +18,7 @@ func SetDefaultRegistry(logger logging.Logger, cfg config.Config, cfgPath string
 	cmd := &cobra.Command{
 		Use:     "set-default-registry <name>",
 		Args:    cobra.ExactArgs(1),
+		Hidden:  true,
 		Short:   prependExperimental("Set default registry"),
 		Example: "pack set-default-registry myregistry",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This reorders the commands presented in pack

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
```
$  out/pack
CLI for building apps using Cloud Native Buildpacks

Usage:
  pack [command]

Available Commands:
  build                 Generate app image from source code
  rebase                Rebase app image with latest run image
  inspect-image         Show information about a built image
  inspect-buildpack     Show information about a buildpack
  inspect-builder       Show information about a builder
  version               Show current 'pack' version
  report                Display useful information for reporting an issue
  add-registry          (experimental) Add buildpack registry to your pack config file
  list-registries       (experimental) List buildpack registries
  set-default-registry  (experimental) Set default registry
  remove-registry       (experimental) Remove registry
  completion            Outputs completion script location
  config                Interact with Pack's configuration
  stack                 Displays stack information
  builder               Interact with builders
  buildpack             Interact with buildpacks
  help                  Help about any command

Flags:
  -h, --help         Help for 'pack'
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output
      --version      Show current 'pack' version

Use "pack [command] --help" for more information about a command.
```

#### After
```
$  go run cmd/pack/main.go
CLI for building apps using Cloud Native Buildpacks

Usage:
  pack [command]

Available Commands:
  build                 Generate app image from source code
  builder               Interact with builders
  buildpack             Interact with buildpacks
  config                Interact with Pack's configuration
  rebase                Rebase app image with latest run image
  stack                 Displays stack information
  inspect-image         Show information about a built image
  inspect-buildpack     Show information about a buildpack
  inspect-builder       Show information about a builder
  completion            Outputs completion script location
  report                Display useful information for reporting an issue
  version               Show current 'pack' version
  help                  Help about any command

Flags:
  -h, --help         Help for 'pack'
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output
      --version      Show current 'pack' version

Use "pack [command] --help" for more information about a command.
```
## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->