### PR TITLE
Add buildpack homepages to inspect-image output

### DIFF
--- a/acceptance/testdata/pack_fixtures/inspect_builder_nested_depth_2_output.txt
+++ b/acceptance/testdata/pack_fixtures/inspect_builder_nested_depth_2_output.txt
@@ -33,11 +33,11 @@ Run Images:
 Buildpacks:
   ID                           VERSION                             HOMEPAGE
   noop.buildpack               noop.buildpack.later-version        http://geocities.com/cool-bp
-  noop.buildpack               noop.buildpack.version
-  read/env                     read-env-version
-  simple/layers                simple-layers-version
-  simple/nested-level-1        nested-l1-version
-  simple/nested-level-2        nested-l2-version
+  noop.buildpack               noop.buildpack.version              -
+  read/env                     read-env-version                    -
+  simple/layers                simple-layers-version               -
+  simple/nested-level-1        nested-l1-version                   -
+  simple/nested-level-2        nested-l2-version                   -
 
 Detection Order:
  └ Group #1:
@@ -79,11 +79,11 @@ Run Images:
 Buildpacks:
   ID                           VERSION                             HOMEPAGE
   noop.buildpack               noop.buildpack.later-version        http://geocities.com/cool-bp
-  noop.buildpack               noop.buildpack.version
-  read/env                     read-env-version
-  simple/layers                simple-layers-version
-  simple/nested-level-1        nested-l1-version
-  simple/nested-level-2        nested-l2-version
+  noop.buildpack               noop.buildpack.version              -
+  read/env                     read-env-version                    -
+  simple/layers                simple-layers-version               -
+  simple/nested-level-1        nested-l1-version                   -
+  simple/nested-level-2        nested-l2-version                   -
 
 Detection Order:
  └ Group #1:

--- a/acceptance/testdata/pack_fixtures/inspect_builder_nested_output.txt
+++ b/acceptance/testdata/pack_fixtures/inspect_builder_nested_output.txt
@@ -33,11 +33,11 @@ Run Images:
 Buildpacks:
   ID                           VERSION                             HOMEPAGE
   noop.buildpack               noop.buildpack.later-version        http://geocities.com/cool-bp
-  noop.buildpack               noop.buildpack.version
-  read/env                     read-env-version
-  simple/layers                simple-layers-version
-  simple/nested-level-1        nested-l1-version
-  simple/nested-level-2        nested-l2-version
+  noop.buildpack               noop.buildpack.version              -
+  read/env                     read-env-version                    -
+  simple/layers                simple-layers-version               -
+  simple/nested-level-1        nested-l1-version                   -
+  simple/nested-level-2        nested-l2-version                   -
 
 Detection Order:
  └ Group #1:
@@ -81,11 +81,11 @@ Run Images:
 Buildpacks:
   ID                           VERSION                             HOMEPAGE
   noop.buildpack               noop.buildpack.later-version        http://geocities.com/cool-bp
-  noop.buildpack               noop.buildpack.version
-  read/env                     read-env-version
-  simple/layers                simple-layers-version
-  simple/nested-level-1        nested-l1-version
-  simple/nested-level-2        nested-l2-version
+  noop.buildpack               noop.buildpack.version              -
+  read/env                     read-env-version                    -
+  simple/layers                simple-layers-version               -
+  simple/nested-level-1        nested-l1-version                   -
+  simple/nested-level-2        nested-l2-version                   -
 
 Detection Order:
  └ Group #1:

--- a/acceptance/testdata/pack_fixtures/inspect_builder_output.txt
+++ b/acceptance/testdata/pack_fixtures/inspect_builder_output.txt
@@ -33,9 +33,9 @@ Run Images:
 Buildpacks:
   ID                    VERSION                             HOMEPAGE
   noop.buildpack        noop.buildpack.later-version        http://geocities.com/cool-bp
-  noop.buildpack        noop.buildpack.version
-  read/env              read-env-version
-  simple/layers         simple-layers-version
+  noop.buildpack        noop.buildpack.version              -
+  read/env              read-env-version                    -
+  simple/layers         simple-layers-version               -
 
 Detection Order:
  └ Group #1:
@@ -75,9 +75,9 @@ Run Images:
 Buildpacks:
   ID                    VERSION                             HOMEPAGE
   noop.buildpack        noop.buildpack.later-version        http://geocities.com/cool-bp
-  noop.buildpack        noop.buildpack.version
-  read/env              read-env-version
-  simple/layers         simple-layers-version
+  noop.buildpack        noop.buildpack.version              -
+  read/env              read-env-version                    -
+  simple/layers         simple-layers-version               -
 
 Detection Order:
  └ Group #1:

--- a/acceptance/testdata/pack_fixtures/inspect_buildpack_output.txt
+++ b/acceptance/testdata/pack_fixtures/inspect_buildpack_output.txt
@@ -9,8 +9,8 @@ Stacks:
 
 Buildpacks:
   ID                          VERSION                             HOMEPAGE
-  simple/layers               simple-layers-version
-  simple/layers/parent        simple-layers-parent-version
+  simple/layers               simple-layers-version               -
+  simple/layers/parent        simple-layers-parent-version        -
 
 Detection Order:
  └ Group #1:

--- a/acceptance/testdata/pack_fixtures/inspect_image_local_output.txt
+++ b/acceptance/testdata/pack_fixtures/inspect_image_local_output.txt
@@ -17,7 +17,7 @@ Run Images:
   {{.run_image_mirror}}
 
 Buildpacks:
-  ID                   VERSION
+  ID                   VERSION                      HOMEPAGE
   simple/layers        simple-layers-version
 
 Processes:

--- a/acceptance/testdata/pack_fixtures/inspect_image_local_output.txt
+++ b/acceptance/testdata/pack_fixtures/inspect_image_local_output.txt
@@ -18,7 +18,7 @@ Run Images:
 
 Buildpacks:
   ID                   VERSION                      HOMEPAGE
-  simple/layers        simple-layers-version
+  simple/layers        simple-layers-version        -
 
 Processes:
   TYPE                 SHELL        COMMAND        ARGS

--- a/acceptance/testdata/pack_fixtures/inspect_image_published_output.txt
+++ b/acceptance/testdata/pack_fixtures/inspect_image_published_output.txt
@@ -14,7 +14,7 @@ Run Images:
 
 Buildpacks:
   ID                   VERSION                      HOMEPAGE
-  simple/layers        simple-layers-version
+  simple/layers        simple-layers-version        -
 
 Processes:
   TYPE                 SHELL        COMMAND        ARGS

--- a/acceptance/testdata/pack_fixtures/inspect_image_published_output.txt
+++ b/acceptance/testdata/pack_fixtures/inspect_image_published_output.txt
@@ -13,7 +13,7 @@ Run Images:
   {{.run_image_mirror}}
 
 Buildpacks:
-  ID                   VERSION
+  ID                   VERSION                      HOMEPAGE
   simple/layers        simple-layers-version
 
 Processes:

--- a/internal/builder/writer/human_readable.go
+++ b/internal/builder/writer/human_readable.go
@@ -8,6 +8,8 @@ import (
 	"text/tabwriter"
 	"text/template"
 
+	strs "github.com/buildpacks/pack/internal/strings"
+
 	"github.com/buildpacks/pack/internal/style"
 
 	"github.com/buildpacks/pack/internal/dist"
@@ -289,12 +291,6 @@ func buildpacksOutput(buildpacks []dist.BuildpackInfo, builderName string) (stri
 			output: &tabWriterBuf,
 		}
 		buildpacksTabWriter = tabwriter.NewWriter(spaceStrippingWriter, writerMinWidth, writerPadChar, buildpacksTabWidth, writerPadChar, writerFlags)
-		dashOrValue         = func(str string) string {
-			if str == "" {
-				return "-"
-			}
-			return str
-		}
 	)
 
 	_, err := fmt.Fprint(buildpacksTabWriter, "  ID\tVERSION\tHOMEPAGE\n")
@@ -303,7 +299,7 @@ func buildpacksOutput(buildpacks []dist.BuildpackInfo, builderName string) (stri
 	}
 
 	for _, b := range buildpacks {
-		_, err = fmt.Fprintf(buildpacksTabWriter, "  %s\t%s\t%s\n", b.ID, b.Version, dashOrValue(b.Homepage))
+		_, err = fmt.Fprintf(buildpacksTabWriter, "  %s\t%s\t%s\n", b.ID, b.Version, strs.ValueOrDefault(b.Homepage, "-"))
 		if err != nil {
 			return "", []string{}, fmt.Errorf("writing to tab writer: %w", err)
 		}

--- a/internal/builder/writer/human_readable.go
+++ b/internal/builder/writer/human_readable.go
@@ -283,29 +283,38 @@ func buildpacksOutput(buildpacks []dist.BuildpackInfo, builderName string) (stri
 		return fmt.Sprintf("%s  %s\n", output, none), warnings, nil
 	}
 
-	tabWriterBuf := bytes.Buffer{}
-	spaceStrippingWriter := &trailingSpaceStrippingWriter{
-		output: &tabWriterBuf,
-	}
+	var (
+		tabWriterBuf         = bytes.Buffer{}
+		spaceStrippingWriter = &trailingSpaceStrippingWriter{
+			output: &tabWriterBuf,
+		}
+		buildpacksTabWriter = tabwriter.NewWriter(spaceStrippingWriter, writerMinWidth, writerPadChar, buildpacksTabWidth, writerPadChar, writerFlags)
+		dashOrValue         = func(str string) string {
+			if str == "" {
+				return "-"
+			}
+			return str
+		}
+	)
 
-	buildpacksTabWriter := tabwriter.NewWriter(spaceStrippingWriter, writerMinWidth, writerPadChar, buildpacksTabWidth, writerPadChar, writerFlags)
 	_, err := fmt.Fprint(buildpacksTabWriter, "  ID\tVERSION\tHOMEPAGE\n")
 	if err != nil {
 		return "", []string{}, fmt.Errorf("writing to tab writer: %w", err)
 	}
+
 	for _, b := range buildpacks {
-		_, err = fmt.Fprintf(buildpacksTabWriter, "  %s\t%s\t%s\n", b.ID, b.Version, b.Homepage)
+		_, err = fmt.Fprintf(buildpacksTabWriter, "  %s\t%s\t%s\n", b.ID, b.Version, dashOrValue(b.Homepage))
 		if err != nil {
 			return "", []string{}, fmt.Errorf("writing to tab writer: %w", err)
 		}
 	}
+
 	err = buildpacksTabWriter.Flush()
 	if err != nil {
 		return "", []string{}, fmt.Errorf("flushing tab writer: %w", err)
 	}
 
 	output += tabWriterBuf.String()
-
 	return output, []string{}, nil
 }
 

--- a/internal/builder/writer/human_readable_test.go
+++ b/internal/builder/writer/human_readable_test.go
@@ -68,11 +68,11 @@ Run Images:
 
 Buildpacks:
   ID                     VERSION                        HOMEPAGE
-  test.top.nested        test.top.nested.version
+  test.top.nested        test.top.nested.version        -
   test.nested                                           http://geocities.com/top-bp
   test.bp.one            test.bp.one.version            http://geocities.com/cool-bp
-  test.bp.two            test.bp.two.version
-  test.bp.three          test.bp.three.version
+  test.bp.two            test.bp.two.version            -
+  test.bp.three          test.bp.three.version          -
 
 Detection Order:
  ├ Group #1:
@@ -121,11 +121,11 @@ Run Images:
 
 Buildpacks:
   ID                     VERSION                        HOMEPAGE
-  test.top.nested        test.top.nested.version
+  test.top.nested        test.top.nested.version        -
   test.nested                                           http://geocities.com/top-bp
   test.bp.one            test.bp.one.version            http://geocities.com/cool-bp
-  test.bp.two            test.bp.two.version
-  test.bp.three          test.bp.three.version
+  test.bp.two            test.bp.two.version            -
+  test.bp.three          test.bp.three.version          -
 
 Detection Order:
  ├ Group #1:

--- a/internal/commands/buildpack_inspect_test.go
+++ b/internal/commands/buildpack_inspect_test.go
@@ -71,8 +71,9 @@ const simpleOutputSection = `Stacks:
       (omitted)
 
 Buildpacks:
-  ID                           VERSION        HOMEPAGE
-  some/single-buildpack        0.0.1          single-buildpack-homepage
+  ID                                VERSION        HOMEPAGE
+  some/single-buildpack             0.0.1          single-buildpack-homepage
+  some/buildpack-no-homepage        0.0.2          -
 
 Detection Order:
  └ Group #1:
@@ -311,6 +312,10 @@ func testBuildpackInspectCommand(t *testing.T, when spec.G, it spec.S) {
 					ID:       "some/single-buildpack",
 					Version:  "0.0.1",
 					Homepage: "single-buildpack-homepage",
+				},
+				{
+					ID:      "some/buildpack-no-homepage",
+					Version: "0.0.2",
 				},
 			},
 			Order: dist.Order{

--- a/internal/commands/inspect_buildpack.go
+++ b/internal/commands/inspect_buildpack.go
@@ -8,6 +8,8 @@ import (
 	"text/tabwriter"
 	"text/template"
 
+	strs "github.com/buildpacks/pack/internal/strings"
+
 	"github.com/buildpacks/pack/internal/dist"
 
 	"github.com/pkg/errors"
@@ -177,15 +179,7 @@ func determinePrefix(name string, locator buildpack.LocatorType, daemon bool) st
 }
 
 func buildpacksOutput(bps []dist.BuildpackInfo) (string, error) {
-	var (
-		buf         = &bytes.Buffer{}
-		dashOrValue = func(str string) string {
-			if str == "" {
-				return "-"
-			}
-			return str
-		}
-	)
+	buf := &bytes.Buffer{}
 
 	tabWriter := new(tabwriter.Writer).Init(buf, writerMinWidth, writerPadChar, buildpacksTabWidth, writerPadChar, writerFlags)
 	if _, err := fmt.Fprint(tabWriter, "  ID\tVERSION\tHOMEPAGE\n"); err != nil {
@@ -193,7 +187,7 @@ func buildpacksOutput(bps []dist.BuildpackInfo) (string, error) {
 	}
 
 	for _, bp := range bps {
-		if _, err := fmt.Fprintf(tabWriter, "  %s\t%s\t%s\n", bp.ID, bp.Version, dashOrValue(bp.Homepage)); err != nil {
+		if _, err := fmt.Fprintf(tabWriter, "  %s\t%s\t%s\n", bp.ID, bp.Version, strs.ValueOrDefault(bp.Homepage, "-")); err != nil {
 			return "", err
 		}
 	}

--- a/internal/commands/inspect_buildpack.go
+++ b/internal/commands/inspect_buildpack.go
@@ -177,14 +177,23 @@ func determinePrefix(name string, locator buildpack.LocatorType, daemon bool) st
 }
 
 func buildpacksOutput(bps []dist.BuildpackInfo) (string, error) {
-	buf := &bytes.Buffer{}
+	var (
+		buf         = &bytes.Buffer{}
+		dashOrValue = func(str string) string {
+			if str == "" {
+				return "-"
+			}
+			return str
+		}
+	)
+
 	tabWriter := new(tabwriter.Writer).Init(buf, writerMinWidth, writerPadChar, buildpacksTabWidth, writerPadChar, writerFlags)
 	if _, err := fmt.Fprint(tabWriter, "  ID\tVERSION\tHOMEPAGE\n"); err != nil {
 		return "", err
 	}
 
 	for _, bp := range bps {
-		if _, err := fmt.Fprintf(tabWriter, "  %s\t%s\t%s\n", bp.ID, bp.Version, bp.Homepage); err != nil {
+		if _, err := fmt.Fprintf(tabWriter, "  %s\t%s\t%s\n", bp.ID, bp.Version, dashOrValue(bp.Homepage)); err != nil {
 			return "", err
 		}
 	}

--- a/internal/commands/inspect_buildpack_test.go
+++ b/internal/commands/inspect_buildpack_test.go
@@ -233,6 +233,10 @@ func testInspectBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 					Version:  "0.0.1",
 					Homepage: "single-buildpack-homepage",
 				},
+				{
+					ID:      "some/buildpack-no-homepage",
+					Version: "0.0.2",
+				},
 			},
 			Order: dist.Order{
 				{
@@ -266,7 +270,7 @@ func testInspectBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 		command = commands.InspectBuildpack(logger, cfg, mockClient)
 	})
 
-	when("InpectBuildpack", func() {
+	when("InspectBuildpack", func() {
 		when("inspecting an image", func() {
 			when("both remote and local image are present", func() {
 				it.Before(func() {

--- a/internal/inspectimage/bom_display.go
+++ b/internal/inspectimage/bom_display.go
@@ -38,9 +38,8 @@ func displayBOM(bom []lifecycle.BOMEntry) []BOMEntryDisplay {
 
 			Buildpack: dist.BuildpackRef{
 				BuildpackInfo: dist.BuildpackInfo{
-					ID:       entry.Buildpack.ID,
-					Version:  entry.Buildpack.Version,
-					Homepage: entry.Buildpack.Homepage,
+					ID:      entry.Buildpack.ID,
+					Version: entry.Buildpack.Version,
 				},
 				Optional: entry.Buildpack.Optional,
 			},

--- a/internal/inspectimage/bom_display.go
+++ b/internal/inspectimage/bom_display.go
@@ -29,7 +29,7 @@ func NewBOMDisplay(info *pack.ImageInfo) []BOMEntryDisplay {
 }
 
 func displayBOM(bom []lifecycle.BOMEntry) []BOMEntryDisplay {
-	result := []BOMEntryDisplay{}
+	var result []BOMEntryDisplay
 	for _, entry := range bom {
 		result = append(result, BOMEntryDisplay{
 			Name:     entry.Name,
@@ -38,8 +38,9 @@ func displayBOM(bom []lifecycle.BOMEntry) []BOMEntryDisplay {
 
 			Buildpack: dist.BuildpackRef{
 				BuildpackInfo: dist.BuildpackInfo{
-					ID:      entry.Buildpack.ID,
-					Version: entry.Buildpack.Version,
+					ID:       entry.Buildpack.ID,
+					Version:  entry.Buildpack.Version,
+					Homepage: entry.Buildpack.Homepage,
 				},
 				Optional: entry.Buildpack.Optional,
 			},

--- a/internal/inspectimage/info_display.go
+++ b/internal/inspectimage/info_display.go
@@ -91,7 +91,7 @@ func displayBase(base lifecycle.RunImageMetadata) BaseDisplay {
 
 func displayMirrors(info *pack.ImageInfo, generalInfo GeneralInfo) []RunImageMirrorDisplay {
 	// add all user configured run images, then add run images provided by info
-	result := []RunImageMirrorDisplay{}
+	var result []RunImageMirrorDisplay
 	if info == nil {
 		return result
 	}
@@ -127,18 +127,19 @@ func displayMirrors(info *pack.ImageInfo, generalInfo GeneralInfo) []RunImageMir
 }
 
 func displayBuildpacks(buildpacks []lifecycle.GroupBuildpack) []dist.BuildpackInfo {
-	result := []dist.BuildpackInfo{}
+	var result []dist.BuildpackInfo
 	for _, buildpack := range buildpacks {
 		result = append(result, dist.BuildpackInfo{
-			ID:      buildpack.ID,
-			Version: buildpack.Version,
+			ID:       buildpack.ID,
+			Version:  buildpack.Version,
+			Homepage: buildpack.Homepage,
 		})
 	}
 	return result
 }
 
 func displayProcesses(details pack.ProcessDetails) []ProcessDisplay {
-	result := []ProcessDisplay{}
+	var result []ProcessDisplay
 	detailsArray := details.OtherProcesses
 	if details.DefaultProcess != nil {
 		result = append(result, convertToDisplay(*details.DefaultProcess, true))

--- a/internal/inspectimage/writer/bom_json_test.go
+++ b/internal/inspectimage/writer/bom_json_test.go
@@ -48,7 +48,8 @@ func testJSONBOM(t *testing.T, when spec.G, it spec.S) {
       },
       "buildpacks": {
         "id": "test.bp.one.remote",
-        "version": "1.0.0"
+        "version": "1.0.0",
+		"homepage": "https://some-homepage"
       }
     }
   ]
@@ -70,7 +71,8 @@ func testJSONBOM(t *testing.T, when spec.G, it spec.S) {
       },
       "buildpacks": {
         "id": "test.bp.one.remote",
-        "version": "1.0.0"
+        "version": "1.0.0",
+		"homepage": "https://some-homepage"
       }
     }
   ]
@@ -106,7 +108,7 @@ func testJSONBOM(t *testing.T, when spec.G, it spec.S) {
 							},
 						},
 					},
-					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0"},
+					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage"},
 				}}}
 
 			localInfo = &pack.ImageInfo{
@@ -121,7 +123,7 @@ func testJSONBOM(t *testing.T, when spec.G, it spec.S) {
 							},
 						},
 					},
-					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0"},
+					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage"},
 				}},
 			}
 

--- a/internal/inspectimage/writer/bom_json_test.go
+++ b/internal/inspectimage/writer/bom_json_test.go
@@ -48,8 +48,7 @@ func testJSONBOM(t *testing.T, when spec.G, it spec.S) {
       },
       "buildpacks": {
         "id": "test.bp.one.remote",
-        "version": "1.0.0",
-		"homepage": "https://some-homepage"
+        "version": "1.0.0"
       }
     }
   ]
@@ -71,8 +70,7 @@ func testJSONBOM(t *testing.T, when spec.G, it spec.S) {
       },
       "buildpacks": {
         "id": "test.bp.one.remote",
-        "version": "1.0.0",
-		"homepage": "https://some-homepage"
+        "version": "1.0.0"
       }
     }
   ]

--- a/internal/inspectimage/writer/bom_yaml_test.go
+++ b/internal/inspectimage/writer/bom_yaml_test.go
@@ -45,7 +45,6 @@ local:
   buildpacks:
     id: test.bp.one.remote
     version: 1.0.0
-    homepage: https://some-homepage
 `
 		expectedRemoteOutput = `---
 remote:
@@ -61,7 +60,6 @@ remote:
   buildpacks:
     id: test.bp.one.remote
     version: 1.0.0
-    homepage: https://some-homepage
 `
 	)
 

--- a/internal/inspectimage/writer/bom_yaml_test.go
+++ b/internal/inspectimage/writer/bom_yaml_test.go
@@ -45,6 +45,7 @@ local:
   buildpacks:
     id: test.bp.one.remote
     version: 1.0.0
+    homepage: https://some-homepage
 `
 		expectedRemoteOutput = `---
 remote:
@@ -60,6 +61,7 @@ remote:
   buildpacks:
     id: test.bp.one.remote
     version: 1.0.0
+    homepage: https://some-homepage
 `
 	)
 
@@ -92,7 +94,7 @@ remote:
 							},
 						},
 					},
-					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0"},
+					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage"},
 				}}}
 
 			localInfo = &pack.ImageInfo{
@@ -107,7 +109,7 @@ remote:
 							},
 						},
 					},
-					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0"},
+					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage"},
 				}},
 			}
 

--- a/internal/inspectimage/writer/human_readable.go
+++ b/internal/inspectimage/writer/human_readable.go
@@ -56,6 +56,7 @@ func writeImageInfo(
 ) error {
 	imgTpl := template.Must(template.New("runImages").
 		Funcs(template.FuncMap{"StringsJoin": strings.Join}).
+		Funcs(template.FuncMap{"DashOrValue": dashOrValue}).
 		Parse(runImagesTemplate))
 	imgTpl = template.Must(imgTpl.New("buildpacks").
 		Parse(buildpacksTemplate))
@@ -79,6 +80,14 @@ func writeImageInfo(
 		logger.Info(remoteOutput.String())
 	}
 	return nil
+}
+
+func dashOrValue(str string) string {
+	if str == "" {
+		return "-"
+	}
+
+	return str
 }
 
 func inspectImageOutput(info *inspectimage.InfoDisplay, tpl *template.Template) (*bytes.Buffer, error) {
@@ -119,7 +128,7 @@ Buildpacks:
 {{- if .Info.Buildpacks }}
   ID	VERSION	HOMEPAGE
 {{- range $_, $b := .Info.Buildpacks }}
-  {{ $b.ID }}	{{ $b.Version }}	{{ $b.Homepage }}
+  {{ $b.ID }}	{{ $b.Version }}	{{ DashOrValue $b.Homepage }}
 {{- end }}
 {{- else }}
   (buildpack metadata not present)

--- a/internal/inspectimage/writer/human_readable.go
+++ b/internal/inspectimage/writer/human_readable.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildpacks/pack/internal/inspectimage"
 
 	"github.com/buildpacks/pack"
+	strs "github.com/buildpacks/pack/internal/strings"
 	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/logging"
 )
@@ -56,7 +57,7 @@ func writeImageInfo(
 ) error {
 	imgTpl := template.Must(template.New("runImages").
 		Funcs(template.FuncMap{"StringsJoin": strings.Join}).
-		Funcs(template.FuncMap{"DashOrValue": dashOrValue}).
+		Funcs(template.FuncMap{"StringsValueOrDefault": strs.ValueOrDefault}).
 		Parse(runImagesTemplate))
 	imgTpl = template.Must(imgTpl.New("buildpacks").
 		Parse(buildpacksTemplate))
@@ -80,14 +81,6 @@ func writeImageInfo(
 		logger.Info(remoteOutput.String())
 	}
 	return nil
-}
-
-func dashOrValue(str string) string {
-	if str == "" {
-		return "-"
-	}
-
-	return str
 }
 
 func inspectImageOutput(info *inspectimage.InfoDisplay, tpl *template.Template) (*bytes.Buffer, error) {
@@ -128,7 +121,7 @@ Buildpacks:
 {{- if .Info.Buildpacks }}
   ID	VERSION	HOMEPAGE
 {{- range $_, $b := .Info.Buildpacks }}
-  {{ $b.ID }}	{{ $b.Version }}	{{ DashOrValue $b.Homepage }}
+  {{ $b.ID }}	{{ $b.Version }}	{{ StringsValueOrDefault $b.Homepage "-" }}
 {{- end }}
 {{- else }}
   (buildpack metadata not present)

--- a/internal/inspectimage/writer/human_readable.go
+++ b/internal/inspectimage/writer/human_readable.go
@@ -117,9 +117,9 @@ Run Images:
 var buildpacksTemplate = `
 Buildpacks:
 {{- if .Info.Buildpacks }}
-  ID	VERSION
+  ID	VERSION	HOMEPAGE
 {{- range $_, $b := .Info.Buildpacks }}
-  {{ $b.ID }}	{{ $b.Version }}
+  {{ $b.ID }}	{{ $b.Version }}	{{ $b.Homepage }}
 {{- end }}
 {{- else }}
   (buildpack metadata not present)

--- a/internal/inspectimage/writer/human_readable_test.go
+++ b/internal/inspectimage/writer/human_readable_test.go
@@ -51,9 +51,10 @@ Run Images:
   other-remote-mirror
 
 Buildpacks:
-  ID                        VERSION        HOMEPAGE
-  test.bp.one.remote        1.0.0          https://some-homepage-one
-  test.bp.two.remote        2.0.0          https://some-homepage-two
+  ID                          VERSION        HOMEPAGE
+  test.bp.one.remote          1.0.0          https://some-homepage-one
+  test.bp.two.remote          2.0.0          https://some-homepage-two
+  test.bp.three.remote        3.0.0          -
 
 Processes:
   TYPE                              SHELL        COMMAND                      ARGS
@@ -75,9 +76,10 @@ Run Images:
   other-local-mirror
 
 Buildpacks:
-  ID                       VERSION        HOMEPAGE
-  test.bp.one.local        1.0.0          https://some-homepage-one
-  test.bp.two.local        2.0.0          https://some-homepage-two
+  ID                         VERSION        HOMEPAGE
+  test.bp.one.local          1.0.0          https://some-homepage-one
+  test.bp.two.local          2.0.0          https://some-homepage-two
+  test.bp.three.local        3.0.0          -
 
 Processes:
   TYPE                             SHELL        COMMAND                     ARGS
@@ -101,6 +103,7 @@ Processes:
 				Buildpacks: []lifecycle.GroupBuildpack{
 					{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
 					{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
+					{ID: "test.bp.three.remote", Version: "3.0.0"},
 				},
 				Base: lifecycle.RunImageMetadata{
 					TopLayer:  "some-remote-top-layer",
@@ -154,6 +157,7 @@ Processes:
 				Buildpacks: []lifecycle.GroupBuildpack{
 					{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
 					{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
+					{ID: "test.bp.three.local", Version: "3.0.0"},
 				},
 				Base: lifecycle.RunImageMetadata{
 					TopLayer:  "some-local-top-layer",

--- a/internal/inspectimage/writer/human_readable_test.go
+++ b/internal/inspectimage/writer/human_readable_test.go
@@ -51,9 +51,9 @@ Run Images:
   other-remote-mirror
 
 Buildpacks:
-  ID                        VERSION
-  test.bp.one.remote        1.0.0
-  test.bp.two.remote        2.0.0
+  ID                        VERSION        HOMEPAGE
+  test.bp.one.remote        1.0.0          https://some-homepage-one
+  test.bp.two.remote        2.0.0          https://some-homepage-two
 
 Processes:
   TYPE                              SHELL        COMMAND                      ARGS
@@ -75,9 +75,9 @@ Run Images:
   other-local-mirror
 
 Buildpacks:
-  ID                       VERSION
-  test.bp.one.local        1.0.0
-  test.bp.two.local        2.0.0
+  ID                       VERSION        HOMEPAGE
+  test.bp.one.local        1.0.0          https://some-homepage-one
+  test.bp.two.local        2.0.0          https://some-homepage-two
 
 Processes:
   TYPE                             SHELL        COMMAND                     ARGS
@@ -99,8 +99,8 @@ Processes:
 			remoteInfo = &pack.ImageInfo{
 				StackID: "test.stack.id.remote",
 				Buildpacks: []lifecycle.GroupBuildpack{
-					{ID: "test.bp.one.remote", Version: "1.0.0"},
-					{ID: "test.bp.two.remote", Version: "2.0.0"},
+					{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
 				},
 				Base: lifecycle.RunImageMetadata{
 					TopLayer:  "some-remote-top-layer",
@@ -152,8 +152,8 @@ Processes:
 			localInfo = &pack.ImageInfo{
 				StackID: "test.stack.id.local",
 				Buildpacks: []lifecycle.GroupBuildpack{
-					{ID: "test.bp.one.local", Version: "1.0.0"},
-					{ID: "test.bp.two.local", Version: "2.0.0"},
+					{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
 				},
 				Base: lifecycle.RunImageMetadata{
 					TopLayer:  "some-local-top-layer",

--- a/internal/inspectimage/writer/json_test.go
+++ b/internal/inspectimage/writer/json_test.go
@@ -57,10 +57,12 @@ func testJSON(t *testing.T, when spec.G, it spec.S) {
     ],
     "buildpacks": [
       {
+        "homepage": "https://some-homepage-one",
         "id": "test.bp.one.local",
         "version": "1.0.0"
       },
       {
+        "homepage": "https://some-homepage-two",
         "id": "test.bp.two.local",
         "version": "2.0.0"
       }
@@ -116,11 +118,13 @@ func testJSON(t *testing.T, when spec.G, it spec.S) {
     "buildpacks": [
       {
         "id": "test.bp.one.remote",
-        "version": "1.0.0"
+        "version": "1.0.0",
+        "homepage": "https://some-homepage-one"
       },
       {
         "id": "test.bp.two.remote",
-        "version": "2.0.0"
+        "version": "2.0.0",
+        "homepage": "https://some-homepage-two"
       }
     ],
     "processes": [
@@ -165,8 +169,8 @@ func testJSON(t *testing.T, when spec.G, it spec.S) {
 			remoteInfo = &pack.ImageInfo{
 				StackID: "test.stack.id.remote",
 				Buildpacks: []lifecycle.GroupBuildpack{
-					{ID: "test.bp.one.remote", Version: "1.0.0"},
-					{ID: "test.bp.two.remote", Version: "2.0.0"},
+					{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
 				},
 				Base: lifecycle.RunImageMetadata{
 					TopLayer:  "some-remote-top-layer",
@@ -195,7 +199,7 @@ func testJSON(t *testing.T, when spec.G, it spec.S) {
 							},
 						},
 					},
-					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0"},
+					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
 				}},
 				Processes: pack.ProcessDetails{
 					DefaultProcess: &launch.Process{
@@ -218,8 +222,8 @@ func testJSON(t *testing.T, when spec.G, it spec.S) {
 			localInfo = &pack.ImageInfo{
 				StackID: "test.stack.id.local",
 				Buildpacks: []lifecycle.GroupBuildpack{
-					{ID: "test.bp.one.local", Version: "1.0.0"},
-					{ID: "test.bp.two.local", Version: "2.0.0"},
+					{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
 				},
 				Base: lifecycle.RunImageMetadata{
 					TopLayer:  "some-local-top-layer",
@@ -242,7 +246,7 @@ func testJSON(t *testing.T, when spec.G, it spec.S) {
 							},
 						},
 					},
-					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0"},
+					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
 				}},
 				Processes: pack.ProcessDetails{
 					DefaultProcess: &launch.Process{

--- a/internal/inspectimage/writer/toml_test.go
+++ b/internal/inspectimage/writer/toml_test.go
@@ -56,10 +56,12 @@ name = 'other-local-mirror'
 [[local_info.buildpacks]]
 id = 'test.bp.one.local'
 version = '1.0.0'
+homepage = 'https://some-homepage-one'
 
 [[local_info.buildpacks]]
 id = 'test.bp.two.local'
 version = '2.0.0'
+homepage = 'https://some-homepage-two'
 
 [[local_info.processes]]
 type = 'some-local-type'
@@ -108,10 +110,12 @@ name = 'other-remote-mirror'
 [[remote_info.buildpacks]]
 id = 'test.bp.one.remote'
 version = '1.0.0'
+homepage = 'https://some-homepage-one'
 
 [[remote_info.buildpacks]]
 id = 'test.bp.two.remote'
 version = '2.0.0'
+homepage = 'https://some-homepage-two'
 
 [[remote_info.processes]]
 type = 'some-remote-type'
@@ -151,8 +155,8 @@ args = [
 			remoteInfo = &pack.ImageInfo{
 				StackID: "test.stack.id.remote",
 				Buildpacks: []lifecycle.GroupBuildpack{
-					{ID: "test.bp.one.remote", Version: "1.0.0"},
-					{ID: "test.bp.two.remote", Version: "2.0.0"},
+					{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
 				},
 				Base: lifecycle.RunImageMetadata{
 					TopLayer:  "some-remote-top-layer",
@@ -181,7 +185,7 @@ args = [
 							},
 						},
 					},
-					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0"},
+					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
 				}},
 				Processes: pack.ProcessDetails{
 					DefaultProcess: &launch.Process{
@@ -204,8 +208,8 @@ args = [
 			localInfo = &pack.ImageInfo{
 				StackID: "test.stack.id.local",
 				Buildpacks: []lifecycle.GroupBuildpack{
-					{ID: "test.bp.one.local", Version: "1.0.0"},
-					{ID: "test.bp.two.local", Version: "2.0.0"},
+					{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
 				},
 				Base: lifecycle.RunImageMetadata{
 					TopLayer:  "some-local-top-layer",
@@ -228,7 +232,7 @@ args = [
 							},
 						},
 					},
-					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0"},
+					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
 				}},
 				Processes: pack.ProcessDetails{
 					DefaultProcess: &launch.Process{

--- a/internal/inspectimage/writer/yaml_test.go
+++ b/internal/inspectimage/writer/yaml_test.go
@@ -46,9 +46,11 @@ local_info:
   - name: some-local-mirror
   - name: other-local-mirror
   buildpacks:
-  - id: test.bp.one.local
+  - homepage: https://some-homepage-one
+    id: test.bp.one.local
     version: 1.0.0
-  - id: test.bp.two.local
+  - homepage: https://some-homepage-two
+    id: test.bp.two.local
     version: 2.0.0
   processes:
   - type: some-local-type
@@ -81,9 +83,11 @@ remote_info:
   - name: some-remote-mirror
   - name: other-remote-mirror
   buildpacks:
-  - id: test.bp.one.remote
+  - homepage: https://some-homepage-one
+    id: test.bp.one.remote
     version: 1.0.0
-  - id: test.bp.two.remote
+  - homepage: https://some-homepage-two
+    id: test.bp.two.remote
     version: 2.0.0
   processes:
   - type: some-remote-type
@@ -119,8 +123,8 @@ remote_info:
 			remoteInfo = &pack.ImageInfo{
 				StackID: "test.stack.id.remote",
 				Buildpacks: []lifecycle.GroupBuildpack{
-					{ID: "test.bp.one.remote", Version: "1.0.0"},
-					{ID: "test.bp.two.remote", Version: "2.0.0"},
+					{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
 				},
 				Base: lifecycle.RunImageMetadata{
 					TopLayer:  "some-remote-top-layer",
@@ -149,7 +153,7 @@ remote_info:
 							},
 						},
 					},
-					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0"},
+					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
 				}},
 				Processes: pack.ProcessDetails{
 					DefaultProcess: &launch.Process{
@@ -172,8 +176,8 @@ remote_info:
 			localInfo = &pack.ImageInfo{
 				StackID: "test.stack.id.local",
 				Buildpacks: []lifecycle.GroupBuildpack{
-					{ID: "test.bp.one.local", Version: "1.0.0"},
-					{ID: "test.bp.two.local", Version: "2.0.0"},
+					{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
 				},
 				Base: lifecycle.RunImageMetadata{
 					TopLayer:  "some-local-top-layer",
@@ -196,7 +200,7 @@ remote_info:
 							},
 						},
 					},
-					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0"},
+					Buildpack: lifecycle.GroupBuildpack{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
 				}},
 				Processes: pack.ProcessDetails{
 					DefaultProcess: &launch.Process{

--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -1,0 +1,9 @@
+package strings
+
+func ValueOrDefault(str, def string) string {
+	if str == "" {
+		return def
+	}
+
+	return str
+}

--- a/internal/strings/strings_test.go
+++ b/internal/strings/strings_test.go
@@ -1,0 +1,31 @@
+package strings_test
+
+import (
+	"testing"
+
+	"github.com/buildpacks/pack/internal/strings"
+
+	"github.com/sclevine/spec"
+
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestValueOrDefault(t *testing.T) {
+	spec.Run(t, "Strings", func(t *testing.T, when spec.G, it spec.S) {
+		var (
+			assert = h.NewAssertionManager(t)
+		)
+
+		when("#ValueOrDefault", func() {
+			it("returns value when value is non-empty", func() {
+				output := strings.ValueOrDefault("some-value", "-")
+				assert.Equal(output, "some-value")
+			})
+
+			it("returns default when value is empty", func() {
+				output := strings.ValueOrDefault("", "-")
+				assert.Equal(output, "-")
+			})
+		})
+	})
+}


### PR DESCRIPTION
## Summary
Add buildpack homepages to inspect-image output

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
```
Buildpacks:
  ID                                         VERSION
  paketo-buildpacks/ca-certificates          1.0.1
  paketo-buildpacks/bellsoft-liberica        6.1.0
  paketo-buildpacks/executable-jar           3.1.3
  paketo-buildpacks/spring-boot              3.5.0
```

#### After
```
Buildpacks:
  ID                                                  VERSION        HOMEPAGE
  paketo-buildpacks/ca-certificates                   1.0.1          https://github.com/paketo-buildpacks/ca-certificates
  paketo-buildpacks/bellsoft-liberica                 6.1.0          https://github.com/paketo-buildpacks/bellsoft-liberica
  paketo-buildpacks/executable-jar                    3.1.3          https://github.com/paketo-buildpacks/executable-jar
  paketo-buildpacks/spring-boot                       3.5.0          https://github.com/paketo-buildpacks/spring-boot
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see https://github.com/buildpacks/docs/pull/315
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1033
