### PR TITLE
Update Default Lifecycle Version to 0.10.1

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -8,7 +8,7 @@ labels:
     description: |
       _Experimental features that may change in the future. Use them at your discretion._
       
-      _To enable these features, add `experimental = true` to your `~/.pack/config.toml`._
+      _To enable these features, run `pack config experimental true`, or add `experimental = true` to your `~/.pack/config.toml`._
     weight: 9
   type/enhancement:
     title: Features

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1205,6 +1205,7 @@ func testAcceptance(
 								pack.Supports("build --network"),
 								"--network flag not supported for build",
 							)
+							h.SkipIf(t, dockerHostOS() == "windows", "temporarily disabled on WCOW due to CI flakiness")
 
 							var err error
 							tmpDir, err = ioutil.TempDir("", "archive-buildpacks-")
@@ -1214,6 +1215,7 @@ func testAcceptance(
 						})
 
 						it.After(func() {
+							h.SkipIf(t, dockerHostOS() == "windows", "temporarily disabled on WCOW due to CI flakiness")
 							assert.Succeeds(os.RemoveAll(tmpDir))
 							assert.Succeeds(h.DockerRmi(dockerCli, repoName))
 						})

--- a/acceptance/testdata/pack_fixtures/report_output.txt
+++ b/acceptance/testdata/pack_fixtures/report_output.txt
@@ -2,7 +2,7 @@ Pack:
   Version:  {{ .Version }}
   OS/Arch:  {{ .OS }}/{{ .Arch }}
 
-Default Lifecycle Version:  0.9.3
+Default Lifecycle Version:  0.10.1
 
 Supported Platform APIs:  0.3, 0.4
 

--- a/build_test.go
+++ b/build_test.go
@@ -1655,7 +1655,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.PullPolicy, config.PullNever)
 
-					args = fakeImageFetcher.FetchCalls["buildpacksio/lifecycle:0.9.3"]
+					args = fakeImageFetcher.FetchCalls["buildpacksio/lifecycle:0.10.1"]
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.PullPolicy, config.PullNever)
 				})

--- a/internal/builder/lifecycle.go
+++ b/internal/builder/lifecycle.go
@@ -14,7 +14,7 @@ import (
 
 // A snapshot of the latest tested lifecycle version values
 const (
-	DefaultLifecycleVersion    = "0.9.3"
+	DefaultLifecycleVersion    = "0.10.1"
 	DefaultBuildpackAPIVersion = "0.2"
 )
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -71,7 +71,7 @@ func logError(logger logging.Logger, f func(cmd *cobra.Command, args []string) e
 }
 
 func enableExperimentalTip(logger logging.Logger, configPath string) {
-	logging.Tip(logger, "To enable experimental features, add %s to %s.", style.Symbol("experimental = true"), style.Symbol(configPath))
+	logging.Tip(logger, "To enable experimental features, run `pack config experimental true` to add %s to %s.", style.Symbol("experimental = true"), style.Symbol(configPath))
 }
 
 func multiValueHelp(name string) string {

--- a/internal/commands/config_trusted_builder.go
+++ b/internal/commands/config_trusted_builder.go
@@ -28,7 +28,7 @@ func ConfigTrustedBuilder(logger logging.Logger, cfg config.Config, cfgPath stri
 	}
 
 	listCmd := generateListCmd("trusted-builders", logger, cfg, listTrustedBuilders)
-	listCmd.Long = "List Trusted Builders.\n\nShow the builders that are either trusted by default or have been explicitly trusted locally using `trust-builder`"
+	listCmd.Long = "List Trusted Builders.\n\nShow the builders that are either trusted by default or have been explicitly trusted locally using `trusted-builder add`"
 	listCmd.Example = "pack config trusted-builders list"
 	cmd.AddCommand(listCmd)
 

--- a/internal/commands/create_builder.go
+++ b/internal/commands/create_builder.go
@@ -28,12 +28,12 @@ func CreateBuilder(logger logging.Logger, cfg config.Config, client PackClient) 
 		Example: "pack create-builder my-builder:bionic --config ./builder.toml",
 		Long: `A builder is an image that bundles all the bits and information on how to build your apps, such as buildpacks, an implementation of the lifecycle, and a build-time environment that pack uses when executing the lifecycle. When building an app, you can use community builders; you can see our suggestions by running
 
-	pack suggest-builders
+	pack builder suggest
 
 Creating a custom builder allows you to control what buildpacks are used and what image apps are based on. For more on how to create a builder, see: https://buildpacks.io/docs/operator-guide/create-a-builder/.
 `,
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			logger.Warn("Command 'pack create-builder' has been deprecated, please use 'pack builder create' instead")
+			deprecationWarning(logger, "create-builder", "builder create")
 
 			if err := validateCreateFlags(&flags, cfg); err != nil {
 				return err

--- a/internal/commands/inspect_builder_test.go
+++ b/internal/commands/inspect_builder_test.go
@@ -251,7 +251,7 @@ func testInspectBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 				assert.Contains(outBuf.String(), `Please select a default builder with:
 
-	pack set-default-builder <builder-image>`)
+	pack config default-builder <builder-image>`)
 
 				assert.Matches(outBuf.String(), regexp.MustCompile(`Paketo Buildpacks:\s+'paketobuildpacks/builder:base'`))
 				assert.Matches(outBuf.String(), regexp.MustCompile(`Paketo Buildpacks:\s+'paketobuildpacks/builder:full'`))

--- a/internal/commands/list_trusted_builders.go
+++ b/internal/commands/list_trusted_builders.go
@@ -12,7 +12,7 @@ func ListTrustedBuilders(logger logging.Logger, cfg config.Config) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:     "list-trusted-builders",
 		Short:   "List Trusted Builders",
-		Long:    "List Trusted Builders.\n\nShow the builders that are either trusted by default or have been explicitly trusted locally using `trust-builder`",
+		Long:    "List Trusted Builders.\n\nShow the builders that are either trusted by default or have been explicitly trusted locally using `trusted-builder add`",
 		Example: "pack list-trusted-builders",
 		Hidden:  true,
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -28,7 +28,7 @@ func PackageBuildpack(logger logging.Logger, cfg config.Config, client Buildpack
 		Long: "package-buildpack allows users to package (a) buildpack(s) into OCI format, which can then to be hosted in " +
 			"image repositories. You can also package a number of buildpacks together, to enable easier distribution of " +
 			"a set of buildpacks. Packaged buildpacks can be used as inputs to `pack build` (using the `--buildpack` flag), " +
-			"and they can be included in the configs used in `pack create-builder` and `pack package-buildpack`. For more " +
+			"and they can be included in the configs used in `pack builder create` and `pack buildpack package`. For more " +
 			"on how to package a buildpack, see: https://buildpacks.io/docs/buildpack-author-guide/package-a-buildpack/.",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			deprecationWarning(logger, "package-buildpack", "buildpack package")

--- a/internal/commands/set_run_image_mirrors.go
+++ b/internal/commands/set_run_image_mirrors.go
@@ -21,6 +21,7 @@ func SetRunImagesMirrors(logger logging.Logger, cfg config.Config) *cobra.Comman
 		Short:   "Set mirrors to other repositories for a given run image",
 		Example: "pack set-run-image-mirrors cnbs/sample-stack-run:bionic --mirror index.docker.io/cnbs/sample-stack-run:bionic",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			deprecationWarning(logger, "set-run-image-mirrors", "config run-image-mirrors")
 			runImage := args[0]
 			cfg = config.SetRunImageMirrors(cfg, runImage, mirrors)
 			configPath, err := config.DefaultConfigPath()

--- a/internal/commands/suggest_builders.go
+++ b/internal/commands/suggest_builders.go
@@ -55,7 +55,7 @@ func SuggestBuilders(logger logging.Logger, inspector BuilderInspector) *cobra.C
 		Short:   "Display list of recommended builders",
 		Example: "pack suggest-builders",
 		Run: func(cmd *cobra.Command, s []string) {
-			logger.Warn("Command 'pack suggest-builder' has been deprecated, please use 'pack builder suggest' instead")
+			deprecationWarning(logger, "suggest-builder", "builder suggest")
 			suggestBuilders(logger, inspector)
 		},
 	}
@@ -66,7 +66,7 @@ func SuggestBuilders(logger logging.Logger, inspector BuilderInspector) *cobra.C
 func suggestSettingBuilder(logger logging.Logger, inspector BuilderInspector) {
 	logger.Info("Please select a default builder with:")
 	logger.Info("")
-	logger.Info("\tpack set-default-builder <builder-image>")
+	logger.Info("\tpack config default-builder <builder-image>")
 	logger.Info("")
 	suggestBuilders(logger, inspector)
 }


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
In #992, we bumped the library version, but neglected to update `DefaultLifecycleVersion` in our newly created builders to be the latest lifecycle release. This PR fixes that. 

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Related to #992 
