### PR TITLE
Add global pull policy configuration command

### DIFF
--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -87,7 +87,11 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				logger.Warn("Using untrusted builder with volume mounts. If there is sensitive data in the volumes, this may present a security vulnerability.")
 			}
 
-			pullPolicy, err := pubcfg.ParsePullPolicy(flags.Policy)
+			stringPolicy := flags.Policy
+			if stringPolicy == "" {
+				stringPolicy = cfg.PullPolicy
+			}
+			pullPolicy, err := pubcfg.ParsePullPolicy(stringPolicy)
 			if err != nil {
 				return errors.Wrapf(err, "parsing pull policy %s", flags.Policy)
 			}

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -151,6 +151,45 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 				command.SetArgs([]string{"image", "--builder", "my-builder", "--pull-policy", "unknown-policy"})
 				h.AssertError(t, command.Execute(), "parsing pull policy")
 			})
+			it("takes precedence over a configured pull policy", func() {
+				mockClient.EXPECT().
+					Build(gomock.Any(), EqBuildOptionsWithPullPolicy(pubcfg.PullNever)).
+					Return(nil)
+
+				cfg := config.Config{PullPolicy: "if-not-present"}
+				command := commands.Build(logger, cfg, mockClient)
+
+				logger.WantVerbose(true)
+				command.SetArgs([]string{"image", "--builder", "my-builder", "--pull-policy", "never"})
+				h.AssertNil(t, command.Execute())
+			})
+		})
+
+		when("--pull-policy is not specified", func() {
+			when("no pull policy set in config", func() {
+				it("uses the default policy", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithPullPolicy(pubcfg.PullAlways)).
+						Return(nil)
+
+					command.SetArgs([]string{"image", "--builder", "my-builder"})
+					h.AssertNil(t, command.Execute())
+				})
+			})
+			when("pull policy is set in config", func() {
+				it("uses the set policy", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithPullPolicy(pubcfg.PullNever)).
+						Return(nil)
+
+					cfg := config.Config{PullPolicy: "never"}
+					command := commands.Build(logger, cfg, mockClient)
+
+					logger.WantVerbose(true)
+					command.SetArgs([]string{"image", "--builder", "my-builder"})
+					h.AssertNil(t, command.Execute())
+				})
+			})
 		})
 
 		when("volume mounts are specified", func() {

--- a/internal/commands/builder_create.go
+++ b/internal/commands/builder_create.go
@@ -43,7 +43,11 @@ Creating a custom builder allows you to control what buildpacks are used and wha
 				return err
 			}
 
-			pullPolicy, err := pubcfg.ParsePullPolicy(flags.Policy)
+			stringPolicy := flags.Policy
+			if stringPolicy == "" {
+				stringPolicy = cfg.PullPolicy
+			}
+			pullPolicy, err := pubcfg.ParsePullPolicy(stringPolicy)
 			if err != nil {
 				return errors.Wrapf(err, "parsing pull policy %s", flags.Policy)
 			}

--- a/internal/commands/builder_create_test.go
+++ b/internal/commands/builder_create_test.go
@@ -92,6 +92,20 @@ func testCreateCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("--pull-policy is not specified", func() {
+			when("configured pull policy is invalid", func() {
+				it("errors when config set with unknown policy", func() {
+					cfg = config.Config{PullPolicy: "unknown-policy"}
+					command = commands.BuilderCreate(logger, cfg, mockClient)
+					command.SetArgs([]string{
+						"some/builder",
+						"--config", builderConfigPath,
+					})
+					h.AssertError(t, command.Execute(), "parsing pull policy")
+				})
+			})
+		})
+
 		when("--buildpack-registry flag is specified but experimental isn't set in the config", func() {
 			it("errors with a descriptive message", func() {
 				command.SetArgs([]string{

--- a/internal/commands/buildpack.go
+++ b/internal/commands/buildpack.go
@@ -15,7 +15,7 @@ func NewBuildpackCommand(logger logging.Logger, cfg config.Config, client PackCl
 		RunE:    nil,
 	}
 
-	cmd.AddCommand(BuildpackPackage(logger, client, packageConfigReader))
+	cmd.AddCommand(BuildpackPackage(logger, client, cfg, packageConfigReader))
 	if cfg.Experimental {
 		cmd.AddCommand(BuildpackPull(logger, cfg, client))
 		cmd.AddCommand(BuildpackRegister(logger, cfg, client))

--- a/internal/commands/buildpack.go
+++ b/internal/commands/buildpack.go
@@ -15,7 +15,7 @@ func NewBuildpackCommand(logger logging.Logger, cfg config.Config, client PackCl
 		RunE:    nil,
 	}
 
-	cmd.AddCommand(BuildpackPackage(logger, client, cfg, packageConfigReader))
+	cmd.AddCommand(BuildpackPackage(logger, cfg, client, packageConfigReader))
 	if cfg.Experimental {
 		cmd.AddCommand(BuildpackPull(logger, cfg, client))
 		cmd.AddCommand(BuildpackRegister(logger, cfg, client))

--- a/internal/commands/buildpack_package.go
+++ b/internal/commands/buildpack_package.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildpacks/pack"
 	pubbldpkg "github.com/buildpacks/pack/buildpackage"
 	pubcfg "github.com/buildpacks/pack/config"
+	"github.com/buildpacks/pack/internal/config"
 	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/logging"
 )
@@ -33,7 +34,7 @@ type PackageConfigReader interface {
 }
 
 // BuildpackPackage packages (a) buildpack(s) into OCI format, based on a package config
-func BuildpackPackage(logger logging.Logger, client BuildpackPackager, packageConfigReader PackageConfigReader) *cobra.Command {
+func BuildpackPackage(logger logging.Logger, client BuildpackPackager, cfg config.Config, packageConfigReader PackageConfigReader) *cobra.Command {
 	var flags BuildpackPackageFlags
 	cmd := &cobra.Command{
 		Use:     "package <name> --config <config-path>",
@@ -51,15 +52,20 @@ func BuildpackPackage(logger logging.Logger, client BuildpackPackager, packageCo
 			}
 
 			var err error
-			pullPolicy, err := pubcfg.ParsePullPolicy(flags.Policy)
+			var pullPolicy pubcfg.PullPolicy
+			stringPolicy := flags.Policy
+			if stringPolicy == "" {
+				stringPolicy = cfg.PullPolicy
+			}
+			pullPolicy, err = pubcfg.ParsePullPolicy(stringPolicy)
 			if err != nil {
 				return errors.Wrap(err, "parsing pull policy")
 			}
 
-			cfg := pubbldpkg.DefaultConfig()
+			pubbldpkgCfg := pubbldpkg.DefaultConfig()
 			relativeBaseDir := ""
 			if flags.PackageTomlPath != "" {
-				cfg, err = packageConfigReader.Read(flags.PackageTomlPath)
+				pubbldpkgCfg, err = packageConfigReader.Read(flags.PackageTomlPath)
 				if err != nil {
 					return errors.Wrap(err, "reading config")
 				}
@@ -75,7 +81,7 @@ func BuildpackPackage(logger logging.Logger, client BuildpackPackager, packageCo
 				RelativeBaseDir: relativeBaseDir,
 				Name:            name,
 				Format:          flags.Format,
-				Config:          cfg,
+				Config:          pubbldpkgCfg,
 				Publish:         flags.Publish,
 				PullPolicy:      pullPolicy,
 			}); err != nil {

--- a/internal/commands/buildpack_package.go
+++ b/internal/commands/buildpack_package.go
@@ -34,7 +34,7 @@ type PackageConfigReader interface {
 }
 
 // BuildpackPackage packages (a) buildpack(s) into OCI format, based on a package config
-func BuildpackPackage(logger logging.Logger, client BuildpackPackager, cfg config.Config, packageConfigReader PackageConfigReader) *cobra.Command {
+func BuildpackPackage(logger logging.Logger, cfg config.Config, client BuildpackPackager, packageConfigReader PackageConfigReader) *cobra.Command {
 	var flags BuildpackPackageFlags
 	cmd := &cobra.Command{
 		Use:     "package <name> --config <config-path>",
@@ -51,21 +51,19 @@ func BuildpackPackage(logger logging.Logger, client BuildpackPackager, cfg confi
 				return err
 			}
 
-			var err error
-			var pullPolicy pubcfg.PullPolicy
 			stringPolicy := flags.Policy
 			if stringPolicy == "" {
 				stringPolicy = cfg.PullPolicy
 			}
-			pullPolicy, err = pubcfg.ParsePullPolicy(stringPolicy)
+			pullPolicy, err := pubcfg.ParsePullPolicy(stringPolicy)
 			if err != nil {
 				return errors.Wrap(err, "parsing pull policy")
 			}
 
-			pubbldpkgCfg := pubbldpkg.DefaultConfig()
+			bpPackageCfg := pubbldpkg.DefaultConfig()
 			relativeBaseDir := ""
 			if flags.PackageTomlPath != "" {
-				pubbldpkgCfg, err = packageConfigReader.Read(flags.PackageTomlPath)
+				bpPackageCfg, err = packageConfigReader.Read(flags.PackageTomlPath)
 				if err != nil {
 					return errors.Wrap(err, "reading config")
 				}
@@ -81,7 +79,7 @@ func BuildpackPackage(logger logging.Logger, client BuildpackPackager, cfg confi
 				RelativeBaseDir: relativeBaseDir,
 				Name:            name,
 				Format:          flags.Format,
-				Config:          pubbldpkgCfg,
+				Config:          bpPackageCfg,
 				Publish:         flags.Publish,
 				PullPolicy:      pullPolicy,
 			}); err != nil {

--- a/internal/commands/buildpack_package_test.go
+++ b/internal/commands/buildpack_package_test.go
@@ -112,6 +112,21 @@ func testPackageCommand(t *testing.T, when spec.G, it spec.S) {
 					h.AssertEq(t, receivedOptions.PullPolicy, pubcfg.PullAlways)
 				})
 			})
+			when("no --pull-policy", func() {
+				var pullPolicyArgs = []string{
+					"some-image-name",
+					"--config", "/path/to/some/file",
+				}
+
+				it("uses the default policy when no policy configured", func() {
+					cmd := packageCommand(withBuildpackPackager(fakeBuildpackPackager))
+					cmd.SetArgs(pullPolicyArgs)
+					h.AssertNil(t, cmd.Execute())
+
+					receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+					h.AssertEq(t, receivedOptions.PullPolicy, pubcfg.PullAlways)
+				})
+			})
 		})
 
 		when("no config path is specified", func() {
@@ -209,7 +224,7 @@ func packageCommand(ops ...packageCommandOption) *cobra.Command {
 		op(config)
 	}
 
-	cmd := commands.BuildpackPackage(config.logger, config.buildpackPackager, config.packageConfigReader)
+	cmd := commands.BuildpackPackage(config.logger, config.buildpackPackager, config.clientConfig, config.packageConfigReader)
 	cmd.SetArgs([]string{config.imageName, "--config", config.configPath})
 
 	return cmd

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -20,10 +20,10 @@ func NewConfigCommand(logger logging.Logger, cfg config.Config, cfgPath string, 
 	cmd.AddCommand(ConfigExperimental(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigTrustedBuilder(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigRunImagesMirrors(logger, cfg, cfgPath))
+	cmd.AddCommand(ConfigPullPolicy(logger, cfg, cfgPath))
 
 	if cfg.Experimental {
 		cmd.AddCommand(ConfigRegistries(logger, cfg, cfgPath))
-		cmd.AddCommand(ConfigPullPolicy(logger, cfg, cfgPath))
 	}
 
 	AddHelpFlag(cmd, "config")

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -18,9 +18,9 @@ func NewConfigCommand(logger logging.Logger, cfg config.Config, cfgPath string, 
 
 	cmd.AddCommand(ConfigDefaultBuilder(logger, cfg, cfgPath, client))
 	cmd.AddCommand(ConfigExperimental(logger, cfg, cfgPath))
+	cmd.AddCommand(ConfigPullPolicy(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigTrustedBuilder(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigRunImagesMirrors(logger, cfg, cfgPath))
-	cmd.AddCommand(ConfigPullPolicy(logger, cfg, cfgPath))
 
 	if cfg.Experimental {
 		cmd.AddCommand(ConfigRegistries(logger, cfg, cfgPath))

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -23,6 +23,7 @@ func NewConfigCommand(logger logging.Logger, cfg config.Config, cfgPath string, 
 
 	if cfg.Experimental {
 		cmd.AddCommand(ConfigRegistries(logger, cfg, cfgPath))
+		cmd.AddCommand(ConfigPullPolicy(logger, cfg, cfgPath))
 	}
 
 	AddHelpFlag(cmd, "config")

--- a/internal/commands/config_pull_policy.go
+++ b/internal/commands/config_pull_policy.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -15,15 +17,14 @@ func ConfigPullPolicy(logger logging.Logger, cfg config.Config, cfgPath string) 
 	var unset bool
 
 	cmd := &cobra.Command{
-		Use:     "pull-policy <if-not-present | always | never>",
-		Args:    cobra.MaximumNArgs(1),
-		Short:   "List, set and unset the global pull policy used by other commands",
-		Aliases: []string{"pull-policy"},
+		Use:   "pull-policy <if-not-present | always | never>",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "List, set and unset the global pull policy used by other commands",
 		Long: bpRegistryExplanation + "\n\nYou can use this command to list, set, and unset the default pull policy that will be used when working with containers:\n" +
 			"* To list your pull policy, run `pack config pull-policy`.\n" +
 			"* To set your pull policy, run `pack config pull-policy <pull-policy>`.\n" +
 			"* To unset your pull policy, run `pack config pull-policy --unset`.\n" +
-			"Unsetting the pull policy will reset the policy to the default, which is always",
+			fmt.Sprintf("Unsetting the pull policy will reset the policy to the default, which is %s", style.Symbol("always")),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			switch {
 			case unset:
@@ -75,7 +76,7 @@ func ConfigPullPolicy(logger logging.Logger, cfg config.Config, cfgPath string) 
 		}),
 	}
 
-	cmd.Flags().BoolVarP(&unset, "unset", "u", false, "Unset pull policy, and set it back to the default pull-policy, which is always")
+	cmd.Flags().BoolVarP(&unset, "unset", "u", false, "Unset pull policy, and set it back to the default pull-policy, which is "+style.Symbol("always"))
 	AddHelpFlag(cmd, "pull-policy")
 	return cmd
 }

--- a/internal/commands/config_pull_policy.go
+++ b/internal/commands/config_pull_policy.go
@@ -17,12 +17,12 @@ func ConfigPullPolicy(logger logging.Logger, cfg config.Config, cfgPath string) 
 	var unset bool
 
 	cmd := &cobra.Command{
-		Use:   "pull-policy <if-not-present | always | never>",
+		Use:   "pull-policy <always | if-not-present | never>",
 		Args:  cobra.MaximumNArgs(1),
 		Short: "List, set and unset the global pull policy used by other commands",
-		Long: bpRegistryExplanation + "\n\nYou can use this command to list, set, and unset the default pull policy that will be used when working with containers:\n" +
+		Long: "You can use this command to list, set, and unset the default pull policy that will be used when working with containers:\n" +
 			"* To list your pull policy, run `pack config pull-policy`.\n" +
-			"* To set your pull policy, run `pack config pull-policy <pull-policy>`.\n" +
+			"* To set your pull policy, run `pack config pull-policy <always | if-not-present | never>`.\n" +
 			"* To unset your pull policy, run `pack config pull-policy --unset`.\n" +
 			fmt.Sprintf("Unsetting the pull policy will reset the policy to the default, which is %s", style.Symbol("always")),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
@@ -55,7 +55,7 @@ func ConfigPullPolicy(logger logging.Logger, cfg config.Config, cfgPath string) 
 				newPullPolicy := args[0]
 
 				if newPullPolicy == cfg.PullPolicy {
-					logger.Infof("Pull policy is already set to %s", newPullPolicy)
+					logger.Infof("Pull policy is already set to %s", style.Symbol(newPullPolicy))
 					return nil
 				}
 

--- a/internal/commands/config_pull_policy.go
+++ b/internal/commands/config_pull_policy.go
@@ -68,7 +68,11 @@ func ConfigPullPolicy(logger logging.Logger, cfg config.Config, cfgPath string) 
 
 				cfg.PullPolicy = newPullPolicy
 				if err := config.Write(cfg, cfgPath); err != nil {
+<<<<<<< HEAD
 					return errors.Wrapf(err, "writing config to %s", cfgPath)
+=======
+					return errors.Wrap(err, "writing config to")
+>>>>>>> c57c6a95 (Add ConfigPullPolicy function and tests)
 				}
 
 				logger.Infof("Successfully set %s as the pull policy", style.Symbol(pullPolicy.String()))

--- a/internal/commands/config_pull_policy.go
+++ b/internal/commands/config_pull_policy.go
@@ -1,0 +1,84 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	pubcfg "github.com/buildpacks/pack/config"
+
+	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
+)
+
+func ConfigPullPolicy(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
+	var unset bool
+
+	cmd := &cobra.Command{
+		Use:     "pull-policy <if-not-present | always | never>",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "List, set and unset the global pull policy used by other commands",
+		Aliases: []string{"pull-policy"},
+		Long: bpRegistryExplanation + "\n\nYou can use this command to list, set, and unset the default pull policy that will be used when working with containers:\n" +
+			"* To list your pull policy, run `pack config pull-policy`.\n" +
+			"* To set your pull policy, run `pack config pull-policy <pull-policy>`.\n" +
+			"* To unset your pull policy, run `pack config pull-policy --unset`.\n" +
+			fmt.Sprintf("Unsetting the pull policy will reset the policy to the default, which is always"),
+		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			switch {
+			case unset:
+				if len(args) > 0 {
+					return errors.Errorf("pull policy and --unset cannot be specified simultaneously")
+				}
+				oldPullPolicy := cfg.PullPolicy
+				cfg.PullPolicy = ""
+				if err := config.Write(cfg, cfgPath); err != nil {
+					return errors.Wrapf(err, "writing config to %s", cfgPath)
+				}
+
+				pullPolicy, err := pubcfg.ParsePullPolicy(cfg.PullPolicy)
+				if err != nil {
+					return err
+				}
+
+				logger.Infof("Successfully unset pull policy %s", style.Symbol(oldPullPolicy))
+				logger.Infof("Pull policy has been set to %s", style.Symbol(pullPolicy.String()))
+
+			case len(args) == 0: // list
+				pullPolicy, err := pubcfg.ParsePullPolicy(cfg.PullPolicy)
+				if err != nil {
+					return err
+				}
+
+				logger.Infof("The current pull policy is %s", style.Symbol(pullPolicy.String()))
+			default: // set
+				newPullPolicy := args[0]
+
+				if newPullPolicy == cfg.PullPolicy {
+					logger.Infof("Pull policy is already set to %s", newPullPolicy)
+					return nil
+				}
+
+				pullPolicy, err := pubcfg.ParsePullPolicy(newPullPolicy)
+				if err != nil {
+					return err
+				}
+
+				cfg.PullPolicy = newPullPolicy
+				if err := config.Write(cfg, cfgPath); err != nil {
+					return errors.Wrapf(err, "writing config to %s", cfgPath)
+				}
+
+				logger.Infof("Successfully set %s as the pull policy", style.Symbol(pullPolicy.String()))
+			}
+
+			return nil
+		}),
+	}
+
+	cmd.Flags().BoolVarP(&unset, "unset", "u", false, "Unset pull policy, and set it back to the default pull-policy, which is always")
+	AddHelpFlag(cmd, "pull-policy")
+	return cmd
+}

--- a/internal/commands/config_pull_policy.go
+++ b/internal/commands/config_pull_policy.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -25,7 +23,7 @@ func ConfigPullPolicy(logger logging.Logger, cfg config.Config, cfgPath string) 
 			"* To list your pull policy, run `pack config pull-policy`.\n" +
 			"* To set your pull policy, run `pack config pull-policy <pull-policy>`.\n" +
 			"* To unset your pull policy, run `pack config pull-policy --unset`.\n" +
-			fmt.Sprintf("Unsetting the pull policy will reset the policy to the default, which is always"),
+			"Unsetting the pull policy will reset the policy to the default, which is always",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			switch {
 			case unset:
@@ -45,7 +43,6 @@ func ConfigPullPolicy(logger logging.Logger, cfg config.Config, cfgPath string) 
 
 				logger.Infof("Successfully unset pull policy %s", style.Symbol(oldPullPolicy))
 				logger.Infof("Pull policy has been set to %s", style.Symbol(pullPolicy.String()))
-
 			case len(args) == 0: // list
 				pullPolicy, err := pubcfg.ParsePullPolicy(cfg.PullPolicy)
 				if err != nil {
@@ -68,11 +65,7 @@ func ConfigPullPolicy(logger logging.Logger, cfg config.Config, cfgPath string) 
 
 				cfg.PullPolicy = newPullPolicy
 				if err := config.Write(cfg, cfgPath); err != nil {
-<<<<<<< HEAD
 					return errors.Wrapf(err, "writing config to %s", cfgPath)
-=======
-					return errors.Wrap(err, "writing config to")
->>>>>>> c57c6a95 (Add ConfigPullPolicy function and tests)
 				}
 
 				logger.Infof("Successfully set %s as the pull policy", style.Symbol(pullPolicy.String()))

--- a/internal/commands/config_pull_policy_test.go
+++ b/internal/commands/config_pull_policy_test.go
@@ -28,7 +28,7 @@ func TestConfigPullPolicy(t *testing.T) {
 
 func testConfigPullPolicyCommand(t *testing.T, when spec.G, it spec.S) {
 	var (
-		command          *cobra.Command
+		command      *cobra.Command
 		logger       logging.Logger
 		outBuf       bytes.Buffer
 		tempPackHome string

--- a/internal/commands/config_pull_policy_test.go
+++ b/internal/commands/config_pull_policy_test.go
@@ -1,0 +1,198 @@
+package commands_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/commands"
+	"github.com/buildpacks/pack/internal/config"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestConfigPullPolicy(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "ConfigPullPolicyCommand", testConfigPullPolicyCommand, spec.Random(), spec.Report(report.Terminal{}))
+}
+
+func testConfigPullPolicyCommand(t *testing.T, when spec.G, it spec.S) {
+	var (
+		command          *cobra.Command
+		logger       logging.Logger
+		outBuf       bytes.Buffer
+		tempPackHome string
+		configFile   string
+		assert       = h.NewAssertionManager(t)
+		cfg          = config.Config{}
+	)
+
+	it.Before(func() {
+		var err error
+		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		h.AssertNil(t, err)
+		configFile = filepath.Join(tempPackHome, "config.toml")
+
+		command = commands.ConfigPullPolicy(logger, cfg, configFile)
+		command.SetOut(logging.GetWriterForLevel(logger, logging.InfoLevel))
+	})
+
+	it.After(func() {
+		h.AssertNil(t, os.RemoveAll(tempPackHome))
+	})
+
+	when("#ConfigPullPolicy", func() {
+		when("no policy is specified", func() {
+			it("lists default pull policy", func() {
+				command.SetArgs([]string{})
+
+				h.AssertNil(t, command.Execute())
+
+				assert.Contains(outBuf.String(), "always")
+			})
+		})
+
+		when("policy set to always in config", func() {
+			it("lists always as pull policy", func() {
+				cfg.PullPolicy = "always"
+				command = commands.ConfigPullPolicy(logger, cfg, configFile)
+				command.SetArgs([]string{})
+
+				h.AssertNil(t, command.Execute())
+
+				assert.Contains(outBuf.String(), "always")
+			})
+		})
+
+		when("policy set to never in config", func() {
+			it("lists never as pull policy", func() {
+				cfg.PullPolicy = "never"
+				command = commands.ConfigPullPolicy(logger, cfg, configFile)
+				command.SetArgs([]string{})
+
+				h.AssertNil(t, command.Execute())
+
+				assert.Contains(outBuf.String(), "never")
+			})
+		})
+
+		when("policy set to if-not-present in config", func() {
+			it("lists if-not-present as pull policy", func() {
+				cfg.PullPolicy = "if-not-present"
+				command = commands.ConfigPullPolicy(logger, cfg, configFile)
+				command.SetArgs([]string{})
+
+				h.AssertNil(t, command.Execute())
+
+				assert.Contains(outBuf.String(), "if-not-present")
+			})
+		})
+
+		when("policy provided is the same as configured pull policy", func() {
+			it("provides a helpful message", func() {
+				cfg.PullPolicy = "if-not-present"
+				command = commands.ConfigPullPolicy(logger, cfg, configFile)
+				command.SetArgs([]string{"if-not-present"})
+
+				h.AssertNil(t, command.Execute())
+
+				output := outBuf.String()
+				h.AssertEq(t, strings.TrimSpace(output), `Pull policy is already set to if-not-present`)
+			})
+			it("it does not change the configured policy", func() {
+				command = commands.ConfigPullPolicy(logger, cfg, configFile)
+				command.SetArgs([]string{"never"})
+				assert.Succeeds(command.Execute())
+
+				command = commands.ConfigPullPolicy(logger, cfg, configFile)
+				command.SetArgs([]string{"never"})
+				assert.Succeeds(command.Execute())
+
+				readCfg, err := config.Read(configFile)
+				assert.Nil(err)
+				assert.Equal(readCfg.PullPolicy, "never")
+			})
+		})
+
+		when("invalid policy is specified", func() {
+			it("reports error", func() {
+				cfg.PullPolicy = "unknown-policy"
+				command = commands.ConfigPullPolicy(logger, cfg, configFile)
+				command.SetArgs([]string{})
+
+				err := command.Execute()
+				h.AssertError(t, err, `invalid pull policy unknown-policy`)
+			})
+			it("does not write invalid policy to config", func() {
+				command.SetArgs([]string{"never"})
+				assert.Succeeds(command.Execute())
+
+				command.SetArgs([]string{"invalid-policy"})
+				command.Execute()
+
+				readCfg, err := config.Read(configFile)
+				assert.Nil(err)
+				assert.Equal(readCfg.PullPolicy, "never")
+			})
+		})
+
+		when("valid policy is specified", func() {
+			it("sets the policy in config", func() {
+				command.SetArgs([]string{"never"})
+				assert.Succeeds(command.Execute())
+
+				readCfg, err := config.Read(configFile)
+				assert.Nil(err)
+				assert.Equal(readCfg.PullPolicy, "never")
+			})
+			it("returns clear error if fails to write", func() {
+				assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+				command := commands.ConfigPullPolicy(logger, cfg, configFile)
+				command.SetArgs([]string{"if-not-present"})
+				assert.ErrorContains(command.Execute(), "writing config to")
+			})
+		})
+
+		when("--unset", func() {
+			it("removes set policy and resets to default pull policy", func() {
+				command.SetArgs([]string{"never"})
+				command = commands.ConfigPullPolicy(logger, cfg, configFile)
+
+				command.SetArgs([]string{"--unset"})
+				assert.Succeeds(command.Execute())
+
+				cfg, err := config.Read(configFile)
+				assert.Nil(err)
+				assert.Equal(cfg.PullPolicy, "")
+			})
+			it("returns clear error if fails to write", func() {
+				assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+				command := commands.ConfigPullPolicy(logger, config.Config{PullPolicy: "never"}, configFile)
+				command.SetArgs([]string{"--unset"})
+				assert.ErrorContains(command.Execute(), "writing config to")
+			})
+		})
+
+		when("--unset and policy to set is provided", func() {
+			it("errors", func() {
+				command.SetArgs([]string{
+					"never",
+					"--unset",
+				})
+				err := command.Execute()
+				h.AssertError(t, err, `pull policy and --unset cannot be specified simultaneously`)
+			})
+		})
+	})
+}

--- a/internal/commands/config_pull_policy_test.go
+++ b/internal/commands/config_pull_policy_test.go
@@ -109,7 +109,7 @@ func testConfigPullPolicyCommand(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, command.Execute())
 
 					output := outBuf.String()
-					h.AssertEq(t, strings.TrimSpace(output), `Pull policy is already set to if-not-present`)
+					h.AssertEq(t, strings.TrimSpace(output), `Pull policy is already set to 'if-not-present'`)
 				})
 				it("it does not change the configured policy", func() {
 					command = commands.ConfigPullPolicy(logger, cfg, configFile)

--- a/internal/commands/config_pull_policy_test.go
+++ b/internal/commands/config_pull_policy_test.go
@@ -53,118 +53,116 @@ func testConfigPullPolicyCommand(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#ConfigPullPolicy", func() {
-		when("no policy is specified", func() {
-			it("lists default pull policy", func() {
-				command.SetArgs([]string{})
+		when("list", func() {
+			when("no policy is specified", func() {
+				it("lists default pull policy", func() {
+					command.SetArgs([]string{})
 
-				h.AssertNil(t, command.Execute())
+					h.AssertNil(t, command.Execute())
 
-				assert.Contains(outBuf.String(), "always")
+					assert.Contains(outBuf.String(), "always")
+				})
+			})
+			when("policy set to always in config", func() {
+				it("lists always as pull policy", func() {
+					cfg.PullPolicy = "always"
+					command = commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{})
+
+					h.AssertNil(t, command.Execute())
+
+					assert.Contains(outBuf.String(), "always")
+				})
+			})
+
+			when("policy set to never in config", func() {
+				it("lists never as pull policy", func() {
+					cfg.PullPolicy = "never"
+					command = commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{})
+
+					h.AssertNil(t, command.Execute())
+
+					assert.Contains(outBuf.String(), "never")
+				})
+			})
+
+			when("policy set to if-not-present in config", func() {
+				it("lists if-not-present as pull policy", func() {
+					cfg.PullPolicy = "if-not-present"
+					command = commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{})
+
+					h.AssertNil(t, command.Execute())
+
+					assert.Contains(outBuf.String(), "if-not-present")
+				})
 			})
 		})
+		when("set", func() {
+			when("policy provided is the same as configured pull policy", func() {
+				it("provides a helpful message", func() {
+					cfg.PullPolicy = "if-not-present"
+					command = commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{"if-not-present"})
 
-		when("policy set to always in config", func() {
-			it("lists always as pull policy", func() {
-				cfg.PullPolicy = "always"
-				command = commands.ConfigPullPolicy(logger, cfg, configFile)
-				command.SetArgs([]string{})
+					h.AssertNil(t, command.Execute())
 
-				h.AssertNil(t, command.Execute())
+					output := outBuf.String()
+					h.AssertEq(t, strings.TrimSpace(output), `Pull policy is already set to if-not-present`)
+				})
+				it("it does not change the configured policy", func() {
+					command = commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{"never"})
+					assert.Succeeds(command.Execute())
 
-				assert.Contains(outBuf.String(), "always")
+					readCfg, err := config.Read(configFile)
+					assert.Nil(err)
+					assert.Equal(readCfg.PullPolicy, "never")
+
+					command = commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{"never"})
+					assert.Succeeds(command.Execute())
+
+					readCfg, err = config.Read(configFile)
+					assert.Nil(err)
+					assert.Equal(readCfg.PullPolicy, "never")
+				})
+			})
+
+			when("invalid policy is specified", func() {
+				it("does not write invalid policy to config", func() {
+					command.SetArgs([]string{"never"})
+					assert.Succeeds(command.Execute())
+
+					command.SetArgs([]string{"invalid-policy"})
+					err := command.Execute()
+					h.AssertError(t, err, `invalid pull policy invalid-policy`)
+
+					readCfg, err := config.Read(configFile)
+					assert.Nil(err)
+					assert.Equal(readCfg.PullPolicy, "never")
+				})
+			})
+
+			when("valid policy is specified", func() {
+				it("sets the policy in config", func() {
+					command.SetArgs([]string{"never"})
+					assert.Succeeds(command.Execute())
+
+					readCfg, err := config.Read(configFile)
+					assert.Nil(err)
+					assert.Equal(readCfg.PullPolicy, "never")
+				})
+				it("returns clear error if fails to write", func() {
+					assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+					command := commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{"if-not-present"})
+					assert.ErrorContains(command.Execute(), "writing config to")
+				})
 			})
 		})
-
-		when("policy set to never in config", func() {
-			it("lists never as pull policy", func() {
-				cfg.PullPolicy = "never"
-				command = commands.ConfigPullPolicy(logger, cfg, configFile)
-				command.SetArgs([]string{})
-
-				h.AssertNil(t, command.Execute())
-
-				assert.Contains(outBuf.String(), "never")
-			})
-		})
-
-		when("policy set to if-not-present in config", func() {
-			it("lists if-not-present as pull policy", func() {
-				cfg.PullPolicy = "if-not-present"
-				command = commands.ConfigPullPolicy(logger, cfg, configFile)
-				command.SetArgs([]string{})
-
-				h.AssertNil(t, command.Execute())
-
-				assert.Contains(outBuf.String(), "if-not-present")
-			})
-		})
-
-		when("policy provided is the same as configured pull policy", func() {
-			it("provides a helpful message", func() {
-				cfg.PullPolicy = "if-not-present"
-				command = commands.ConfigPullPolicy(logger, cfg, configFile)
-				command.SetArgs([]string{"if-not-present"})
-
-				h.AssertNil(t, command.Execute())
-
-				output := outBuf.String()
-				h.AssertEq(t, strings.TrimSpace(output), `Pull policy is already set to if-not-present`)
-			})
-			it("it does not change the configured policy", func() {
-				command = commands.ConfigPullPolicy(logger, cfg, configFile)
-				command.SetArgs([]string{"never"})
-				assert.Succeeds(command.Execute())
-
-				command = commands.ConfigPullPolicy(logger, cfg, configFile)
-				command.SetArgs([]string{"never"})
-				assert.Succeeds(command.Execute())
-
-				readCfg, err := config.Read(configFile)
-				assert.Nil(err)
-				assert.Equal(readCfg.PullPolicy, "never")
-			})
-		})
-
-		when("invalid policy is specified", func() {
-			it("reports error", func() {
-				cfg.PullPolicy = "unknown-policy"
-				command = commands.ConfigPullPolicy(logger, cfg, configFile)
-				command.SetArgs([]string{})
-
-				err := command.Execute()
-				h.AssertError(t, err, `invalid pull policy unknown-policy`)
-			})
-			it("does not write invalid policy to config", func() {
-				command.SetArgs([]string{"never"})
-				assert.Succeeds(command.Execute())
-
-				command.SetArgs([]string{"invalid-policy"})
-				command.Execute()
-
-				readCfg, err := config.Read(configFile)
-				assert.Nil(err)
-				assert.Equal(readCfg.PullPolicy, "never")
-			})
-		})
-
-		when("valid policy is specified", func() {
-			it("sets the policy in config", func() {
-				command.SetArgs([]string{"never"})
-				assert.Succeeds(command.Execute())
-
-				readCfg, err := config.Read(configFile)
-				assert.Nil(err)
-				assert.Equal(readCfg.PullPolicy, "never")
-			})
-			it("returns clear error if fails to write", func() {
-				assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
-				command := commands.ConfigPullPolicy(logger, cfg, configFile)
-				command.SetArgs([]string{"if-not-present"})
-				assert.ErrorContains(command.Execute(), "writing config to")
-			})
-		})
-
-		when("--unset", func() {
+		when("unset", func() {
 			it("removes set policy and resets to default pull policy", func() {
 				command.SetArgs([]string{"never"})
 				command = commands.ConfigPullPolicy(logger, cfg, configFile)
@@ -183,7 +181,6 @@ func testConfigPullPolicyCommand(t *testing.T, when spec.G, it spec.S) {
 				assert.ErrorContains(command.Execute(), "writing config to")
 			})
 		})
-
 		when("--unset and policy to set is provided", func() {
 			it("errors", func() {
 				command.SetArgs([]string{

--- a/internal/commands/config_test.go
+++ b/internal/commands/config_test.go
@@ -63,7 +63,7 @@ func testConfigCommand(t *testing.T, when spec.G, it spec.S) {
 			output := outBuf.String()
 			h.AssertContains(t, output, "Interact with Pack's configuration")
 			h.AssertContains(t, output, "Usage:")
-			for _, command := range []string{"trusted-builders", "run-image-mirrors", "default-builder", "experimental", "registries"} {
+			for _, command := range []string{"trusted-builders", "run-image-mirrors", "default-builder", "experimental", "registries", "pull-policy"} {
 				h.AssertContains(t, output, command)
 			}
 		})

--- a/internal/commands/create_builder.go
+++ b/internal/commands/create_builder.go
@@ -39,7 +39,11 @@ Creating a custom builder allows you to control what buildpacks are used and wha
 				return err
 			}
 
-			pullPolicy, err := pubcfg.ParsePullPolicy(flags.Policy)
+			stringPolicy := flags.Policy
+			if stringPolicy == "" {
+				stringPolicy = cfg.PullPolicy
+			}
+			pullPolicy, err := pubcfg.ParsePullPolicy(stringPolicy)
 			if err != nil {
 				return errors.Wrapf(err, "parsing pull policy %s", flags.Policy)
 			}

--- a/internal/commands/create_builder_test.go
+++ b/internal/commands/create_builder_test.go
@@ -95,6 +95,20 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("--pull-policy is not specified", func() {
+			when("configured pull policy is invalid", func() {
+				it("returns error for when config set with unknown policy", func() {
+					cfg = config.Config{PullPolicy: "unknown-policy"}
+					command = commands.BuilderCreate(logger, cfg, mockClient)
+					command.SetArgs([]string{
+						"some/builder",
+						"--config", builderConfigPath,
+					})
+					h.AssertError(t, command.Execute(), "parsing pull policy")
+				})
+			})
+		})
+
 		when("--buildpack-registry flag is specified but experimental isn't set in the config", func() {
 			it("errors with a descriptive message", func() {
 				command.SetArgs([]string{

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -37,8 +37,11 @@ func PackageBuildpack(logger logging.Logger, cfg config.Config, client Buildpack
 				return err
 			}
 
-			var err error
-			pullPolicy, err := pubcfg.ParsePullPolicy(flags.Policy)
+			stringPolicy := flags.Policy
+			if stringPolicy == "" {
+				stringPolicy = cfg.PullPolicy
+			}
+			pullPolicy, err := pubcfg.ParsePullPolicy(stringPolicy)
 			if err != nil {
 				return errors.Wrap(err, "parsing pull policy")
 			}

--- a/internal/commands/rebase.go
+++ b/internal/commands/rebase.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 
 	pubcfg "github.com/buildpacks/pack/config"
@@ -28,9 +29,13 @@ func Rebase(logger logging.Logger, cfg config.Config, client PackClient) *cobra.
 			opts.AdditionalMirrors = getMirrors(cfg)
 
 			var err error
-			opts.PullPolicy, err = pubcfg.ParsePullPolicy(policy)
+			stringPolicy := policy
+			if stringPolicy == "" {
+				stringPolicy = cfg.PullPolicy
+			}
+			opts.PullPolicy, err = pubcfg.ParsePullPolicy(stringPolicy)
 			if err != nil {
-				return errors.Wrapf(err, "parsing pull policy %s", policy)
+				return errors.Wrapf(err, "parsing pull policy %s", stringPolicy)
 			}
 
 			if err := client.Rebase(cmd.Context(), opts); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	DefaultRegistry     string           `toml:"default-registry-url,omitempty"`
 	DefaultRegistryName string           `toml:"default-registry,omitempty"`
 	DefaultBuilder      string           `toml:"default-builder-image,omitempty"`
+	PullPolicy          string           `toml:"pull-policy,omitempty"`
 	Experimental        bool             `toml:"experimental,omitempty"`
 	RunImages           []RunImage       `toml:"run-images"`
 	TrustedBuilders     []TrustedBuilder `toml:"trusted-builders,omitempty"`


### PR DESCRIPTION
## Summary

Adds the following commands to set, list, or unset a global container pull policy:

* `pack config pull-policy` (lists the configured policy--default is "always")
* `pack config pull-policy <if-not-present | always | never>` (set the default pull-policy)
* `pack config pull-policy --unset` (unset a configured global policy and reset to default--"always)

The changes still allow `--pull-policy` to be provided as an option in the command line. If `--pull-policy` is provided, it takes precedence to any globally configured pull-policy

## Output

### Before

These commands did not exist, so I can't think of any output to show.

### After

#### `pack config -h`

```bash
$  out/pack config -h
Interact with Pack's configuration

Usage:
  pack config [command]

Available Commands:
  default-builder   List, set and unset the default builder used by other commands
  experimental      Print and set the current 'experimental' value from the config
  trusted-builders  Interact with trusted builders
  run-image-mirrors Interact with run image mirrors
  pull-policy       List, set and unset the global pull policy used by other commands
  registries        (experimental) Interact with registries

Flags:
  -h, --help   Help for 'config'

Global Flags:
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output

Use "pack config [command] --help" for more information about a command.
```

#### `pack config pull-policy -h`

```bash
$ out/pack config pull-policy -h
A Buildpack Registry is a (still experimental) place to publish, store, and discover buildpacks.

You can use this command to list, set, and unset the default pull policy that will be used when working with containers:
* To list your pull policy, run `pack config pull-policy`.
* To set your pull policy, run `pack config pull-policy <pull-policy>`.
* To unset your pull policy, run `pack config pull-policy --unset`.
Unsetting the pull policy will reset the policy to the default, which is always

Usage:
  pack config pull-policy <if-not-present | always | never> [flags]

Aliases:
  pull-policy, pull-policy

Flags:
  -h, --help    Help for 'pull-policy'
  -u, --unset   Unset pull policy, and set it back to the default pull-policy, which is always

Global Flags:
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output
```

#### `pack config pull-policy`
When no other policy has been configured.

```bash
$ out/pack config pull-policy
The current pull policy is always
```

#### `pack config pull-policy never`
When no other policy has been configured.

```bash
$ out/pack config pull-policy never
Successfully set never as the pull policy
```

#### `pack config pull-policy if-not-present`
When no other policy has been configured.

```bash
$ out/pack config pull-policy if-not-present
Successfully set if-not-present as the pull policy
```

#### `pack config pull-policy always`
When no other policy has been configured.

```bash
$ out/pack config pull-policy always
Successfully set always as the pull policy
```

#### `pack config pull-policy never`
When never was already the configured policy.

```bash
$ out/pack config pull-policy always
Pull policy is already set to never
```

#### `pack config pull-policy invalid-policy`
When never was already the configured policy.

```bash
$ out/pack config pull-policy invalid-policy
ERROR: invalid pull policy invalid-policy
```

#### `pack config pull-policy --unset`

```bash
$ out/pack config pull-policy --unset
Successfully unset pull policy never
Pull policy has been set to always
```

#### `pack config pull-policy never --unset` (invalid command)

```bash
$ out/pack config pull-policy never --unset
ERROR: pull policy and --unset cannot be specified simultaneously
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] I would imagine, but not totally sure? see #991 (If it should be documented, I could do that as well)

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #991 
