### PR TITLE
Make project.toml buildpack paths relative to project root

### DIFF
--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -214,6 +214,7 @@ type Feature int
 const (
 	BuilderTomlValidation Feature = iota
 	ExcludeAndIncludeDescriptor
+	DescriptorWithBuildpacks
 	CreatorInPack
 	ReadWriteVolumeMounts
 	NoColorInBuildpacks
@@ -228,6 +229,9 @@ var featureTests = map[Feature]func(i *PackInvoker) bool{
 	},
 	ExcludeAndIncludeDescriptor: func(i *PackInvoker) bool {
 		return i.laterThan("0.9.0")
+	},
+	DescriptorWithBuildpacks: func(i *PackInvoker) bool {
+		return i.laterThan("0.16.0")
 	},
 	CreatorInPack: func(i *PackInvoker) bool {
 		return i.atLeast("0.10.0")

--- a/build.go
+++ b/build.go
@@ -668,7 +668,7 @@ func (c *Client) processBuildpacks(ctx context.Context, builderImage imgutil.Ima
 				Version: version,
 			})
 		case buildpack.URILocator:
-			bp, err = paths.FilePathToURI(bp, opts.RelativeBaseDir)
+			bp, err = paths.FilePathToURI(bp, relativeBaseDir)
 			if err != nil {
 				return fetchedBPs, order, errors.Wrapf(err, "making absolute: %s", style.Symbol(bp))
 			}


### PR DESCRIPTION
Signed-off-by: dwillist <dthornton@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
Buildpacks listed in a project descriptor that use relative paths should be considered relative to the descriptor file.

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1031 
