### PR TITLE
Remove usage of deprecated module.

### DIFF
--- a/testhelpers/tar_assertions.go
+++ b/testhelpers/tar_assertions.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-containerregistry/pkg/v1/v1util"
 	"github.com/pkg/errors"
 
 	"github.com/buildpacks/pack/internal/archive"
@@ -133,7 +132,7 @@ func IsJSON() TarEntryAssertion {
 
 func IsGzipped() TarEntryAssertion {
 	return func(t *testing.T, header *tar.Header, data []byte) {
-		isGzipped, err := v1util.IsGzipped(bytes.NewReader(data))
+		_, isGzipped, err := isGzipped(bytes.NewReader(data))
 		AssertNil(t, err)
 		if !isGzipped {
 			t.Fatal("is not gzipped")


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
v1util was deprecated and removed in latest version of go-containerregistry.
Removed in: https://github.com/google/go-containerregistry/commit/3584fa0df9f1bd51a7cf559c97126a20212fa7cd#

Function itself was already copied into this module, so it is easy to use it instead.


## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
This is blocking update of this dependency: https://github.com/buildpacks/pack/pull/1018
