### PR TITLE
Redact all user provided strings from pack report

### DIFF
--- a/internal/commands/report.go
+++ b/internal/commands/report.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"regexp"
 	"runtime"
 	"strings"
 	"text/template"
@@ -82,8 +83,19 @@ Config:
 }
 
 func sanitize(line string) string {
-	if strings.HasPrefix(line, "default-builder-image") {
-		return `default-builder-image = "[REDACTED]"`
+	re := regexp.MustCompile(`"(.*?)"`)
+	redactedString := `"[REDACTED]"`
+	sensitiveFields := []string{
+		"default-builder-image",
+		"image",
+		"mirrors",
+		"name",
+		"url",
+	}
+	for _, field := range sensitiveFields {
+		if strings.HasPrefix(strings.TrimSpace(line), field) {
+			return re.ReplaceAllString(line, redactedString)
+		}
 	}
 
 	return line


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>

## Summary
<!-- Provide a high-level summary of the change. -->
This PR updates `park report` to sanitize all user strings and redact private values.

## Output
<!-- If applicable, please provide examples of the output changes. -->


#### Before
```
pack report
Pack:
  Version:  0.17.0
  OS/Arch:  linux/amd64

Default Lifecycle Version:  0.10.2

Supported Platform APIs:  0.3, 0.4

Config:
  default-builder-image = "[REDACTED]"
  experimental = true
  
  [[run-images]]
    image = "super-secret-project/run"
    mirrors = ["gcr.io/super-secret-project/run", "secret.io/super-secret-project/run"]
  
  [[trusted-builders]]
    name = "super-secret-project/builder"
  
  [[registries]]
    name = "secret-registry"
    type = "github"
    url = "https://github.com/super-secret-project/registry"
```

#### After

```
$ pack report
Pack:
  Version:  0.0.0+git-fda5858
  OS/Arch:  linux/amd64

Default Lifecycle Version:  0.10.2

Supported Platform APIs:  0.3, 0.4

Config:
  default-builder-image = "[REDACTED]"
  experimental = true
  
  [[run-images]]
    image = "[REDACTED]"
    mirrors = ["[REDACTED]", "[REDACTED]"]
  
  [[trusted-builders]]
    name = "[REDACTED]"
  
  [[registries]]
    name = "[REDACTED]"
    type = "github"
    url = "[REDACTED]"
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1032 
