### PR TITLE
Added new keys to BuildpackInfo to support new keys in buildpack.toml

### DIFF
--- a/inspect_buildpack.go
+++ b/inspect_buildpack.go
@@ -137,7 +137,7 @@ func extractOrder(buildpackMd buildpackage.Metadata) dist.Order {
 
 func extractBuildpacks(layersMd dist.BuildpackLayers) []dist.BuildpackInfo {
 	result := []dist.BuildpackInfo{}
-	buildpackSet := map[dist.BuildpackInfo]bool{}
+	buildpackSet := map[*dist.BuildpackInfo]bool{}
 
 	for buildpackID, buildpackMap := range layersMd {
 		for version, layerInfo := range buildpackMap {
@@ -146,12 +146,12 @@ func extractBuildpacks(layersMd dist.BuildpackLayers) []dist.BuildpackInfo {
 				Version:  version,
 				Homepage: layerInfo.Homepage,
 			}
-			buildpackSet[bp] = true
+			buildpackSet[&bp] = true
 		}
 	}
 
 	for currentBuildpack := range buildpackSet {
-		result = append(result, currentBuildpack)
+		result = append(result, *currentBuildpack)
 	}
 
 	sort.Slice(result, func(i int, j int) bool {

--- a/internal/builder/detection_order_calculator.go
+++ b/internal/builder/detection_order_calculator.go
@@ -30,14 +30,14 @@ func (c *DetectionOrderCalculator) Order(
 ) (pubbldr.DetectionOrder, error) {
 	recurser := newDetectionOrderRecurser(layers, maxDepth)
 
-	return recurser.detectionOrderFromOrder(order, dist.BuildpackRef{}, 0, map[dist.BuildpackRef]interface{}{}), nil
+	return recurser.detectionOrderFromOrder(order, dist.BuildpackRef{}, 0, map[string]interface{}{}), nil
 }
 
 func (r *detectionOrderRecurser) detectionOrderFromOrder(
 	order dist.Order,
 	parentBuildpack dist.BuildpackRef,
 	currentDepth int,
-	visited map[dist.BuildpackRef]interface{},
+	visited map[string]interface{},
 ) pubbldr.DetectionOrder {
 	var detectionOrder pubbldr.DetectionOrder
 	for _, orderEntry := range order {
@@ -58,14 +58,14 @@ func (r *detectionOrderRecurser) detectionOrderFromOrder(
 func (r *detectionOrderRecurser) detectionOrderFromGroup(
 	group []dist.BuildpackRef,
 	currentDepth int,
-	visited map[dist.BuildpackRef]interface{},
+	visited map[string]interface{},
 ) pubbldr.DetectionOrder {
 	var groupDetectionOrder pubbldr.DetectionOrder
 
 	for _, bp := range group {
-		_, bpSeen := visited[bp]
+		_, bpSeen := visited[bp.FullName()]
 		if !bpSeen {
-			visited[bp] = true
+			visited[bp.FullName()] = true
 		}
 
 		layer, ok := r.layers.Get(bp.ID, bp.Version)
@@ -96,8 +96,8 @@ func (r *detectionOrderRecurser) shouldGoDeeper(currentDepth int) bool {
 	return false
 }
 
-func copyMap(toCopy map[dist.BuildpackRef]interface{}) map[dist.BuildpackRef]interface{} {
-	result := make(map[dist.BuildpackRef]interface{}, len(toCopy))
+func copyMap(toCopy map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{}, len(toCopy))
 	for key := range toCopy {
 		result[key] = true
 	}

--- a/internal/builder/inspect.go
+++ b/internal/builder/inspect.go
@@ -132,14 +132,14 @@ func (i *Inspector) Inspect(name string, daemon bool, orderDetectionDepth int) (
 }
 
 func uniqueBuildpacks(buildpacks []dist.BuildpackInfo) []dist.BuildpackInfo {
-	foundBuildpacks := map[dist.BuildpackInfo]interface{}{}
+	foundBuildpacks := map[string]interface{}{}
 	var uniqueBuildpacks []dist.BuildpackInfo
 
 	for _, bp := range buildpacks {
-		_, ok := foundBuildpacks[bp]
+		_, ok := foundBuildpacks[bp.FullName()]
 		if !ok {
 			uniqueBuildpacks = append(uniqueBuildpacks, bp)
-			foundBuildpacks[bp] = true
+			foundBuildpacks[bp.FullName()] = true
 		}
 	}
 

--- a/internal/buildpackage/builder_test.go
+++ b/internal/buildpackage/builder_test.go
@@ -416,8 +416,17 @@ func testPackageBuilder(t *testing.T, when spec.G, it spec.S) {
 			buildpack1, err := ifakes.NewFakeBuildpack(dist.BuildpackDescriptor{
 				API: api.MustParse("0.2"),
 				Info: dist.BuildpackInfo{
-					ID:      "bp.1.id",
-					Version: "bp.1.version",
+					ID:          "bp.1.id",
+					Version:     "bp.1.version",
+					Description: "some description",
+					Homepage:    "https://example.com/homepage",
+					Keywords:    []string{"some-keyword"},
+					Licenses: []dist.License{
+						{
+							Type: "MIT",
+							URI:  "https://example.com/license",
+						},
+					},
 				},
 				Stacks: []dist.Stack{
 					{ID: "stack.id.1"},
@@ -442,6 +451,11 @@ func testPackageBuilder(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, len(md.Stacks), 2)
 			h.AssertEq(t, md.Stacks[0].ID, "stack.id.1")
 			h.AssertEq(t, md.Stacks[1].ID, "stack.id.2")
+			h.AssertEq(t, md.Keywords[0], "some-keyword")
+			h.AssertEq(t, md.Homepage, "https://example.com/homepage")
+			h.AssertEq(t, md.Description, "some description")
+			h.AssertEq(t, md.Licenses[0].Type, "MIT")
+			h.AssertEq(t, md.Licenses[0].URI, "https://example.com/license")
 
 			osVal, err := packageImage.OS()
 			h.AssertNil(t, err)

--- a/internal/dist/buildpack.go
+++ b/internal/dist/buildpack.go
@@ -40,9 +40,17 @@ type Buildpack interface {
 }
 
 type BuildpackInfo struct {
-	ID       string `toml:"id,omitempty" json:"id,omitempty" yaml:"id,omitempty"`
-	Version  string `toml:"version,omitempty" json:"version,omitempty" yaml:"version,omitempty"`
-	Homepage string `toml:"homepage,omitempty" json:"homepage,omitempty" yaml:"homepage,omitempty"`
+	ID          string    `toml:"id,omitempty" json:"id,omitempty" yaml:"id,omitempty"`
+	Version     string    `toml:"version,omitempty" json:"version,omitempty" yaml:"version,omitempty"`
+	Description string    `toml:"description,omitempty" json:"description,omitempty" yaml:"description,omitempty"`
+	Homepage    string    `toml:"homepage,omitempty" json:"homepage,omitempty" yaml:"homepage,omitempty"`
+	Keywords    []string  `toml:"keywords,omitempty" json:"keywords,omitempty" yaml:"keywords,omitempty"`
+	Licenses    []License `toml:"licenses,omitempty" json:"licenses,omitempty" yaml:"licenses,omitempty"`
+}
+
+type License struct {
+	Type string `toml:"type"`
+	URI  string `toml:"uri"`
 }
 
 func (b BuildpackInfo) FullName() string {

--- a/internal/dist/buildpack_test.go
+++ b/internal/dist/buildpack_test.go
@@ -429,9 +429,17 @@ version = "1.2.3"
 	when("#Match", func() {
 		it("compares, using only the id and version", func() {
 			other := dist.BuildpackInfo{
-				ID:       "same",
-				Version:  "1.2.3",
-				Homepage: "something else",
+				ID:          "same",
+				Version:     "1.2.3",
+				Description: "something else",
+				Homepage:    "something else",
+				Keywords:    []string{"something", "else"},
+				Licenses: []dist.License{
+					{
+						Type: "MIT",
+						URI:  "https://example.com",
+					},
+				},
 			}
 
 			self := dist.BuildpackInfo{

--- a/internal/dist/dist.go
+++ b/internal/dist/dist.go
@@ -1,6 +1,8 @@
 package dist
 
-import "github.com/buildpacks/lifecycle/api"
+import (
+	"github.com/buildpacks/lifecycle/api"
+)
 
 const BuildpackLayersLabel = "io.buildpacks.buildpack.layers"
 

--- a/project/project.go
+++ b/project/project.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
+
+	"github.com/buildpacks/pack/internal/dist"
 )
 
 type Buildpack struct {
@@ -25,14 +27,9 @@ type Build struct {
 	Env        []EnvVar    `toml:"env"`
 }
 
-type License struct {
-	Type string `toml:"type"`
-	URI  string `toml:"uri"`
-}
-
 type Project struct {
-	Name     string    `toml:"name"`
-	Licenses []License `toml:"licenses"`
+	Name     string         `toml:"name"`
+	Licenses []dist.License `toml:"licenses"`
 }
 
 type Descriptor struct {


### PR DESCRIPTION
## Summary

Implementation of https://github.com/buildpacks/rfcs/pull/127

**Important:** 
* this makes `dist.BuildpackInfo` no longer acceptable as a key because it contains types that are not compareable, so I've changed it to a pointer where the actual value is required, and a string where the `FullName()` can be used.
* I had to move the `License` struct into `internal/dist` to avoid a circular reference in the `project` tests (which import `testhelper`, which imports `internal/dist`) 

## Output

#### Before

N/A

#### After

N/A

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [X] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
