### PR TITLE
Correct homebrew formula

### DIFF
--- a/.github/workflows/delivery/homebrew/pack.rb
+++ b/.github/workflows/delivery/homebrew/pack.rb
@@ -8,7 +8,7 @@ class Pack < Formula
   if OS.mac? && Hardware::CPU.arm?
     url "{{MACOS_ARM64_URL}}"
     sha256 "{{MACOS_ARM64_SHA}}"
-  elif OS.mac?
+  elsif OS.mac?
     url "{{MACOS_URL}}"
     sha256 "{{MACOS_SHA}}"
   else 


### PR DESCRIPTION
Signed-off-by: dwillist <dthornton@vmware.com>

## Summary
small syntax fix in our homebrew formula that prevented the `OS.mac?` line from evaluating

