### PR TITLE
Auto add labels/milestones to new PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,5 +8,5 @@ type/chore:
   - ./go.sum
 
 type/enhancement:
-  - any: ['./*.go', './**/*.go', '!./acceptance/**/*', '!./test*/**/*']
+  - any: ['./*.go', './**/*.go', '!./acceptance/**/*', '!./test*/**/*', '!./**/*_test.go']
     all: ['!.github/**/*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,12 +1,12 @@
 # Rules defined here: https://github.com/actions/labeler
 type/chore:
-  - ./*.md
-  - ./**/*.yml
-  - ./acceptance/**/*
-  - ./.github/**/*
-  - ./go.mod
-  - ./go.sum
+  - '*.md'
+  - '**/*.yml'
+  - 'acceptance/**/*'
+  - '.github/**/*'
+  - 'go.mod'
+  - 'go.sum'
 
 type/enhancement:
-  - any: ['./*.go', './**/*.go', '!./acceptance/**/*', '!./test*/**/*', '!./**/*_test.go']
-    all: ['!.github/**/*']
+  - '*.go'
+  - '**/*.go'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+# Rules defined here: https://github.com/actions/labeler
+type/chore:
+  - ./*.md
+  - ./**/*.yml
+  - ./acceptance/**/*
+  - ./.github/**/*
+  - ./go.mod
+  - ./go.sum
+
+type/enhancement:
+  - any: ['./*.go', './**/*.go', '!./acceptance/**/*', '!./test*/**/*']
+    all: ['!.github/**/*']

--- a/.github/workflows/privileged-pr-process.yml
+++ b/.github/workflows/privileged-pr-process.yml
@@ -19,9 +19,9 @@ jobs:
         id: assets
         with:
           script: |
-            var milestone = await github.issues.listMilestones({
-                      owner: github.context.repo.owner,
-                      repo: github.context.repo.repo,
+            var milestone = await github.issues.listMilestonesForRepo({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
                       state: 'open',
                       sort: 'due_on',
                       direction: 'asc'
@@ -31,12 +31,12 @@ jobs:
 
             if (milestone) {
                 await github.issues.update({
-                  owner: github.context.repo.owner,
-                  repo: github.context.repo.repo,
-                  issue_number: github.event.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.number,
                   milestone: milestone.number,
                   });
-                core.setOutput('milestone', addMilestone);
+                core.setOutput('milestone', milestone.number);
               } else {
               console.log(`Milestone not found, Please create it first.`);
             }

--- a/.github/workflows/privileged-pr-process.yml
+++ b/.github/workflows/privileged-pr-process.yml
@@ -38,5 +38,5 @@ jobs:
                   });
                 core.setOutput('milestone', milestone.number);
               } else {
-              console.log(`Milestone not found, Please create it first.`);
+              console.log(`No milestone found. Please create one first.`);
             }

--- a/.github/workflows/privileged-pr-process.yml
+++ b/.github/workflows/privileged-pr-process.yml
@@ -30,7 +30,7 @@ jobs:
                   .catch(err => {throw "ERROR: " + err.message});
 
             if (milestone) {
-                await client.issues.update({
+                await github.issues.update({
                   owner: github.context.repo.owner,
                   repo: github.context.repo.repo,
                   issue_number: github.event.number,

--- a/.github/workflows/privileged-pr-process.yml
+++ b/.github/workflows/privileged-pr-process.yml
@@ -1,0 +1,42 @@
+name: "Process Pull Request"
+# NOTE: This workflow is privileged, and shouldn't be used to checkout the repo or run any of the PR code
+# See more in: https://securitylab.github.com/research/github-actions-preventing-pwn-requests
+on:
+  - pull_request_target
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@main
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+  add-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add milestone
+        uses: actions/github-script@v1
+        id: assets
+        with:
+          script: |
+            var milestone = await github.issues.listMilestones({
+                      owner: github.context.repo.owner,
+                      repo: github.context.repo.repo,
+                      state: 'open',
+                      sort: 'due_on',
+                      direction: 'asc'
+                   })
+                  .then(result => result.data[0])
+                  .catch(err => {throw "ERROR: " + err.message});
+
+            if (milestone) {
+                await client.issues.update({
+                  owner: github.context.repo.owner,
+                  repo: github.context.repo.repo,
+                  issue_number: github.event.number,
+                  milestone: milestone.number,
+                  });
+                core.setOutput('milestone', addMilestone);
+              } else {
+              console.log(`Milestone not found, Please create it first.`);
+            }


### PR DESCRIPTION
* For labelling, we use Githubs built in labeler action, together with a config file (.github/labeler.yml), describing a number of paths.
* For milestones, this uses the github-script to get the list of milestones for the repo, select the first (the oldest open), and assigns that to the PR

Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No
