### PR TITLE
Download correct acceptance files for developers on mac arm64

### DIFF
--- a/acceptance/os/variables_darwin.go
+++ b/acceptance/os/variables_darwin.go
@@ -1,5 +1,5 @@
 // +build acceptance
-// +build darwin
+// +build darwin,amd64
 
 package os
 

--- a/acceptance/os/variables_darwin_arm64.go
+++ b/acceptance/os/variables_darwin_arm64.go
@@ -1,0 +1,8 @@
+// +build acceptance
+// +build darwin,arm64
+
+package os
+
+import "regexp"
+
+var PackBinaryExp = regexp.MustCompile(`pack-v\d+.\d+.\d+-macos-`)


### PR DESCRIPTION
Signed-off-by: David Freilich <dfreilich@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->
In #1058 , we restricted acceptance tests to run on traditional mac architectures (or, at the least, don't explicitly support the fact that mac has multiple architectures). This PR adds in a separate file for Mac M1 chips for acceptance tests, to enable native development and speed up the run time for new contributors. 
