### PR TITLE
Promote the registry commands out of experimental state

### DIFF
--- a/internal/commands/add_registry.go
+++ b/internal/commands/add_registry.go
@@ -18,7 +18,7 @@ func AddBuildpackRegistry(logger logging.Logger, cfg config.Config, cfgPath stri
 		Use:     "add-registry <name> <url>",
 		Args:    cobra.ExactArgs(2),
 		Hidden:  true,
-		Short:   prependExperimental("Add buildpack registry to your pack config file"),
+		Short:   "Add buildpack registry to your pack config file",
 		Example: "pack add-registry my-registry https://github.com/buildpacks/my-registry",
 		Long: "A Buildpack Registry is a (still experimental) place to publish, store, and discover buildpacks. " +
 			"Users can add buildpacks registries using add-registry, and publish/yank buildpacks from it, as well as use those buildpacks when building applications.",

--- a/internal/commands/buildpack.go
+++ b/internal/commands/buildpack.go
@@ -16,11 +16,9 @@ func NewBuildpackCommand(logger logging.Logger, cfg config.Config, client PackCl
 	}
 
 	cmd.AddCommand(BuildpackPackage(logger, cfg, client, packageConfigReader))
-	if cfg.Experimental {
-		cmd.AddCommand(BuildpackPull(logger, cfg, client))
-		cmd.AddCommand(BuildpackRegister(logger, cfg, client))
-		cmd.AddCommand(BuildpackYank(logger, cfg, client))
-	}
+	cmd.AddCommand(BuildpackPull(logger, cfg, client))
+	cmd.AddCommand(BuildpackRegister(logger, cfg, client))
+	cmd.AddCommand(BuildpackYank(logger, cfg, client))
 
 	AddHelpFlag(cmd, "buildpack")
 	return cmd

--- a/internal/commands/buildpack_pull.go
+++ b/internal/commands/buildpack_pull.go
@@ -22,7 +22,7 @@ func BuildpackPull(logger logging.Logger, cfg config.Config, client PackClient) 
 	cmd := &cobra.Command{
 		Use:     "pull <uri>",
 		Args:    cobra.ExactArgs(1),
-		Short:   prependExperimental("Pull a buildpack from a registry and store it locally"),
+		Short:   "Pull a buildpack from a registry and store it locally",
 		Example: "pack buildpack pull example/my-buildpack@1.0.0",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			registry, err := config.GetRegistry(cfg, flags.BuildpackRegistry)

--- a/internal/commands/buildpack_register.go
+++ b/internal/commands/buildpack_register.go
@@ -20,7 +20,7 @@ func BuildpackRegister(logger logging.Logger, cfg config.Config, client PackClie
 	cmd := &cobra.Command{
 		Use:     "register <image>",
 		Args:    cobra.ExactArgs(1),
-		Short:   prependExperimental("Register a buildpack to a registry"),
+		Short:   "Register a buildpack to a registry",
 		Example: "pack register my-buildpack",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			registry, err := config.GetRegistry(cfg, flags.BuildpackRegistry)

--- a/internal/commands/buildpack_test.go
+++ b/internal/commands/buildpack_test.go
@@ -44,22 +44,7 @@ func testBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNil(t, cmd.Execute())
 			output := outBuf.String()
 			h.AssertContains(t, output, "Interact with buildpacks")
-			h.AssertContains(t, output, "Usage:")
-			h.AssertContains(t, output, "package")
-			for _, command := range []string{"register", "yank", "pull"} {
-				h.AssertNotContains(t, output, command)
-			}
-		})
-
-		it("only shows experimental commands if in the config", func() {
-			cmd = commands.NewBuildpackCommand(logger, config.Config{Experimental: true}, mockClient, fakes.NewFakePackageConfigReader())
-			cmd.SetOut(logging.GetWriterForLevel(logger, logging.InfoLevel))
-			cmd.SetArgs([]string{})
-			h.AssertNil(t, cmd.Execute())
-			output := outBuf.String()
-			h.AssertContains(t, output, "Interact with buildpacks")
-			h.AssertContains(t, output, "Usage:")
-			for _, command := range []string{"package", "register", "yank", "pull"} {
+			for _, command := range []string{"Usage", "package", "register", "yank", "pull"} {
 				h.AssertContains(t, output, command)
 			}
 		})

--- a/internal/commands/buildpack_yank.go
+++ b/internal/commands/buildpack_yank.go
@@ -23,7 +23,7 @@ func BuildpackYank(logger logging.Logger, cfg config.Config, client PackClient) 
 	cmd := &cobra.Command{
 		Use:     "yank <buildpack-id-and-version>",
 		Args:    cobra.ExactArgs(1),
-		Short:   prependExperimental("Yank a buildpack from a registry"),
+		Short:   "Yank a buildpack from a registry",
 		Example: "pack yank my-buildpack@0.0.1",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			buildpackIDVersion := args[0]

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -78,10 +78,6 @@ func multiValueHelp(name string) string {
 	return fmt.Sprintf("\nRepeat for each %s in order,\n  or supply once by comma-separated list", name)
 }
 
-func prependExperimental(short string) string {
-	return fmt.Sprintf("(%s) %s", style.Warn("experimental"), short)
-}
-
 func getMirrors(config config.Config) map[string][]string {
 	mirrors := map[string][]string{}
 	for _, ri := range config.RunImages {

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -21,10 +21,7 @@ func NewConfigCommand(logger logging.Logger, cfg config.Config, cfgPath string, 
 	cmd.AddCommand(ConfigPullPolicy(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigRunImagesMirrors(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigTrustedBuilder(logger, cfg, cfgPath))
-
-	if cfg.Experimental {
-		cmd.AddCommand(ConfigRegistries(logger, cfg, cfgPath))
-	}
+	cmd.AddCommand(ConfigRegistries(logger, cfg, cfgPath))
 
 	AddHelpFlag(cmd, "config")
 	return cmd

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -19,9 +19,9 @@ func NewConfigCommand(logger logging.Logger, cfg config.Config, cfgPath string, 
 	cmd.AddCommand(ConfigDefaultBuilder(logger, cfg, cfgPath, client))
 	cmd.AddCommand(ConfigExperimental(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigPullPolicy(logger, cfg, cfgPath))
+	cmd.AddCommand(ConfigRegistries(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigRunImagesMirrors(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigTrustedBuilder(logger, cfg, cfgPath))
-	cmd.AddCommand(ConfigRegistries(logger, cfg, cfgPath))
 
 	AddHelpFlag(cmd, "config")
 	return cmd

--- a/internal/commands/config_registries.go
+++ b/internal/commands/config_registries.go
@@ -28,7 +28,7 @@ func ConfigRegistries(logger logging.Logger, cfg config.Config, cfgPath string) 
 	cmd := &cobra.Command{
 		Use:     "registries",
 		Aliases: []string{"registry", "registreis"},
-		Short:   prependExperimental("List, add and remove registries"),
+		Short:   "List, add and remove registries",
 		Long:    bpRegistryExplanation + "\nYou can use the attached commands to list, add, and remove registries from your config",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			listRegistries(args, logger, cfg)
@@ -38,14 +38,12 @@ func ConfigRegistries(logger logging.Logger, cfg config.Config, cfgPath string) 
 
 	listCmd := generateListCmd("registries", logger, cfg, listRegistries)
 	listCmd.Example = "pack config registries list"
-	listCmd.Short = prependExperimental(listCmd.Short)
 	listCmd.Long = bpRegistryExplanation + "List Registries saved in the pack config.\n\nShow the registries that are either added by default or have been explicitly added by using `pack config registries add`"
 	cmd.AddCommand(listCmd)
 
 	addCmd := generateAdd("registries", logger, cfg, cfgPath, addRegistry)
 	addCmd.Args = cobra.ExactArgs(2)
 	addCmd.Example = "pack config registries add my-registry https://github.com/buildpacks/my-registry"
-	addCmd.Short = prependExperimental(addCmd.Short)
 	addCmd.Long = bpRegistryExplanation + "Users can add registries from the config by using registries remove, and publish/yank buildpacks from it, as well as use those buildpacks when building applications."
 	addCmd.Flags().BoolVar(&setDefault, "default", false, "Set this buildpack registry as the default")
 	addCmd.Flags().StringVar(&registryType, "type", "github", "Type of buildpack registry [git|github]")
@@ -53,7 +51,6 @@ func ConfigRegistries(logger logging.Logger, cfg config.Config, cfgPath string) 
 
 	rmCmd := generateRemove("registries", logger, cfg, cfgPath, removeRegistry)
 	rmCmd.Example = "pack config registries remove myregistry"
-	rmCmd.Short = prependExperimental(rmCmd.Short)
 	rmCmd.Long = bpRegistryExplanation + "Users can remove registries from the config by using `pack config registries remove <registry>`"
 	cmd.AddCommand(rmCmd)
 

--- a/internal/commands/config_registries_default.go
+++ b/internal/commands/config_registries_default.go
@@ -17,7 +17,7 @@ func ConfigRegistriesDefault(logger logging.Logger, cfg config.Config, cfgPath s
 	cmd := &cobra.Command{
 		Use:     "default <name>",
 		Args:    cobra.MaximumNArgs(1),
-		Short:   prependExperimental("Set default registry"),
+		Short:   "Set default registry",
 		Example: "pack config registries default myregistry",
 		Long: bpRegistryExplanation + "\n\nYou can use this command to list, set, and unset a default registry, which will be used when looking for buildpacks:" +
 			"* To list your default registry, run `pack config registries default`.\n" +

--- a/internal/commands/config_test.go
+++ b/internal/commands/config_test.go
@@ -66,14 +66,6 @@ func testConfigCommand(t *testing.T, when spec.G, it spec.S) {
 				h.AssertContains(t, output, command)
 			}
 		})
-
-		it("doesn't print experimental commands if experimental not enabled", func() {
-			command = commands.NewConfigCommand(logger, config.Config{}, configPath, mockClient)
-			command.SetArgs([]string{})
-			h.AssertNil(t, command.Execute())
-			output := outBuf.String()
-			h.AssertNotContains(t, output, "registries")
-		})
 	})
 }
 

--- a/internal/commands/list_registries.go
+++ b/internal/commands/list_registries.go
@@ -13,7 +13,7 @@ func ListBuildpackRegistries(logger logging.Logger, cfg config.Config) *cobra.Co
 		Use:     "list-registries",
 		Args:    cobra.NoArgs,
 		Hidden:  true,
-		Short:   prependExperimental("List buildpack registries"),
+		Short:   "List buildpack registries",
 		Example: "pack list-registries",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			deprecationWarning(logger, "list-registries", "config registries list")

--- a/internal/commands/register_buildpack.go
+++ b/internal/commands/register_buildpack.go
@@ -19,7 +19,7 @@ func RegisterBuildpack(logger logging.Logger, cfg config.Config, client PackClie
 		Use:     "register-buildpack <image>",
 		Hidden:  true,
 		Args:    cobra.ExactArgs(1),
-		Short:   prependExperimental("Register the buildpack to a registry"),
+		Short:   "Register the buildpack to a registry",
 		Example: "pack register-buildpack my-buildpack",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			deprecationWarning(logger, "register-buildpack", "buildpack register")

--- a/internal/commands/remove_registry.go
+++ b/internal/commands/remove_registry.go
@@ -13,7 +13,7 @@ func RemoveRegistry(logger logging.Logger, cfg config.Config, cfgPath string) *c
 		Use:     "remove-registry <name>",
 		Args:    cobra.ExactArgs(1),
 		Hidden:  true,
-		Short:   prependExperimental("Remove registry"),
+		Short:   "Remove registry",
 		Example: "pack remove-registry myregistry",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			deprecationWarning(logger, "remove-registry", "config registries remove")

--- a/internal/commands/set_default_registry.go
+++ b/internal/commands/set_default_registry.go
@@ -19,7 +19,7 @@ func SetDefaultRegistry(logger logging.Logger, cfg config.Config, cfgPath string
 		Use:     "set-default-registry <name>",
 		Args:    cobra.ExactArgs(1),
 		Hidden:  true,
-		Short:   prependExperimental("Set default registry"),
+		Short:   "Set default registry",
 		Example: "pack set-default-registry myregistry",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			deprecationWarning(logger, "set-default-registry", "config registries default")

--- a/internal/commands/yank_buildpack.go
+++ b/internal/commands/yank_buildpack.go
@@ -18,7 +18,7 @@ func YankBuildpack(logger logging.Logger, cfg config.Config, client PackClient) 
 		Use:     "yank-buildpack <buildpack-id-and-version>",
 		Hidden:  true,
 		Args:    cobra.ExactArgs(1),
-		Short:   prependExperimental("Yank the buildpack from the registry"),
+		Short:   "Yank the buildpack from the registry",
 		Example: "pack yank-buildpack my-buildpack@0.0.1",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			deprecationWarning(logger, "yank-buildpack", "buildpack yank")


### PR DESCRIPTION
## Summary

Moves the following commands out of experimental state:

* `pack buildpack register`
* `pack buildpack yank`
* `pack buildpack pull`
* `pack config registry`

I left the deprecated commands (like `pull-buildpack`) in experimental state because it seems wrong to promote them if they're deprecated.

## Output

N/A

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see https://github.com/buildpacks/docs/pull/286
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
