### PR TITLE
Clean acceptance tests of old exclusions

### DIFF
--- a/acceptance/buildpacks/package_file_buildpack.go
+++ b/acceptance/buildpacks/package_file_buildpack.go
@@ -76,13 +76,7 @@ func (p PackageFile) Prepare(sourceDir, _ string) error {
 		"--format", "file",
 	}
 
-	var output string
-	if p.pack.Supports("buildpack package") {
-		output = p.pack.RunSuccessfully("buildpack", append([]string{"package"}, packArgs...)...)
-	} else {
-		output = p.pack.RunSuccessfully("package-buildpack", packArgs...)
-	}
-
+	output := p.pack.RunSuccessfully("buildpack", append([]string{"package"}, packArgs...)...)
 	if !strings.Contains(output, fmt.Sprintf("Successfully created package '%s'", p.destination)) {
 		return errors.New("failed to create package")
 	}

--- a/acceptance/buildpacks/package_image_buildpack.go
+++ b/acceptance/buildpacks/package_image_buildpack.go
@@ -83,13 +83,7 @@ func (p PackageImage) Prepare(sourceDir, _ string) error {
 		packArgs = append(packArgs, "--publish")
 	}
 
-	var output string
-	if p.pack.Supports("buildpack package") {
-		output = p.pack.RunSuccessfully("buildpack", append([]string{"package"}, packArgs...)...)
-	} else {
-		output = p.pack.RunSuccessfully("package-buildpack", packArgs...)
-	}
-
+	output := p.pack.RunSuccessfully("buildpack", append([]string{"package"}, packArgs...)...)
 	assertOutput := assertions.NewOutputAssertionManager(p.testObject, output)
 	if p.publish {
 		assertOutput.ReportsPackagePublished(p.name)

--- a/acceptance/config/lifecycle_asset.go
+++ b/acceptance/config/lifecycle_asset.go
@@ -174,15 +174,7 @@ func (l *LifecycleAsset) JSONOutputForAPIs(baseIndentationWidth int) (
 
 type LifecycleFeature int
 
-const (
-	CreatorInLifecycle LifecycleFeature = iota
-)
-
-var lifecycleFeatureTests = map[LifecycleFeature]func(l *LifecycleAsset) bool{
-	CreatorInLifecycle: func(l *LifecycleAsset) bool {
-		return l.atLeast074()
-	},
-}
+var lifecycleFeatureTests = map[LifecycleFeature]func(l *LifecycleAsset) bool{}
 
 func (l *LifecycleAsset) SupportsFeature(f LifecycleFeature) bool {
 	return lifecycleFeatureTests[f](l)

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -74,7 +74,7 @@ func (i *PackInvoker) cmd(name string, args ...string) *exec.Cmd {
 
 	cmdArgs := append([]string{name}, args...)
 	cmdArgs = append(cmdArgs, "--no-color")
-	if i.verbose && i.Supports("--verbose") {
+	if i.verbose {
 		cmdArgs = append(cmdArgs, "--verbose")
 	}
 
@@ -173,16 +173,7 @@ func (i *PackInvoker) Version() string {
 func (i *PackInvoker) EnableExperimental() {
 	i.testObject.Helper()
 
-	if i.Supports("config experimental") {
-		i.JustRunSuccessfully("config", "experimental", "true")
-	} else {
-		err := ioutil.WriteFile(
-			filepath.Join(i.home, "config.toml"),
-			[]byte("experimental=true"),
-			os.ModePerm,
-		)
-		i.assert.Nil(err)
-	}
+	i.JustRunSuccessfully("config", "experimental", "true")
 }
 
 // supports returns whether or not the executor's pack binary supports a
@@ -211,51 +202,7 @@ func (i *PackInvoker) Supports(command string) bool {
 
 type Feature int
 
-const (
-	BuilderTomlValidation Feature = iota
-	ExcludeAndIncludeDescriptor
-	FixedExcludeAndIncludeDescriptor
-	DescriptorWithBuildpacks
-	CreatorInPack
-	ReadWriteVolumeMounts
-	NoColorInBuildpacks
-	QuietMode
-	InspectBuilderOutputFormat
-	OSInPackageTOML
-)
-
-var featureTests = map[Feature]func(i *PackInvoker) bool{
-	BuilderTomlValidation: func(i *PackInvoker) bool {
-		return i.laterThan("0.9.0")
-	},
-	ExcludeAndIncludeDescriptor: func(i *PackInvoker) bool {
-		return i.laterThan("0.9.0")
-	},
-	FixedExcludeAndIncludeDescriptor: func(i *PackInvoker) bool {
-		return i.laterThan("0.16.0")
-	},
-	DescriptorWithBuildpacks: func(i *PackInvoker) bool {
-		return i.laterThan("0.16.0")
-	},
-	CreatorInPack: func(i *PackInvoker) bool {
-		return i.atLeast("0.10.0")
-	},
-	ReadWriteVolumeMounts: func(i *PackInvoker) bool {
-		return i.laterThan("0.12.0")
-	},
-	NoColorInBuildpacks: func(i *PackInvoker) bool {
-		return i.atLeast("0.12.0")
-	},
-	QuietMode: func(i *PackInvoker) bool {
-		return i.atLeast("0.13.2")
-	},
-	InspectBuilderOutputFormat: func(i *PackInvoker) bool {
-		return i.laterThan("0.14.2")
-	},
-	OSInPackageTOML: func(i *PackInvoker) bool {
-		return i.laterThan("0.15.0")
-	},
-}
+var featureTests = map[Feature]func(i *PackInvoker) bool{}
 
 func (i *PackInvoker) SupportsFeature(f Feature) bool {
 	return featureTests[f](i)


### PR DESCRIPTION
Our acceptance tests include a mechanism for skipping tests unless pack or the lifecycle supports a given feature. All of our skips were outdated, given that we only test pack against main and the latest release. This PR removes all outdated skips, to make our acceptance tests and support status clearer.
