### PR TITLE
Enable GID override in Build

### DIFF
--- a/build.go
+++ b/build.go
@@ -149,6 +149,9 @@ type BuildOptions struct {
 
 	// ProjectDescriptor describes the project and any configuration specific to the project
 	ProjectDescriptor project.Descriptor
+
+	// TBD
+	GroupID config.GroupID
 }
 
 // ProxyConfig specifies proxy setting to be set as environment variables in a container.
@@ -241,7 +244,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		buildEnvs[k] = v
 	}
 
-	ephemeralBuilder, err := c.createEphemeralBuilder(rawBuilderImage, buildEnvs, order, fetchedBPs)
+	ephemeralBuilder, err := c.createEphemeralBuilder(rawBuilderImage, buildEnvs, order, fetchedBPs, opts)
 	if err != nil {
 		return err
 	}
@@ -803,9 +806,10 @@ func ensureBPSupport(bpPath string) (err error) {
 	return nil
 }
 
-func (c *Client) createEphemeralBuilder(rawBuilderImage imgutil.Image, env map[string]string, order dist.Order, buildpacks []dist.Buildpack) (*builder.Builder, error) {
+func (c *Client) createEphemeralBuilder(rawBuilderImage imgutil.Image, env map[string]string, order dist.Order, buildpacks []dist.Buildpack, opts BuildOptions) (*builder.Builder, error) {
 	origBuilderName := rawBuilderImage.Name()
-	bldr, err := builder.New(rawBuilderImage, fmt.Sprintf("pack.local/builder/%x:latest", randString(10)))
+	name := fmt.Sprintf("pack.local/builder/%x:latest", randString(10))
+	bldr, err := builder.New(rawBuilderImage, name, opts.GroupID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid builder %s", style.Symbol(origBuilderName))
 	}

--- a/config/gid.go
+++ b/config/gid.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+type GroupID struct {
+	ID           string
+	FlagProvided bool
+}
+
+func (gid *GroupID) GetID(sGID string) (int, error) {
+	if gid.FlagProvided {
+		id, err := strconv.Atoi(gid.ID)
+
+		if err != nil {
+			return 0, errors.Errorf("invalid gid %s", gid.ID)
+		}
+
+		return id, nil
+	}
+
+	return strconv.Atoi(sGID)
+}

--- a/create_builder.go
+++ b/create_builder.go
@@ -128,7 +128,7 @@ func (c *Client) createBaseBuilder(ctx context.Context, opts CreateBuilderOption
 	}
 
 	c.logger.Debugf("Creating builder %s from build-image %s", style.Symbol(opts.BuilderName), style.Symbol(baseImage.Name()))
-	bldr, err := builder.New(baseImage, opts.BuilderName)
+	bldr, err := builder.New(baseImage, opts.BuilderName, config.GroupID{})
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid build-image")
 	}

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -31,6 +31,7 @@ type BuildFlags struct {
 	Network            string
 	DescriptorPath     string
 	DefaultProcessType string
+	GroupID            string
 	Env                []string
 	EnvFiles           []string
 	Buildpacks         []string
@@ -97,6 +98,11 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				return errors.Wrapf(err, "parsing pull policy %s", flags.Policy)
 			}
 
+			var gid = pubcfg.GroupID{
+				FlagProvided: flags.GroupID != "",
+				ID:           flags.GroupID,
+			}
+
 			if err := packClient.Build(cmd.Context(), pack.BuildOptions{
 				AppPath:           flags.AppPath,
 				Builder:           flags.Builder,
@@ -119,6 +125,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				ProjectDescriptorBaseDir: filepath.Dir(actualDescriptorPath),
 				ProjectDescriptor:        descriptor,
 				CacheImage:               flags.CacheImage,
+				GroupID:                  gid,
 			}); err != nil {
 				return errors.Wrap(err, "failed to build")
 			}
@@ -152,6 +159,7 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringVar(&buildFlags.Policy, "pull-policy", "", `Pull policy to use. Accepted values are always, never, and if-not-present. (default "always")`)
 	cmd.Flags().StringSliceVarP(&buildFlags.AdditionalTags, "tag", "t", nil, "Additional tags to push the output image to."+multiValueHelp("tag"))
 	cmd.Flags().StringVar(&buildFlags.CacheImage, "cache-image", "", `Cache build layers in remote registry. Requires --publish`)
+	cmd.Flags().StringVar(&buildFlags.GroupID, "gid", "", "Set group '0' as the owner of the contents in '/workspace/' within the app image")
 }
 
 func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackClient, logger logging.Logger) error {


### PR DESCRIPTION
## Summary

Allows group ID to be set via a `-gid` flag.
#961

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
Resolves #961
