### PR TITLE
Use exact version for setup-go action (0.16.0beta1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           stable: 'false'
-          go-version: '1.16-beta1' # It looks like pre-releases need exact versioning
+          go-version: '1.16.0-beta1' # Pre-releases need exact versioning (https://github.com/actions/setup-go/issues/96)
       - name: Build
         run: |
           env GOARCH=${{ matrix.goarch }} GOOS=${{ matrix.goos }} make build


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
The current job for building a release for additional architectures (at this point, only macos-arm64) is broken, because it doesn't specify the correct version for the setup-go action to download. This PR fixes that. 

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Related: #1030
