### PR TITLE
Dont calculate buildpack layer diffIDs twice when creating a builder

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -306,17 +306,17 @@ func (b *Builder) Save(logger logging.Logger, creatorMetadata CreatorMetadata) e
 			return err
 		}
 
-		if err := b.image.AddLayer(bpLayerTar); err != nil {
-			return errors.Wrapf(err,
-				"adding layer tar for buildpack %s",
-				style.Symbol(bp.Descriptor().Info.FullName()),
-			)
-		}
-
 		diffID, err := dist.LayerDiffID(bpLayerTar)
 		if err != nil {
 			return errors.Wrapf(err,
 				"getting content hashes for buildpack %s",
+				style.Symbol(bp.Descriptor().Info.FullName()),
+			)
+		}
+
+		if err := b.image.AddLayerWithDiffID(bpLayerTar, diffID.String()); err != nil {
+			return errors.Wrapf(err,
+				"adding layer tar for buildpack %s",
 				style.Symbol(bp.Descriptor().Info.FullName()),
 			)
 		}


### PR DESCRIPTION
Signed-off-by: Emily Casey <ecasey@vmware.com>

## Summary
Provides the buildpack layer diffIDs to `imgutil` so `imgutil` can avoid recalculating them.

Builder creation without `--publish` is annoyingly slow for a large builder. This only saves a couple seconds for the largest paketo builder. Other performance improvements would be more impactful such as:
* Not calculating the layer diffID at all when we know it (e.g. when we are pulling a buildpack from a buildpackage)
* https://github.com/buildpacks/pack/issues/866

But I thought I would contribute this after noticing it because it is a trivial change the preserve the existing behavior.

## Output

#### Before
Using https://github.com/paketo-buildpacks/full-builder:

```
> time pack builder create bldr/full -c ./builder.toml --pull-policy=never
pack builder create bldr/full -c ./builder.toml --pull-policy=never  11.32s user 5.38s system 45% cpu 36.312 total
```

#### After
```
> time pack builder create bldr/full -c ./builder.toml --pull-policy=never
pack builder create bldr/full -c ./builder.toml --pull-policy=never 9.71s user 4.84s system 40% cpu 36.326 total
```

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No
