### PR TITLE
Update project.toml includes and excludes to respect repository root

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -2002,6 +2002,10 @@ func testAcceptance(
 								// Create test directories and files:
 								//
 								// ├── cookie.jar
+								// ├── other-cookie.jar
+								// ├── nested-cookie.jar
+								// ├── nested
+								// │   └── nested-cookie.jar
 								// ├── secrets
 								// │   ├── api_keys.json
 								// |   |── user_token
@@ -2009,11 +2013,23 @@ func testAcceptance(
 								// │   ├── mountain.jpg
 								// │   └── person.png
 								// └── test.sh
+
 								err = os.Mkdir(filepath.Join(tempAppDir, "secrets"), 0755)
 								assert.Nil(err)
 								err = ioutil.WriteFile(filepath.Join(tempAppDir, "secrets", "api_keys.json"), []byte("{}"), 0755)
 								assert.Nil(err)
 								err = ioutil.WriteFile(filepath.Join(tempAppDir, "secrets", "user_token"), []byte("token"), 0755)
+								assert.Nil(err)
+
+								err = os.Mkdir(filepath.Join(tempAppDir, "nested"), 0755)
+								assert.Nil(err)
+								err = ioutil.WriteFile(filepath.Join(tempAppDir,"nested", "nested-cookie.jar"), []byte("chocolate chip"), 0755)
+								assert.Nil(err)
+
+								err = ioutil.WriteFile(filepath.Join(tempAppDir, "other-cookie.jar"), []byte("chocolate chip"), 0755)
+								assert.Nil(err)
+
+								err = ioutil.WriteFile(filepath.Join(tempAppDir, "nested-cookie.jar"), []byte("chocolate chip"), 0755)
 								assert.Nil(err)
 
 								err = os.Mkdir(filepath.Join(tempAppDir, "media"), 0755)
@@ -2040,7 +2056,7 @@ name = "exclude test"
 [[project.licenses]]
 type = "MIT"
 [build]
-exclude = [ "*.sh", "secrets/", "media/metadata" ]
+exclude = [ "*.sh", "secrets/", "media/metadata", "/other-cookie.jar" ,"/nested-cookie.jar"]
 `
 								excludeDescriptorPath := filepath.Join(tempAppDir, "exclude.toml")
 								err := ioutil.WriteFile(excludeDescriptorPath, []byte(projectToml), 0755)
@@ -2056,8 +2072,10 @@ exclude = [ "*.sh", "secrets/", "media/metadata" ]
 								assert.NotContains(output, "api_keys.json")
 								assert.NotContains(output, "user_token")
 								assert.NotContains(output, "test.sh")
+								assert.NotContains(output, "other-cookie.jar")
 
 								assert.Contains(output, "cookie.jar")
+								assert.Contains(output, "nested-cookie.jar")
 								assert.Contains(output, "mountain.jpg")
 								assert.Contains(output, "person.png")
 							})

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -263,6 +263,34 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 					verify.NextSymLink("/nested/dir/dir-in-archive/sub-dir/link-file", "../some-file.txt")
 				}
 			})
+
+			it("filter is only handed relevant section of the filepath", func() {
+				tarFile := filepath.Join(tmpDir, "some.tar")
+				fh, err := os.Create(tarFile)
+				h.AssertNil(t, err)
+
+				tw := tar.NewWriter(fh)
+
+				err = archive.WriteDirToTar(tw, src, "/nested/dir/dir-in-archive", 1234, 2345, 0777, true, func(path string) bool {
+					return !strings.Contains(path, "dir-to-tar")
+				})
+				h.AssertNil(t, err)
+				h.AssertNil(t, tw.Close())
+				h.AssertNil(t, fh.Close())
+
+				file, err := os.Open(filepath.Join(tmpDir, "some.tar"))
+				h.AssertNil(t, err)
+				defer file.Close()
+
+				tr := tar.NewReader(file)
+
+				verify := h.NewTarVerifier(t, tr, 1234, 2345)
+				verify.NextFile("/nested/dir/dir-in-archive/some-file.txt", "some-content", int64(os.ModePerm))
+				verify.NextDirectory("/nested/dir/dir-in-archive/sub-dir", int64(os.ModePerm))
+				if runtime.GOOS != "windows" {
+					verify.NextSymLink("/nested/dir/dir-in-archive/sub-dir/link-file", "../some-file.txt")
+				}
+			})
 		})
 
 		when("normalize mod time is false", func() {


### PR DESCRIPTION
Signed-off-by: dwillist <dthornton@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
Fixes issue where files were filtered against the `include` and `exclude` sections in `project.toml` as absolute paths. 
Given the following application: 
```
.
├── node_modules
├── package.json
├── package-lock.json
├── project.toml
├── README.md
└── server.js
```

and the following contents of `project.toml` (which uses `.gitignore` syntax)
```
[build]
include = [
  "src/", 
  "/package.json",
  "/package-lock.json",
  "/node_modules",
]
```

`/package.json` would be interpreted as a file at the root of your filesystem. 

#### Before


#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #987 
