### PR TITLE
Update buildpack register example

### DIFF
--- a/internal/commands/buildpack_register.go
+++ b/internal/commands/buildpack_register.go
@@ -21,7 +21,7 @@ func BuildpackRegister(logger logging.Logger, cfg config.Config, client PackClie
 		Use:     "register <image>",
 		Args:    cobra.ExactArgs(1),
 		Short:   "Register a buildpack to a registry",
-		Example: "pack register my-buildpack",
+		Example: "pack buildpack register my-buildpack",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			registry, err := config.GetRegistry(cfg, flags.BuildpackRegistry)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
```
 $  pack help buildpack register
(experimental) Register a buildpack to a registry

Usage:
  pack buildpack register <image> [flags]

Examples:
pack register my-buildpack
```

#### After
```
$  go run cmd/pack/main.go help buildpack register
Register a buildpack to a registry

Usage:
  pack buildpack register <image> [flags]

Examples:
pack buildpack register my-buildpack
```
## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1060