### PR TITLE
Remove explicitly tested strings from acceptance tests

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -373,7 +373,8 @@ func testWithoutSpecificBuilderRequirement(
 					)
 
 					assert.NotNil(err)
-					assert.Contains(output, "reading config")
+					assertOutput := assertions.NewOutputAssertionManager(t, output)
+					assertOutput.ReportsReadingConfig()
 				})
 			})
 		})
@@ -499,15 +500,13 @@ func testWithoutSpecificBuilderRequirement(
 				assertOutput.IncludesHerokuBuilders()
 				assertOutput.IncludesGoogleBuilder()
 				assertOutput.IncludesPaketoBuilders()
-				assert.NotContains(output, "has been deprecated")
 			})
 
 			when("add", func() {
 				it("sets the builder as trusted in ~/.pack/config.toml", func() {
 					builderName := "some-builder" + h.RandString(10)
 
-					output := pack.RunSuccessfully("config", "trusted-builders", "add", builderName)
-					assert.NotContains(output, "has been deprecated")
+					pack.JustRunSuccessfully("config", "trusted-builders", "add", builderName)
 					assert.Contains(pack.ConfigFileContents(), builderName)
 				})
 			})
@@ -520,8 +519,7 @@ func testWithoutSpecificBuilderRequirement(
 
 					assert.Contains(pack.ConfigFileContents(), builderName)
 
-					output := pack.RunSuccessfully("config", "trusted-builders", "remove", builderName)
-					assert.NotContains(output, "has been deprecated")
+					pack.JustRunSuccessfully("config", "trusted-builders", "remove", builderName)
 
 					assert.NotContains(pack.ConfigFileContents(), builderName)
 				})
@@ -536,7 +534,6 @@ func testWithoutSpecificBuilderRequirement(
 					assertOutput.IncludesHerokuBuilders()
 					assertOutput.IncludesGoogleBuilder()
 					assertOutput.IncludesPaketoBuilders()
-					assert.NotContains(output, "has been deprecated")
 				})
 
 				it("shows a builder trusted by pack config trusted-builders add", func() {
@@ -703,7 +700,8 @@ func testAcceptance(
 					)
 
 					assert.NotNil(err)
-					assert.Contains(output, "invalid builder toml")
+					assertOutput := assertions.NewOutputAssertionManager(t, output)
+					assertOutput.ReportsInvalidBuilderToml()
 				})
 			})
 
@@ -2008,14 +2006,15 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 							return h.DockerRmi(dockerCli, value)
 						})
 						builderName = value
+
+						output := pack.RunSuccessfully(
+							"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
+						assertOutput := assertions.NewOutputAssertionManager(t, output)
+						assertOutput.ReportsSuccesfulRunImageMirrorsAdd("pack-test/run", "some-registry.com/pack-test/run1")
 					})
 
 					it("displays nested Detection Order groups", func() {
-						output := pack.RunSuccessfully(
-							"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
-						assert.Equal(output, "Run Image 'pack-test/run' configured with mirror 'some-registry.com/pack-test/run1'\n")
-
-						output = pack.RunSuccessfully("inspect-builder", builderName)
+						output := pack.RunSuccessfully("inspect-builder", builderName)
 
 						deprecatedBuildpackAPIs,
 							supportedBuildpackAPIs,
@@ -2047,12 +2046,8 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 					})
 
 					it("provides nested detection output up to depth", func() {
-						output := pack.RunSuccessfully(
-							"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
-						assert.Equal(output, "Run Image 'pack-test/run' configured with mirror 'some-registry.com/pack-test/run1'\n")
-
 						depth := "1"
-						output = pack.RunSuccessfully("inspect-builder", "--depth", depth, builderName)
+						output := pack.RunSuccessfully("inspect-builder", "--depth", depth, builderName)
 
 						deprecatedBuildpackAPIs,
 							supportedBuildpackAPIs,
@@ -2085,12 +2080,7 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 
 					when("output format is toml", func() {
 						it("prints builder information in toml format", func() {
-							output := pack.RunSuccessfully(
-								"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
-
-							assert.Equal(output, "Run Image 'pack-test/run' configured with mirror 'some-registry.com/pack-test/run1'\n")
-
-							output = pack.RunSuccessfully("inspect-builder", builderName, "--output", "toml")
+							output := pack.RunSuccessfully("inspect-builder", builderName, "--output", "toml")
 
 							err := toml.NewDecoder(strings.NewReader(string(output))).Decode(&struct{}{})
 							assert.Nil(err)
@@ -2122,12 +2112,7 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 
 					when("output format is yaml", func() {
 						it("prints builder information in yaml format", func() {
-							output := pack.RunSuccessfully(
-								"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
-
-							assert.Equal(output, "Run Image 'pack-test/run' configured with mirror 'some-registry.com/pack-test/run1'\n")
-
-							output = pack.RunSuccessfully("inspect-builder", builderName, "--output", "yaml")
+							output := pack.RunSuccessfully("inspect-builder", builderName, "--output", "yaml")
 
 							err := yaml.Unmarshal([]byte(output), &struct{}{})
 							assert.Nil(err)
@@ -2159,12 +2144,7 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 
 					when("output format is json", func() {
 						it("prints builder information in json format", func() {
-							output := pack.RunSuccessfully(
-								"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1")
-
-							assert.Equal(output, "Run Image 'pack-test/run' configured with mirror 'some-registry.com/pack-test/run1'\n")
-
-							output = pack.RunSuccessfully("inspect-builder", builderName, "--output", "json")
+							output := pack.RunSuccessfully("inspect-builder", builderName, "--output", "json")
 
 							err := json.Unmarshal([]byte(output), &struct{}{})
 							assert.Nil(err)
@@ -2203,8 +2183,8 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 					output := pack.RunSuccessfully(
 						"config", "run-image-mirrors", "add", "pack-test/run", "--mirror", "some-registry.com/pack-test/run1",
 					)
-
-					assert.Equal(output, "Run Image 'pack-test/run' configured with mirror 'some-registry.com/pack-test/run1'\n")
+					assertOutput := assertions.NewOutputAssertionManager(t, output)
+					assertOutput.ReportsSuccesfulRunImageMirrorsAdd("pack-test/run", "some-registry.com/pack-test/run1")
 
 					output = pack.RunSuccessfully("inspect-builder", builderName)
 

--- a/acceptance/assertions/output.go
+++ b/acceptance/assertions/output.go
@@ -218,3 +218,21 @@ func (o OutputAssertionManager) IncludesDeprecationWarning() {
 
 	o.assert.Matches(o.output, regexp.MustCompile(fmt.Sprintf(`Warning: Command 'pack [\w-]+' has been deprecated, please use 'pack [\w-\s]+' instead`)))
 }
+
+func (o OutputAssertionManager) ReportsSuccesfulRunImageMirrorsAdd(image, mirror string) {
+	o.testObject.Helper()
+
+	o.assert.ContainsF(o.output, "Run Image '%s' configured with mirror '%s'\n", image, mirror)
+}
+
+func (o OutputAssertionManager) ReportsReadingConfig() {
+	o.testObject.Helper()
+
+	o.assert.Contains(o.output, "reading config")
+}
+
+func (o OutputAssertionManager) ReportsInvalidBuilderToml() {
+	o.testObject.Helper()
+
+	o.assert.Contains(o.output, "invalid builder toml")
+}


### PR DESCRIPTION
* Our current practice is to abstract out from testing explicit strings in our acceptance tests, instead moving those string assertions to a dedicated assertion manager
* Remove unnecessary non-deprecated string assertions for trusted-builders
* Move redundant config run-image-mirrors call to a before block
## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Takes advantage of work done in https://github.com/buildpacks/pack/pull/673
