### PR TITLE
Fix inspect-buildpack command when docker URLs are passed to it

### DIFF
--- a/inspect_buildpack.go
+++ b/inspect_buildpack.go
@@ -108,7 +108,8 @@ func metadataFromArchive(downloader Downloader, path string) (buildpackMd buildp
 }
 
 func metadataFromImage(client *Client, name string, daemon bool) (buildpackMd buildpackage.Metadata, layersMd dist.BuildpackLayers, err error) {
-	img, err := client.imageFetcher.Fetch(context.Background(), name, daemon, config.PullNever)
+	imageName := buildpack.ParsePackageLocator(name)
+	img, err := client.imageFetcher.Fetch(context.Background(), imageName, daemon, config.PullNever)
 	if err != nil {
 		return buildpackage.Metadata{}, dist.BuildpackLayers{}, err
 	}

--- a/inspect_buildpack_test.go
+++ b/inspect_buildpack_test.go
@@ -424,9 +424,9 @@ func testInspectBuildpack(t *testing.T, when spec.G, it spec.S) {
 					it.Before(func() {
 						expectedInfo.Location = buildpack.PackageLocator
 						if useDaemon {
-							mockImageFetcher.EXPECT().Fetch(gomock.Any(), "docker://some/buildpack", true, config.PullNever).Return(buildpackImage, nil)
+							mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/buildpack", true, config.PullNever).Return(buildpackImage, nil)
 						} else {
-							mockImageFetcher.EXPECT().Fetch(gomock.Any(), "docker://some/buildpack", false, config.PullNever).Return(buildpackImage, nil)
+							mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/buildpack", false, config.PullNever).Return(buildpackImage, nil)
 						}
 					})
 
@@ -460,7 +460,7 @@ func testInspectBuildpack(t *testing.T, when spec.G, it spec.S) {
 		when("buildpack image", func() {
 			when("unable to fetch buildpack image", func() {
 				it.Before(func() {
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "docker://missing/buildpack", true, config.PullNever).Return(nil, errors.Wrapf(image.ErrNotFound, "big bad error"))
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "missing/buildpack", true, config.PullNever).Return(nil, errors.Wrapf(image.ErrNotFound, "big bad error"))
 				})
 				it("returns an ErrNotFound error", func() {
 					inspectOptions := pack.InspectBuildpackOptions{
@@ -476,7 +476,7 @@ func testInspectBuildpack(t *testing.T, when spec.G, it spec.S) {
 				it.Before(func() {
 					fakeImage := fakes.NewImage("empty", "", nil)
 					h.AssertNil(t, fakeImage.SetLabel(dist.BuildpackLayersLabel, ":::"))
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "docker://missing-metadata/buildpack", true, config.PullNever).Return(fakeImage, nil)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "missing-metadata/buildpack", true, config.PullNever).Return(fakeImage, nil)
 				})
 				it("returns an error", func() {
 					inspectOptions := pack.InspectBuildpackOptions{


### PR DESCRIPTION
## Summary

This fixes a bug that isn't caught by tests because it only occurs once the `docker://` URL reaches the docker API.

## Output

#### Before

```
$ pack inspect-buildpack docker://jkutner/web-tty
Inspecting buildpack: docker://jkutner/web-tty
ERROR: error writing buildpack output: "verifying image 'docker://jkutner/web-tty': Error response from daemon: no such image: docker:/jkutner/web-tty: invalid reference format"
```

#### After

```
$ pack inspect-buildpack docker://jkutner/web-tty
Inspecting buildpack: docker://jkutner/web-tty

LOCAL IMAGE:

Stacks:
  ID: io.buildpacks.stacks.bionic
    Mixins:
      (omitted)
      ...
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
