### PR TITLE
Disables acceptance --network tests for WCOW

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1205,6 +1205,7 @@ func testAcceptance(
 								pack.Supports("build --network"),
 								"--network flag not supported for build",
 							)
+							h.SkipIf(t, dockerHostOS() == "windows", "temporarily disabled on WCOW due to CI flakiness")
 
 							var err error
 							tmpDir, err = ioutil.TempDir("", "archive-buildpacks-")
@@ -1214,6 +1215,7 @@ func testAcceptance(
 						})
 
 						it.After(func() {
+							h.SkipIf(t, dockerHostOS() == "windows", "temporarily disabled on WCOW due to CI flakiness")
 							assert.Succeeds(os.RemoveAll(tmpDir))
 							assert.Succeeds(h.DockerRmi(dockerCli, repoName))
 						})

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -88,7 +88,11 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				logger.Warn("Using untrusted builder with volume mounts. If there is sensitive data in the volumes, this may present a security vulnerability.")
 			}
 
-			pullPolicy, err := pubcfg.ParsePullPolicy(flags.Policy)
+			stringPolicy := flags.Policy
+			if stringPolicy == "" {
+				stringPolicy = cfg.PullPolicy
+			}
+			pullPolicy, err := pubcfg.ParsePullPolicy(stringPolicy)
 			if err != nil {
 				return errors.Wrapf(err, "parsing pull policy %s", flags.Policy)
 			}

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -151,6 +151,45 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 				command.SetArgs([]string{"image", "--builder", "my-builder", "--pull-policy", "unknown-policy"})
 				h.AssertError(t, command.Execute(), "parsing pull policy")
 			})
+			it("takes precedence over a configured pull policy", func() {
+				mockClient.EXPECT().
+					Build(gomock.Any(), EqBuildOptionsWithPullPolicy(pubcfg.PullNever)).
+					Return(nil)
+
+				cfg := config.Config{PullPolicy: "if-not-present"}
+				command := commands.Build(logger, cfg, mockClient)
+
+				logger.WantVerbose(true)
+				command.SetArgs([]string{"image", "--builder", "my-builder", "--pull-policy", "never"})
+				h.AssertNil(t, command.Execute())
+			})
+		})
+
+		when("--pull-policy is not specified", func() {
+			when("no pull policy set in config", func() {
+				it("uses the default policy", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithPullPolicy(pubcfg.PullAlways)).
+						Return(nil)
+
+					command.SetArgs([]string{"image", "--builder", "my-builder"})
+					h.AssertNil(t, command.Execute())
+				})
+			})
+			when("pull policy is set in config", func() {
+				it("uses the set policy", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithPullPolicy(pubcfg.PullNever)).
+						Return(nil)
+
+					cfg := config.Config{PullPolicy: "never"}
+					command := commands.Build(logger, cfg, mockClient)
+
+					logger.WantVerbose(true)
+					command.SetArgs([]string{"image", "--builder", "my-builder"})
+					h.AssertNil(t, command.Execute())
+				})
+			})
 		})
 
 		when("volume mounts are specified", func() {

--- a/internal/commands/builder_create.go
+++ b/internal/commands/builder_create.go
@@ -43,7 +43,11 @@ Creating a custom builder allows you to control what buildpacks are used and wha
 				return err
 			}
 
-			pullPolicy, err := pubcfg.ParsePullPolicy(flags.Policy)
+			stringPolicy := flags.Policy
+			if stringPolicy == "" {
+				stringPolicy = cfg.PullPolicy
+			}
+			pullPolicy, err := pubcfg.ParsePullPolicy(stringPolicy)
 			if err != nil {
 				return errors.Wrapf(err, "parsing pull policy %s", flags.Policy)
 			}

--- a/internal/commands/builder_create_test.go
+++ b/internal/commands/builder_create_test.go
@@ -92,6 +92,20 @@ func testCreateCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("--pull-policy is not specified", func() {
+			when("configured pull policy is invalid", func() {
+				it("errors when config set with unknown policy", func() {
+					cfg = config.Config{PullPolicy: "unknown-policy"}
+					command = commands.BuilderCreate(logger, cfg, mockClient)
+					command.SetArgs([]string{
+						"some/builder",
+						"--config", builderConfigPath,
+					})
+					h.AssertError(t, command.Execute(), "parsing pull policy")
+				})
+			})
+		})
+
 		when("--buildpack-registry flag is specified but experimental isn't set in the config", func() {
 			it("errors with a descriptive message", func() {
 				command.SetArgs([]string{

--- a/internal/commands/buildpack.go
+++ b/internal/commands/buildpack.go
@@ -15,7 +15,7 @@ func NewBuildpackCommand(logger logging.Logger, cfg config.Config, client PackCl
 		RunE:    nil,
 	}
 
-	cmd.AddCommand(BuildpackPackage(logger, client, packageConfigReader))
+	cmd.AddCommand(BuildpackPackage(logger, cfg, client, packageConfigReader))
 	if cfg.Experimental {
 		cmd.AddCommand(BuildpackPull(logger, cfg, client))
 		cmd.AddCommand(BuildpackRegister(logger, cfg, client))

--- a/internal/commands/buildpack_package_test.go
+++ b/internal/commands/buildpack_package_test.go
@@ -112,6 +112,38 @@ func testPackageCommand(t *testing.T, when spec.G, it spec.S) {
 					h.AssertEq(t, receivedOptions.PullPolicy, pubcfg.PullAlways)
 				})
 			})
+			when("no --pull-policy", func() {
+				var pullPolicyArgs = []string{
+					"some-image-name",
+					"--config", "/path/to/some/file",
+				}
+
+				it("uses the default policy when no policy configured", func() {
+					cmd := packageCommand(withBuildpackPackager(fakeBuildpackPackager))
+					cmd.SetArgs(pullPolicyArgs)
+					h.AssertNil(t, cmd.Execute())
+
+					receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+					h.AssertEq(t, receivedOptions.PullPolicy, pubcfg.PullAlways)
+				})
+				it("uses the configured pull policy when policy configured", func() {
+					cmd := packageCommand(
+						withBuildpackPackager(fakeBuildpackPackager),
+						withClientConfig(config.Config{PullPolicy: "never"}),
+					)
+
+					cmd.SetArgs([]string{
+						"some-image-name",
+						"--config", "/path/to/some/file",
+					})
+
+					err := cmd.Execute()
+					h.AssertNil(t, err)
+
+					receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+					h.AssertEq(t, receivedOptions.PullPolicy, pubcfg.PullNever)
+				})
+			})
 		})
 
 		when("no config path is specified", func() {
@@ -209,7 +241,7 @@ func packageCommand(ops ...packageCommandOption) *cobra.Command {
 		op(config)
 	}
 
-	cmd := commands.BuildpackPackage(config.logger, config.buildpackPackager, config.packageConfigReader)
+	cmd := commands.BuildpackPackage(config.logger, config.clientConfig, config.buildpackPackager, config.packageConfigReader)
 	cmd.SetArgs([]string{config.imageName, "--config", config.configPath})
 
 	return cmd
@@ -242,6 +274,12 @@ func withImageName(name string) packageCommandOption {
 func withPackageConfigPath(path string) packageCommandOption {
 	return func(config *packageCommandConfig) {
 		config.configPath = path
+	}
+}
+
+func withClientConfig(clientCfg config.Config) packageCommandOption {
+	return func(config *packageCommandConfig) {
+		config.clientConfig = clientCfg
 	}
 }
 

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -18,6 +18,7 @@ func NewConfigCommand(logger logging.Logger, cfg config.Config, cfgPath string, 
 
 	cmd.AddCommand(ConfigDefaultBuilder(logger, cfg, cfgPath, client))
 	cmd.AddCommand(ConfigExperimental(logger, cfg, cfgPath))
+	cmd.AddCommand(ConfigPullPolicy(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigRunImagesMirrors(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigTrustedBuilder(logger, cfg, cfgPath))
 

--- a/internal/commands/config_pull_policy.go
+++ b/internal/commands/config_pull_policy.go
@@ -1,0 +1,82 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	pubcfg "github.com/buildpacks/pack/config"
+
+	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
+)
+
+func ConfigPullPolicy(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
+	var unset bool
+
+	cmd := &cobra.Command{
+		Use:   "pull-policy <always | if-not-present | never>",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "List, set and unset the global pull policy used by other commands",
+		Long: "You can use this command to list, set, and unset the default pull policy that will be used when working with containers:\n" +
+			"* To list your pull policy, run `pack config pull-policy`.\n" +
+			"* To set your pull policy, run `pack config pull-policy <always | if-not-present | never>`.\n" +
+			"* To unset your pull policy, run `pack config pull-policy --unset`.\n" +
+			fmt.Sprintf("Unsetting the pull policy will reset the policy to the default, which is %s", style.Symbol("always")),
+		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			switch {
+			case unset:
+				if len(args) > 0 {
+					return errors.Errorf("pull policy and --unset cannot be specified simultaneously")
+				}
+				oldPullPolicy := cfg.PullPolicy
+				cfg.PullPolicy = ""
+				if err := config.Write(cfg, cfgPath); err != nil {
+					return errors.Wrapf(err, "writing config to %s", cfgPath)
+				}
+
+				pullPolicy, err := pubcfg.ParsePullPolicy(cfg.PullPolicy)
+				if err != nil {
+					return err
+				}
+
+				logger.Infof("Successfully unset pull policy %s", style.Symbol(oldPullPolicy))
+				logger.Infof("Pull policy has been set to %s", style.Symbol(pullPolicy.String()))
+			case len(args) == 0: // list
+				pullPolicy, err := pubcfg.ParsePullPolicy(cfg.PullPolicy)
+				if err != nil {
+					return err
+				}
+
+				logger.Infof("The current pull policy is %s", style.Symbol(pullPolicy.String()))
+			default: // set
+				newPullPolicy := args[0]
+
+				if newPullPolicy == cfg.PullPolicy {
+					logger.Infof("Pull policy is already set to %s", style.Symbol(newPullPolicy))
+					return nil
+				}
+
+				pullPolicy, err := pubcfg.ParsePullPolicy(newPullPolicy)
+				if err != nil {
+					return err
+				}
+
+				cfg.PullPolicy = newPullPolicy
+				if err := config.Write(cfg, cfgPath); err != nil {
+					return errors.Wrapf(err, "writing config to %s", cfgPath)
+				}
+
+				logger.Infof("Successfully set %s as the pull policy", style.Symbol(pullPolicy.String()))
+			}
+
+			return nil
+		}),
+	}
+
+	cmd.Flags().BoolVarP(&unset, "unset", "u", false, "Unset pull policy, and set it back to the default pull-policy, which is "+style.Symbol("always"))
+	AddHelpFlag(cmd, "pull-policy")
+	return cmd
+}

--- a/internal/commands/config_pull_policy_test.go
+++ b/internal/commands/config_pull_policy_test.go
@@ -1,0 +1,195 @@
+package commands_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/commands"
+	"github.com/buildpacks/pack/internal/config"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestConfigPullPolicy(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "ConfigPullPolicyCommand", testConfigPullPolicyCommand, spec.Random(), spec.Report(report.Terminal{}))
+}
+
+func testConfigPullPolicyCommand(t *testing.T, when spec.G, it spec.S) {
+	var (
+		command      *cobra.Command
+		logger       logging.Logger
+		outBuf       bytes.Buffer
+		tempPackHome string
+		configFile   string
+		assert       = h.NewAssertionManager(t)
+		cfg          = config.Config{}
+	)
+
+	it.Before(func() {
+		var err error
+		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		h.AssertNil(t, err)
+		configFile = filepath.Join(tempPackHome, "config.toml")
+
+		command = commands.ConfigPullPolicy(logger, cfg, configFile)
+		command.SetOut(logging.GetWriterForLevel(logger, logging.InfoLevel))
+	})
+
+	it.After(func() {
+		h.AssertNil(t, os.RemoveAll(tempPackHome))
+	})
+
+	when("#ConfigPullPolicy", func() {
+		when("list", func() {
+			when("no policy is specified", func() {
+				it("lists default pull policy", func() {
+					command.SetArgs([]string{})
+
+					h.AssertNil(t, command.Execute())
+
+					assert.Contains(outBuf.String(), "always")
+				})
+			})
+			when("policy set to always in config", func() {
+				it("lists always as pull policy", func() {
+					cfg.PullPolicy = "always"
+					command = commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{})
+
+					h.AssertNil(t, command.Execute())
+
+					assert.Contains(outBuf.String(), "always")
+				})
+			})
+
+			when("policy set to never in config", func() {
+				it("lists never as pull policy", func() {
+					cfg.PullPolicy = "never"
+					command = commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{})
+
+					h.AssertNil(t, command.Execute())
+
+					assert.Contains(outBuf.String(), "never")
+				})
+			})
+
+			when("policy set to if-not-present in config", func() {
+				it("lists if-not-present as pull policy", func() {
+					cfg.PullPolicy = "if-not-present"
+					command = commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{})
+
+					h.AssertNil(t, command.Execute())
+
+					assert.Contains(outBuf.String(), "if-not-present")
+				})
+			})
+		})
+		when("set", func() {
+			when("policy provided is the same as configured pull policy", func() {
+				it("provides a helpful message", func() {
+					cfg.PullPolicy = "if-not-present"
+					command = commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{"if-not-present"})
+
+					h.AssertNil(t, command.Execute())
+
+					output := outBuf.String()
+					h.AssertEq(t, strings.TrimSpace(output), `Pull policy is already set to 'if-not-present'`)
+				})
+				it("it does not change the configured policy", func() {
+					command = commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{"never"})
+					assert.Succeeds(command.Execute())
+
+					readCfg, err := config.Read(configFile)
+					assert.Nil(err)
+					assert.Equal(readCfg.PullPolicy, "never")
+
+					command = commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{"never"})
+					assert.Succeeds(command.Execute())
+
+					readCfg, err = config.Read(configFile)
+					assert.Nil(err)
+					assert.Equal(readCfg.PullPolicy, "never")
+				})
+			})
+
+			when("invalid policy is specified", func() {
+				it("does not write invalid policy to config", func() {
+					command.SetArgs([]string{"never"})
+					assert.Succeeds(command.Execute())
+
+					command.SetArgs([]string{"invalid-policy"})
+					err := command.Execute()
+					h.AssertError(t, err, `invalid pull policy invalid-policy`)
+
+					readCfg, err := config.Read(configFile)
+					assert.Nil(err)
+					assert.Equal(readCfg.PullPolicy, "never")
+				})
+			})
+
+			when("valid policy is specified", func() {
+				it("sets the policy in config", func() {
+					command.SetArgs([]string{"never"})
+					assert.Succeeds(command.Execute())
+
+					readCfg, err := config.Read(configFile)
+					assert.Nil(err)
+					assert.Equal(readCfg.PullPolicy, "never")
+				})
+				it("returns clear error if fails to write", func() {
+					assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+					command := commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{"if-not-present"})
+					assert.ErrorContains(command.Execute(), "writing config to")
+				})
+			})
+		})
+		when("unset", func() {
+			it("removes set policy and resets to default pull policy", func() {
+				command.SetArgs([]string{"never"})
+				command = commands.ConfigPullPolicy(logger, cfg, configFile)
+
+				command.SetArgs([]string{"--unset"})
+				assert.Succeeds(command.Execute())
+
+				cfg, err := config.Read(configFile)
+				assert.Nil(err)
+				assert.Equal(cfg.PullPolicy, "")
+			})
+			it("returns clear error if fails to write", func() {
+				assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+				command := commands.ConfigPullPolicy(logger, config.Config{PullPolicy: "never"}, configFile)
+				command.SetArgs([]string{"--unset"})
+				assert.ErrorContains(command.Execute(), "writing config to")
+			})
+		})
+		when("--unset and policy to set is provided", func() {
+			it("errors", func() {
+				command.SetArgs([]string{
+					"never",
+					"--unset",
+				})
+				err := command.Execute()
+				h.AssertError(t, err, `pull policy and --unset cannot be specified simultaneously`)
+			})
+		})
+	})
+}

--- a/internal/commands/config_test.go
+++ b/internal/commands/config_test.go
@@ -62,7 +62,7 @@ func testConfigCommand(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNil(t, command.Execute())
 			output := outBuf.String()
 			h.AssertContains(t, output, "Usage:")
-			for _, command := range []string{"trusted-builders", "run-image-mirrors", "default-builder", "experimental", "registries"} {
+			for _, command := range []string{"trusted-builders", "run-image-mirrors", "default-builder", "experimental", "registries", "pull-policy"} {
 				h.AssertContains(t, output, command)
 			}
 		})

--- a/internal/commands/create_builder.go
+++ b/internal/commands/create_builder.go
@@ -39,7 +39,11 @@ Creating a custom builder allows you to control what buildpacks are used and wha
 				return err
 			}
 
-			pullPolicy, err := pubcfg.ParsePullPolicy(flags.Policy)
+			stringPolicy := flags.Policy
+			if stringPolicy == "" {
+				stringPolicy = cfg.PullPolicy
+			}
+			pullPolicy, err := pubcfg.ParsePullPolicy(stringPolicy)
 			if err != nil {
 				return errors.Wrapf(err, "parsing pull policy %s", flags.Policy)
 			}

--- a/internal/commands/create_builder_test.go
+++ b/internal/commands/create_builder_test.go
@@ -95,6 +95,20 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("--pull-policy is not specified", func() {
+			when("configured pull policy is invalid", func() {
+				it("returns error for when config set with unknown policy", func() {
+					cfg = config.Config{PullPolicy: "unknown-policy"}
+					command = commands.BuilderCreate(logger, cfg, mockClient)
+					command.SetArgs([]string{
+						"some/builder",
+						"--config", builderConfigPath,
+					})
+					h.AssertError(t, command.Execute(), "parsing pull policy")
+				})
+			})
+		})
+
 		when("--buildpack-registry flag is specified but experimental isn't set in the config", func() {
 			it("errors with a descriptive message", func() {
 				command.SetArgs([]string{

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -37,8 +37,11 @@ func PackageBuildpack(logger logging.Logger, cfg config.Config, client Buildpack
 				return err
 			}
 
-			var err error
-			pullPolicy, err := pubcfg.ParsePullPolicy(flags.Policy)
+			stringPolicy := flags.Policy
+			if stringPolicy == "" {
+				stringPolicy = cfg.PullPolicy
+			}
+			pullPolicy, err := pubcfg.ParsePullPolicy(stringPolicy)
 			if err != nil {
 				return errors.Wrap(err, "parsing pull policy")
 			}

--- a/internal/commands/rebase.go
+++ b/internal/commands/rebase.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 
 	pubcfg "github.com/buildpacks/pack/config"
@@ -28,9 +29,13 @@ func Rebase(logger logging.Logger, cfg config.Config, client PackClient) *cobra.
 			opts.AdditionalMirrors = getMirrors(cfg)
 
 			var err error
-			opts.PullPolicy, err = pubcfg.ParsePullPolicy(policy)
+			stringPolicy := policy
+			if stringPolicy == "" {
+				stringPolicy = cfg.PullPolicy
+			}
+			opts.PullPolicy, err = pubcfg.ParsePullPolicy(stringPolicy)
 			if err != nil {
-				return errors.Wrapf(err, "parsing pull policy %s", policy)
+				return errors.Wrapf(err, "parsing pull policy %s", stringPolicy)
 			}
 
 			if err := client.Rebase(cmd.Context(), opts); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	DefaultRegistry     string           `toml:"default-registry-url,omitempty"`
 	DefaultRegistryName string           `toml:"default-registry,omitempty"`
 	DefaultBuilder      string           `toml:"default-builder-image,omitempty"`
+	PullPolicy          string           `toml:"pull-policy,omitempty"`
 	Experimental        bool             `toml:"experimental,omitempty"`
 	RunImages           []RunImage       `toml:"run-images"`
 	TrustedBuilders     []TrustedBuilder `toml:"trusted-builders,omitempty"`


### PR DESCRIPTION
- Failures occurring only on Packet GHA runners. Will revert this after further debugging

Signed-off-by: Micah Young <ymicah@vmware.com>

## Summary
Skips tests that fail on GHA WCOW runners

## Output
Failures were: 
```
2021-01-13T05:18:45.5668124Z     acceptance_test.go:1244: Expected 'Builder '10.32.101.130:61090/test/builder-kilkmrycju' is trusted
2021-01-13T05:18:45.5668864Z         Pulling image '10.32.101.130:61090/test/builder-kilkmrycju:latest'
2021-01-13T05:18:45.5669358Z         latest: Pulling from test/builder-kilkmrycju
2021-01-13T05:18:45.5671747Z         Digest: sha256:9bfdf99c076c8fad8882c14457b7b6f4318d1fded7b722c42f810fa49d4abf19
2021-01-13T05:18:45.5672458Z         Status: Image is up to date for 10.32.101.130:61090/test/builder-kilkmrycju:latest
2021-01-13T05:18:45.5673865Z         Selected run image mirror '10.32.101.130:61090/pack-test/run'
2021-01-13T05:18:45.5675512Z         Pulling image '10.32.101.130:61090/pack-test/run'
2021-01-13T05:18:45.5676266Z         latest: Pulling from pack-test/run
2021-01-13T05:18:45.5678627Z         Digest: sha256:1c92a7bf666ef22b42f0694f302084b0d9faf57891398d85c6720a0859875525
2021-01-13T05:18:45.5679273Z         Status: Image is up to date for 10.32.101.130:61090/pack-test/run:latest
2021-01-13T05:18:45.5680281Z         Downloading buildpack from URI: 'file:///C:/Users/Admin/AppData/Local/Temp/archive-buildpacks-325566911/internet-capable-buildpack.tgz'
2021-01-13T05:18:45.5681626Z         Adding buildpack 'internet/bp' version 'internet-bp-version' to builder
2021-01-13T05:18:45.5682044Z         Setting custom order
2021-01-13T05:18:45.5684034Z         Creating builder with the following buildpacks:
2021-01-13T05:18:45.5684746Z         -> 'read/env@read-env-version'
2021-01-13T05:18:45.5686107Z         -> 'noop.buildpack@noop.buildpack.version'
2021-01-13T05:18:45.5686689Z         -> 'noop.buildpack@noop.buildpack.later-version'
2021-01-13T05:18:45.5687156Z         -> 'simple/layers@simple-layers-version'
2021-01-13T05:18:45.5688021Z         -> 'internet/bp@internet-bp-version'
2021-01-13T05:18:45.5688888Z         Using build cache volume 'pack-cache-2e1433ecdd70.build'
2021-01-13T05:18:45.5689591Z         ===> DETECTING
2021-01-13T05:18:45.5690846Z         ======== Output: internet/bp@internet-bp-version ========
2021-01-13T05:18:45.5691243Z         ---- Detect: Internet capable buildpack
2021-01-13T05:18:45.5691735Z         
2021-01-13T05:18:45.5692023Z         Pinging google.com [64.233.177.139] with 32 bytes of data:
2021-01-13T05:18:45.5693043Z         Request timed out.
2021-01-13T05:18:45.5693879Z         
2021-01-13T05:18:45.5694411Z         Ping statistics for 64.233.177.139:
2021-01-13T05:18:45.5694902Z             Packets: Sent = 1, Received = 0, Lost = 1 (100%!l(MISSING)oss),
2021-01-13T05:18:45.5695388Z         RESULT: Disconnected from the internet
2021-01-13T05:18:45.5696041Z         ---- Done
2021-01-13T05:18:45.5696585Z         ======== Results ========
2021-01-13T05:18:45.5697249Z         pass: internet/bp@internet-bp-version
2021-01-13T05:18:45.5697641Z         Resolving plan... (try #1)
2021-01-13T05:18:45.5698303Z         internet/bp internet-bp-version
2021-01-13T05:18:45.5698740Z         ===> ANALYZING
2021-01-13T05:18:45.5699214Z         Previous image with name "10.32.101.130:61090/some-org/aewpagecmg" not found
2021-01-13T05:18:45.5699691Z         ===> RESTORING
2021-01-13T05:18:45.5700276Z         ===> BUILDING
2021-01-13T05:18:45.5701009Z         ---- Build: Internet capable buildpack
2021-01-13T05:18:45.5701490Z         
2021-01-13T05:18:45.5701885Z         Pinging google.com [64.233.177.139] with 32 bytes of data:
2021-01-13T05:18:45.5702299Z         Request timed out.
2021-01-13T05:18:45.5702854Z         
2021-01-13T05:18:45.5703453Z         Ping statistics for 64.233.177.139:
2021-01-13T05:18:45.5703861Z             Packets: Sent = 1, Received = 0, Lost = 1 (100% loss),
2021-01-13T05:18:45.5704510Z         RESULT: Disconnected from the internet
2021-01-13T05:18:45.5704886Z         ---- Done
2021-01-13T05:18:45.5705529Z         ===> EXPORTING
2021-01-13T05:18:45.5706379Z         no project metadata found at path 'project-metadata.toml', project metadata will not be exported
2021-01-13T05:18:45.5707238Z         Layer 'slice-1' SHA: sha256:b06faacc79a77f4f4db6ac0321b60ed50dbc1ac234f0ee78bd3b180c67c958e2
2021-01-13T05:18:45.5707877Z         Adding 1/1 app layer(s)
2021-01-13T05:18:45.5708512Z         Reusing tarball for layer "launcher" with SHA: sha256:9c7dfef05a0dc46b060b6ca8893f9ab7d925c2971d3dfae7aebe85d5501ca2fc
2021-01-13T05:18:45.5709157Z         Adding layer 'launcher'
2021-01-13T05:18:45.5709759Z         Layer 'launcher' SHA: sha256:9c7dfef05a0dc46b060b6ca8893f9ab7d925c2971d3dfae7aebe85d5501ca2fc
2021-01-13T05:18:45.5710731Z         Reusing tarball for layer "config" with SHA: sha256:b3b5aef39e9c887f95daa76318643c15a45ca4278be8ae0de4fc4e0191fe8c44
2021-01-13T05:18:45.5711366Z         Adding layer 'config'
2021-01-13T05:18:45.5711939Z         Layer 'config' SHA: sha256:b3b5aef39e9c887f95daa76318643c15a45ca4278be8ae0de4fc4e0191fe8c44
2021-01-13T05:18:45.5712651Z         Adding label 'io.buildpacks.lifecycle.metadata'
2021-01-13T05:18:45.5713151Z         Adding label 'io.buildpacks.build.metadata'
2021-01-13T05:18:45.5714036Z         Adding label 'io.buildpacks.project.metadata'
2021-01-13T05:18:45.5714428Z         Setting CNB_LAYERS_DIR=c:\layers
2021-01-13T05:18:45.5714733Z         Setting CNB_APP_DIR=c:\workspace
2021-01-13T05:18:45.5715005Z         Setting CNB_PLATFORM_API=0.4
2021-01-13T05:18:45.5715297Z         Setting CNB_DEPRECATION_MODE=quiet
2021-01-13T05:18:45.5715643Z         Prepending c:\cnb\process and c:\cnb\lifecycle to PATH
2021-01-13T05:18:45.5716031Z         Warning: default process type 'web' not present in list []
2021-01-13T05:18:45.5716418Z         Setting ENTRYPOINT: 'c:\cnb\lifecycle\launcher.exe'
2021-01-13T05:18:45.5716750Z         *** Images (1ce6260e3ba0):
2021-01-13T05:18:45.5717010Z               10.32.101.130:61090/some-org/aewpagecmg
2021-01-13T05:18:45.5717267Z         
2021-01-13T05:18:45.5718169Z         *** Image ID: 1ce6260e3ba0a3456e39cca3f1dda7731abf7fe1f2724a6b02f5fb087ab41b96
2021-01-13T05:18:45.5718827Z         Successfully built image '10.32.101.130:61090/some-org/aewpagecmg'
2021-01-13T05:18:45.5719264Z         ' to contain 'RESULT: Connected to the internet'
2021-01-13T05:18:45.5719526Z         
2021-01-13T05:18:45.5719893Z         Diff:  string(
2021-01-13T05:18:45.5720516Z         - 	"RESULT: Connected to the internet",
2021-01-13T05:18:45.5721816Z         + 	"Builder '10.32.101.130:61090/test/builder-kilkmrycju' is trusted\nPulling image '10.32.101.130:61090/test/builder-kilkmrycju:latest'\nlatest: Pulling from test/builder-kilkmrycju\nDigest: sha256:9bfdf99c076c8fad8882c14457b7b6f4318d1fded7b722c42f810fa49d4abf19"...,
2021-01-13T05:18:45.5722717Z           )
```