### PR TITLE
Download pack-x86 release in acceptance tests

### DIFF
--- a/acceptance/os/variables_darwin.go
+++ b/acceptance/os/variables_darwin.go
@@ -5,4 +5,4 @@ package os
 
 import "regexp"
 
-var PackBinaryExp = regexp.MustCompile(`pack-v\d+.\d+.\d+-macos`)
+var PackBinaryExp = regexp.MustCompile(`pack-v\d+.\d+.\d+-macos\.`)


### PR DESCRIPTION
Signed-off-by: dwillist <dthornton@vmware.com>

## Summary
small change needed to get acceptance tests to pass after the `0.17.0` release 

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
Acceptance tests download `macos-arm64` release on macs.

#### After
Acceptance tests download `macos` release on macs.

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No
