### PR TITLE
Output entire sha in quiet mode

### DIFF
--- a/acceptance/assertions/output.go
+++ b/acceptance/assertions/output.go
@@ -35,7 +35,7 @@ func (o OutputAssertionManager) ReportSuccessfulQuietBuild(name string) {
 	o.testObject.Helper()
 	o.testObject.Log("quiet mode")
 
-	o.assert.Matches(strings.TrimSpace(o.output), regexp.MustCompile(name+`@sha256:[\w]{12}`))
+	o.assert.Matches(strings.TrimSpace(o.output), regexp.MustCompile(name+`@sha256:[\w]{64}`))
 }
 
 func (o OutputAssertionManager) ReportsSuccessfulRebase(name string) {

--- a/acceptance/assertions/output.go
+++ b/acceptance/assertions/output.go
@@ -35,7 +35,7 @@ func (o OutputAssertionManager) ReportSuccessfulQuietBuild(name string) {
 	o.testObject.Helper()
 	o.testObject.Log("quiet mode")
 
-	o.assert.Matches(strings.TrimSpace(o.output), regexp.MustCompile(name+`@sha256:[\w]{64}`))
+	o.assert.Matches(strings.TrimSpace(o.output), regexp.MustCompile(name+`@sha256:[\w]{12,64}`))
 }
 
 func (o OutputAssertionManager) ReportsSuccessfulRebase(name string) {

--- a/build.go
+++ b/build.go
@@ -888,26 +888,22 @@ func (c *Client) logImageNameAndSha(ctx context.Context, publish bool, imageRef 
 
 	// Remove tag, if it exists, from the image name
 	imgName := strings.TrimSuffix(imageRef.String(), imageRef.Identifier())
-	imgNameAndSha := fmt.Sprintf("%s@%s\n", imgName, parseShortDigestFromImageID(id))
+	imgNameAndSha := fmt.Sprintf("%s@%s\n", imgName, parseDigestFromImageID(id))
 
 	// Access the logger's Writer directly to bypass ReportSuccessfulQuietBuild mode
 	_, err = c.logger.Writer().Write([]byte(imgNameAndSha))
 	return err
 }
 
-func parseShortDigestFromImageID(id imgutil.Identifier) string {
-	var shortID string
+func parseDigestFromImageID(id imgutil.Identifier) string {
+	var digest string
 	switch v := id.(type) {
 	case local.IDIdentifier:
-		shortID = v.String()
+		digest = v.String()
 	case remote.DigestIdentifier:
-		shortID = v.Digest.DigestStr()
+		digest = v.Digest.DigestStr()
 	}
 
-	shortID = strings.TrimPrefix(shortID, "sha256:")
-	if len(shortID) > 12 {
-		shortID = shortID[0:12]
-	}
-
-	return fmt.Sprintf("sha256:%s", shortID)
+	digest = strings.TrimPrefix(digest, "sha256:")
+	return fmt.Sprintf("sha256:%s", digest)
 }

--- a/build_test.go
+++ b/build_test.go
@@ -230,7 +230,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 						Publish: true,
 					}))
 
-					h.AssertEq(t, strings.TrimSpace(outBuf.String()), "example.io/some/app@sha256:363c754893f0")
+					h.AssertEq(t, strings.TrimSpace(outBuf.String()), "example.io/some/app@sha256:363c754893f0efe22480b4359a5956cf3bd3ce22742fc576973c61348308c2e4")
 				})
 			})
 
@@ -255,7 +255,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 						AppPath: filepath.Join("testdata", "some-app"),
 					}))
 
-					h.AssertEq(t, strings.TrimSpace(outBuf.String()), "some/app@sha256:363c754893f0")
+					h.AssertEq(t, strings.TrimSpace(outBuf.String()), "some/app@sha256:363c754893f0efe22480b4359a5956cf3bd3ce22742fc576973c61348308c2e4")
 				})
 			})
 		})


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
We initially trimmed the sha down to 12 characters. We got a feature request that it output the entire sha [here](https://buildpacks.slack.com/archives/C94UJCNV6/p1611582985045000), which makes more sense anyways (if we have the information, we may as well share it), so this changes that to be the full string.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
```
$  pack build test -p ~/workspace/paketo-samples/go/mod/ -q
test@sha256:7c3b2ba175bf
```

#### After
```
$  out/pack build test -p ~/workspace/paketo-samples/go/mod/ -q
test@sha256:7c3b2ba175bf5779f7b3fad1b0a6d0137367c9fe555afe4d227bedebba7ceb90
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Relates to #285 
Relates to #831
