### PR TITLE
Bump golang/mock to 1.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/docker/docker v20.10.0-beta1.0.20201110211921-af34b94a78a1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/ghodss/yaml v1.0.0
-	github.com/golang/mock v1.4.4
+	github.com/golang/mock v1.5.0
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/google/go-cmp v0.5.4
 	github.com/google/go-containerregistry v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,8 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
+github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -56,9 +56,10 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 	when("#BuildCommand", func() {
 		when("no builder is specified", func() {
 			it("returns a soft error", func() {
-				mockClient.EXPECT().InspectBuilder(gomock.Any(), false).Return(&pack.BuilderInfo{
-					Description: "",
-				}, nil).AnyTimes()
+				mockClient.EXPECT().
+					InspectBuilder(gomock.Any(), false).
+					Return(&pack.BuilderInfo{Description: ""}, nil).
+					AnyTimes()
 
 				command.SetArgs([]string{"image"})
 				err := command.Execute()
@@ -329,10 +330,6 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 		when("a cache-image passed", func() {
 			when("--publish is not used", func() {
 				it("errors", func() {
-					mockClient.EXPECT().
-						Build(gomock.Any(), EqBuildOptionsWithCacheImage("some-cache-image")).
-						Return(nil)
-
 					command.SetArgs([]string{"--builder", "my-builder", "image", "--cache-image", "some-cache-image"})
 					err := command.Execute()
 					h.AssertError(t, err, "cache-image flag requires the publish flag")
@@ -395,10 +392,6 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 		when("an invalid lifecycle-image is provided", func() {
 			when("the repo name is invalid", func() {
 				it("returns a parse error", func() {
-					mockClient.EXPECT().
-						Build(gomock.Any(), gomock.Any()).
-						Return(errors.New(""))
-
 					command.SetArgs([]string{"--builder", "my-builder", "image", "--lifecycle-image", "some-!nv@l!d-image"})
 					err := command.Execute()
 					h.AssertError(t, err, "could not parse reference: some-!nv@l!d-image")
@@ -475,9 +468,6 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 		when("user specifies an invalid project descriptor file", func() {
 			it("should show an error", func() {
 				projectTomlPath := "/incorrect/path/to/project.toml"
-				mockClient.EXPECT().
-					Build(gomock.Any(), EqBuildOptionsWithImage("my-builder", "image")).
-					Return(nil)
 
 				command.SetArgs([]string{"--builder", "my-builder", "--descriptor", projectTomlPath, "image"})
 				h.AssertNotNil(t, command.Execute())
@@ -545,10 +535,6 @@ version = "1.0"
 				})
 
 				it("should fail to build", func() {
-					mockClient.EXPECT().
-						Build(gomock.Any(), EqBuildOptionsWithImage("my-builder", "image")).
-						Return(nil)
-
 					command.SetArgs([]string{"--builder", "my-builder", "--descriptor", projectTomlPath, "image"})
 					h.AssertNotNil(t, command.Execute())
 				})

--- a/internal/commands/suggest_builders.go
+++ b/internal/commands/suggest_builders.go
@@ -95,14 +95,15 @@ func WriteSuggestedBuilder(logger logging.Logger, inspector BuilderInspector, bu
 	descriptions := make([]string, len(builders))
 
 	var wg sync.WaitGroup
-	for i, builder := range builders {
-		wg.Add(1)
+	wg.Add(len(builders))
 
-		go func(i int, builder SuggestedBuilder) {
+	for i, builder := range builders {
+		go func(w *sync.WaitGroup, i int, builder SuggestedBuilder) {
 			descriptions[i] = getBuilderDescription(builder, inspector)
-			wg.Done()
-		}(i, builder)
+			w.Done()
+		}(&wg, i, builder)
 	}
+
 	wg.Wait()
 
 	tw := tabwriter.NewWriter(logger.Writer(), 10, 10, 5, ' ', tabwriter.TabIndent)


### PR DESCRIPTION
## Summary
Bump gomock testing library. And fixed the tests that were breaking. 

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

Resolves https://github.com/buildpacks/pack/pull/1087
