### PR TITLE
Log lifecycle arguments

### DIFF
--- a/internal/build/phase_config_provider.go
+++ b/internal/build/phase_config_provider.go
@@ -71,7 +71,7 @@ func NewPhaseConfigProvider(name string, lifecycleExec *LifecycleExecution, ops 
 
 	lifecycleExec.logger.Debug("Host Settings:")
 	lifecycleExec.logger.Debugf("  Binds: %s", style.Symbol(strings.Join(provider.hostConf.Binds, " ")))
-	lifecycleExec.logger.Debugf("  Network Mode: %s", style.Symbol(fmt.Sprintf("%s", provider.hostConf.NetworkMode)))
+	lifecycleExec.logger.Debugf("  Network Mode: %s", style.Symbol(string(provider.hostConf.NetworkMode)))
 	return provider
 }
 

--- a/internal/build/phase_config_provider.go
+++ b/internal/build/phase_config_provider.go
@@ -3,9 +3,11 @@ package build
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/docker/docker/api/types/container"
 
+	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/logging"
 )
 
@@ -59,6 +61,17 @@ func NewPhaseConfigProvider(name string, lifecycleExec *LifecycleExecution, ops 
 
 	provider.ctrConf.Cmd = append([]string{"/cnb/lifecycle/" + name}, provider.ctrConf.Cmd...)
 
+	lifecycleExec.logger.Debugf("Running the %s on OS %s with:", style.Symbol(provider.Name()), style.Symbol(provider.os))
+	lifecycleExec.logger.Debug("Container Settings:")
+	lifecycleExec.logger.Debugf("  Args: %s", style.Symbol(strings.Join(provider.ctrConf.Cmd, " ")))
+	lifecycleExec.logger.Debugf("  System Envs: %s", style.Symbol(strings.Join(provider.ctrConf.Env, " ")))
+	lifecycleExec.logger.Debugf("  Image: %s", style.Symbol(provider.ctrConf.Image))
+	lifecycleExec.logger.Debugf("  User: %s", style.Symbol(provider.ctrConf.User))
+	lifecycleExec.logger.Debugf("  Labels: %s", style.Symbol(fmt.Sprintf("%s", provider.ctrConf.Labels)))
+
+	lifecycleExec.logger.Debug("Host Settings:")
+	lifecycleExec.logger.Debugf("  Binds: %s", style.Symbol(strings.Join(provider.hostConf.Binds, " ")))
+	lifecycleExec.logger.Debugf("  Network Mode: %s", style.Symbol(fmt.Sprintf("%s", provider.hostConf.NetworkMode)))
 	return provider
 }
 

--- a/internal/build/phase_config_provider_test.go
+++ b/internal/build/phase_config_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"math/rand"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -296,7 +297,11 @@ func testPhaseConfigProvider(t *testing.T, when spec.G, it spec.S) {
 					build.WithRoot(),
 				)
 
-				h.AssertContains(t, outBuf.String(), "Running the 'some-name' on OS 'linux' with")
+				if runtime.GOOS == "windows" {
+					h.AssertContains(t, outBuf.String(), "Running the 'some-name' on OS 'windows'")
+				} else {
+					h.AssertContains(t, outBuf.String(), "Running the 'some-name' on OS 'linux'")
+				}
 				h.AssertContains(t, outBuf.String(), "Args: '/cnb/lifecycle/some-name'")
 				h.AssertContains(t, outBuf.String(), "System Envs: 'CNB_PLATFORM_API=0.4 HTTP_PROXY=some-http-proxy http_proxy=some-http-proxy HTTPS_PROXY=some-https-proxy https_proxy=some-https-proxy NO_PROXY=some-no-proxy no_proxy=some-no-proxy'")
 				h.AssertContains(t, outBuf.String(), "Image: ''")

--- a/internal/build/phase_config_provider_test.go
+++ b/internal/build/phase_config_provider_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"math/rand"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -297,15 +296,11 @@ func testPhaseConfigProvider(t *testing.T, when spec.G, it spec.S) {
 					build.WithRoot(),
 				)
 
-				if runtime.GOOS == "windows" {
-					h.AssertContains(t, outBuf.String(), "Running the 'some-name' on OS 'windows'")
-				} else {
-					h.AssertContains(t, outBuf.String(), "Running the 'some-name' on OS 'linux'")
-				}
+				h.AssertContains(t, outBuf.String(), "Running the 'some-name' on OS")
 				h.AssertContains(t, outBuf.String(), "Args: '/cnb/lifecycle/some-name'")
 				h.AssertContains(t, outBuf.String(), "System Envs: 'CNB_PLATFORM_API=0.4 HTTP_PROXY=some-http-proxy http_proxy=some-http-proxy HTTPS_PROXY=some-https-proxy https_proxy=some-https-proxy NO_PROXY=some-no-proxy no_proxy=some-no-proxy'")
 				h.AssertContains(t, outBuf.String(), "Image: ''")
-				h.AssertContains(t, outBuf.String(), "User: 'root'")
+				h.AssertContains(t, outBuf.String(), "User:")
 				h.AssertContains(t, outBuf.String(), "Labels: 'map[author:pack]'")
 				h.AssertContainsMatch(t, outBuf.String(), `Binds: \'\S+:/layers \S+:/workspace\'`)
 				h.AssertContains(t, outBuf.String(), "Network Mode: ''")

--- a/internal/build/phase_config_provider_test.go
+++ b/internal/build/phase_config_provider_test.go
@@ -302,7 +302,7 @@ func testPhaseConfigProvider(t *testing.T, when spec.G, it spec.S) {
 				h.AssertContains(t, outBuf.String(), "Image: ''")
 				h.AssertContains(t, outBuf.String(), "User:")
 				h.AssertContains(t, outBuf.String(), "Labels: 'map[author:pack]'")
-				h.AssertContainsMatch(t, outBuf.String(), `Binds: \'\S+:/layers \S+:/workspace\'`)
+				h.AssertContainsMatch(t, outBuf.String(), `Binds: \'\S+:\S+layers \S+:\S+workspace'`)
 				h.AssertContains(t, outBuf.String(), "Network Mode: ''")
 			})
 		})

--- a/internal/build/phase_config_provider_test.go
+++ b/internal/build/phase_config_provider_test.go
@@ -3,7 +3,6 @@ package build_test
 import (
 	"bytes"
 	"math/rand"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -287,7 +286,16 @@ func testPhaseConfigProvider(t *testing.T, when spec.G, it spec.S) {
 
 				docker, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
 				h.AssertNil(t, err)
-				lifecycleExec, err := CreateFakeLifecycleExecution(logger, docker, filepath.Join("testdata", "fake-app"), repoName)
+
+				defaultBuilder, err := fakes.NewFakeBuilder()
+				h.AssertNil(t, err)
+
+				opts := build.LifecycleOptions{
+					AppPath: "some-app-path",
+					Builder: defaultBuilder,
+				}
+
+				lifecycleExec, err := build.NewLifecycleExecution(logger, docker, opts)
 				h.AssertNil(t, err)
 
 				_ = build.NewPhaseConfigProvider(
@@ -298,8 +306,8 @@ func testPhaseConfigProvider(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertContains(t, outBuf.String(), "Running the 'some-name' on OS")
 				h.AssertContains(t, outBuf.String(), "Args: '/cnb/lifecycle/some-name'")
-				h.AssertContains(t, outBuf.String(), "System Envs: 'CNB_PLATFORM_API=0.4 HTTP_PROXY=some-http-proxy http_proxy=some-http-proxy HTTPS_PROXY=some-https-proxy https_proxy=some-https-proxy NO_PROXY=some-no-proxy no_proxy=some-no-proxy'")
-				h.AssertContains(t, outBuf.String(), "Image: ''")
+				h.AssertContains(t, outBuf.String(), "System Envs: 'CNB_PLATFORM_API=0.4'")
+				h.AssertContains(t, outBuf.String(), "Image: 'some-builder-name'")
 				h.AssertContains(t, outBuf.String(), "User:")
 				h.AssertContains(t, outBuf.String(), "Labels: 'map[author:pack]'")
 				h.AssertContainsMatch(t, outBuf.String(), `Binds: \'\S+:\S+layers \S+:\S+workspace'`)


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
This adds debug logging to our calls of the lifecycle binaries container, printing any settings we may have adjusted, including:
* Binary name
* container OS
* container args
* container env variables (*NOTE*: This doesn't include the user provided env variables (with `-env`, which are already logged, and will be passed to the container through being written to `/platform/env`)
* container image name
* container user
* container labels
* host binds
* host network mode

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
```
$  pack build test-noop -p ~/workspace/pack/acceptance/testdata/mock_app -B cnbs/sample-builder:bionic --trust-builder -v -e SOME=FOO
...
Provided Environment Variables
  SOME=FOO
Using build cache volume pack-cache-b07b36ffb1de.build
===> DETECTING
...
```

#### After
```
$  go run cmd/pack/main.go build test-noop -p ~/workspace/pack/acceptance/testdata/mock_app -B cnbs/sample-builder:bionic --trust-builder -v -e SOME=FOO
...
Provided Environment Variables
  SOME=FOO
Using build cache volume pack-cache-b07b36ffb1de.build
Running the creator on OS linux with:
Container Settings:
  Args: /cnb/lifecycle/creator -daemon -launch-cache /launch-cache -log-level debug -cache-dir /cache -run-image cnbs/sample-stack-run:bionic -process-type web test-noop
  System Envs: CNB_PLATFORM_API=0.4
  Image: pack.local/builder/6a6378657a7661756f6c:latest
  User: root
  Labels: map[author:pack]
Host Settings:
  Binds: pack-cache-b07b36ffb1de.build:/cache /var/run/docker.sock:/var/run/docker.sock pack-cache-b07b36ffb1de.launch:/launch-cache pack-layers-jywocybjgd:/layers pack-app-tjtwspgelp:/workspace
  Network Mode:
===> DETECTING
...
```
## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #335 
This encompasses changes from #337 (with thanks for @josephlewis42 for opening the issue and taking the initial stab at solving it)
