### PR TITLE
Set correct sha256 value for Mac M1 homebrew formula

### DIFF
--- a/.github/workflows/delivery-homebrew.yml
+++ b/.github/workflows/delivery-homebrew.yml
@@ -72,7 +72,7 @@ jobs:
 
           curl -sSL ${{ steps.assets.outputs.macos_arm64_url }} -o ${{ steps.assets.outputs.macos_arm64_name }}
           macos_arm64_sha256=$(sha256sum ${{ steps.assets.outputs.macos_arm64_name }} | cut -d ' ' -f1)
-          echo "::set-output name=macos_arm64_sha256::macos_arm64_sha256"
+          echo "::set-output name=macos_arm64_sha256::$macos_arm64_sha256"
       - name: Fill pack.rb
         uses: cschleiden/replace-tokens@v1
         with:


### PR DESCRIPTION
Signed-off-by: dwillist <dthornton@vmware.com>

## Summary
Fixes incorrect `sha256` being placed in our homebrew formula as seen here
buildpacks/homebrew-tap#16

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
we put `macos_arm64_sha256` in the tap instead of the `sha256` value.

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

Could not find a good way to test this even using `act` because we perform an "asset lookup" [in this workflow](https://github.com/buildpacks/pack/blob/3d0fd52e2d9230538f84f3d463fd2ea8dd90575c/.github/workflows/delivery-homebrew.yml#L26).