### PR TITLE
Build and Release for Mac Arm64 architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           echo "PACK_VERSION=${version}" >> $GITHUB_ENV
         shell: bash
       - name: Set up go
-        uses: actions/setup-go@v2.1.3
+        uses: actions/setup-go@v2
         with:
           go-version: '1.14'
       - name: Set up go env
@@ -99,55 +99,31 @@ jobs:
           name: pack-${{ matrix.os }}
           path: out/${{ env.PACK_BIN }}
   build-additional-archs:
+    if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
     strategy:
       fail-fast: false
       matrix:
-        config: [ darwin-aarch64, arm64, armv7 ]
         include:
-        - arch: aarch64
-          distro: ubuntu18.04
-          goarch: arm64
-          goarm: 7
-        - arch: aarch64
-          distro: ubuntu18.04
-          goarch: arm64
-          goarm: 7
-        - arch: armv7
-          distro: ubuntu18.04
-          goarch: arm
-          goarm: 7
-    if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+        - goarch: arm64
+          goos: darwin
+          name: macos-arm64
     needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up go
-        uses: actions/setup-go@v2.1.3
+        uses: actions/setup-go@v2
         with:
-          go-version: '1.14'
+          stable: 'false'
+          go-version: '1.16-beta1' # It looks like pre-releases need exact versioning
       - name: Build
         run: |
-          env GOARM=${{ matrix.goarm }} GOARCH=${{ matrix.goarch }} GOOS=linux make build
+          env GOARCH=${{ matrix.goarch }} GOOS=${{ matrix.goos }} make build
         env:
           PACK_BUILD: ${{ github.run_number }}
-      - name: Test artifacts
-        uses: uraimo/run-on-arch-action@v2.0.5
-        with:
-          arch: ${{ matrix.arch }}
-          distro: ${{ matrix.distro }}
-          githubToken: ${{ github.token }}
-          shell: /bin/sh
-          # Mount the artifacts directory as /artifacts in the container
-          dockerRunArgs: |
-            --volume "${PWD}/out:/out"
-
-          # Produce a binary artifact and place it in the mounted volume
-          run: |
-            /out/pack
-            echo "Ran pack"
       - uses: actions/upload-artifact@v2
         with:
-          name: pack-${{ matrix.arch }}
+          name: pack-${{ matrix.name }}
           path: out/${{ env.PACK_BIN }}
   release:
     if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
@@ -180,6 +156,12 @@ jobs:
           chmod +x pack-macos/pack
           filename=pack-v${{ env.PACK_VERSION }}-macos.tgz
           tar -C pack-macos -vzcf $filename pack
+          shasum -a 256 $filename > $filename.sha256
+      - name: Package artifacts - macos-arm64
+        run: |
+          chmod +x pack-macos-arm64/pack
+          filename=pack-v${{ env.PACK_VERSION }}-macos-arm64.tgz
+          tar -C pack-macos-arm64 -vzcf $filename pack
           shasum -a 256 $filename > $filename.sha256
       - name: Package artifacts - linux
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,9 +98,60 @@ jobs:
         with:
           name: pack-${{ matrix.os }}
           path: out/${{ env.PACK_BIN }}
-  release:
+  build-additional-archs:
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [ darwin-aarch64, arm64, armv7 ]
+        include:
+        - arch: aarch64
+          distro: ubuntu18.04
+          goarch: arm64
+          goarm: 7
+        - arch: aarch64
+          distro: ubuntu18.04
+          goarch: arm64
+          goarm: 7
+        - arch: armv7
+          distro: ubuntu18.04
+          goarch: arm
+          goarm: 7
     if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
     needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up go
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: '1.14'
+      - name: Build
+        run: |
+          env GOARM=${{ matrix.goarm }} GOARCH=${{ matrix.goarch }} GOOS=linux make build
+        env:
+          PACK_BUILD: ${{ github.run_number }}
+      - name: Test artifacts
+        uses: uraimo/run-on-arch-action@v2.0.5
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+          githubToken: ${{ github.token }}
+          shell: /bin/sh
+          # Mount the artifacts directory as /artifacts in the container
+          dockerRunArgs: |
+            --volume "${PWD}/out:/out"
+
+          # Produce a binary artifact and place it in the mounted volume
+          run: |
+            /out/pack
+            echo "Ran pack"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pack-${{ matrix.arch }}
+          path: out/${{ env.PACK_BIN }}
+  release:
+    if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+    needs: build-additional-archs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/delivery-homebrew.yml
+++ b/.github/workflows/delivery-homebrew.yml
@@ -53,6 +53,11 @@ jobs:
                 core.setOutput("macos_name", asset.name);
                 core.setOutput("macos_url", asset.browser_download_url);
               }
+
+              if (asset.name.endsWith("macos-arm64.tgz")) {
+                core.setOutput("macos_arm64_name", asset.name);
+                core.setOutput("macos_arm64_url", asset.browser_download_url);
+              }
             });
       - name: Generate asset checksums
         id: checksums
@@ -64,6 +69,10 @@ jobs:
           curl -sSL ${{ steps.assets.outputs.macos_url }} -o ${{ steps.assets.outputs.macos_name }}
           macos_sha256=$(sha256sum ${{ steps.assets.outputs.macos_name }} | cut -d ' ' -f1)
           echo "::set-output name=macos_sha256::$macos_sha256"
+
+          curl -sSL ${{ steps.assets.outputs.macos_arm64_url }} -o ${{ steps.assets.outputs.macos_arm64_name }}
+          macos_arm64_sha256=$(sha256sum ${{ steps.assets.outputs.macos_arm64_name }} | cut -d ' ' -f1)
+          echo "::set-output name=macos_arm64_sha256::macos_arm64_sha256"
       - name: Fill pack.rb
         uses: cschleiden/replace-tokens@v1
         with:
@@ -75,6 +84,8 @@ jobs:
           LINUX_SHA: ${{ steps.checksums.outputs.linux_sha256 }}
           MACOS_URL: ${{ steps.assets.outputs.macos_url }}
           MACOS_SHA: ${{ steps.checksums.outputs.macos_sha256 }}
+          MACOS_ARM64_URL: ${{ steps.assets.outputs.macos_arm64_url }}
+          MACOS_ARM64_SHA:  ${{ steps.checksums.outputs.macos_arm64_sha256 }}
       - run: cat homebrew-tap/Formula/pack.rb
       - name: Commit changes
         run: |

--- a/.github/workflows/delivery/homebrew/pack.rb
+++ b/.github/workflows/delivery/homebrew/pack.rb
@@ -5,7 +5,10 @@
 class Pack < Formula
   desc "A CLI for building apps using Cloud Native Buildpacks"
   homepage "https://github.com/buildpacks/pack"
-  if OS.mac?
+  if OS.mac? && Hardware::CPU.arm?
+    url "{{MACOS_ARM64_URL}}"
+    sha256 "{{MACOS_ARM64_SHA}}"
+  elif OS.mac?
     url "{{MACOS_URL}}"
     sha256 "{{MACOS_SHA}}"
   else 


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->

~This is a WIP, to construct pack for multiple other architectures. Specifically for linux and Mac arm64, and for armv7.~
After investigating, I put linux `arm64` and `arm7` on hold, due to requiring changes in the lifecycle. Mac M1, on the other hand, can successfully build applications, albeit slowly (due to the lifecycle not having a matching release). As such, this PR builds a Mac Arm64 binary and adds it to our releases. Further, it adds it to our Homebrew tap. 

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see #___

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1003