### PR TITLE
Use 0.16.0-rc1 for build, instead of -beta1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,8 +114,8 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          stable: 'false'
-          go-version: '1.16.0-beta1' # Pre-releases need exact versioning (https://github.com/actions/setup-go/issues/96)
+          stable: false
+          go-version: '1.16.0-rc1' # Pre-releases need exact versioning (https://github.com/actions/setup-go/issues/96)
       - name: Build
         run: |
           env GOARCH=${{ matrix.goarch }} GOOS=${{ matrix.goos }} make build


### PR DESCRIPTION
When I tried using beta1, I got an error showing that it was incompatible with the github action OS. `rc1` seems to fix that.
It worked appropriately here: https://github.com/dfreilich/pack/runs/1805635349?check_suite_focus=true
