### PR TITLE
Allow pack buildpack package to create buildpackages without package.…

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -95,7 +95,6 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/buildpacks/imgutil v0.0.0-20201211223552-8581300fe2b2 h1:tQWsNfyiBTEB6BaEs+sRxsbbo/XkNxCEqSWVwTq7I00=
 github.com/buildpacks/imgutil v0.0.0-20201211223552-8581300fe2b2/go.mod h1:NC93OGDehA2ksqgTzugeQcPqmTpilMPYRO+XaFsDyts=
 github.com/buildpacks/imgutil v0.0.0-20210209163614-30601e371ce3 h1:NuBOSLnHIE+gTjeRC/PAopad83eNT1YLRclBSIRYhKU=
 github.com/buildpacks/imgutil v0.0.0-20210209163614-30601e371ce3/go.mod h1:JiWXkmkaiXrr5nq77JUtu7ys/5OAznS4VI7TwKthP7s=
@@ -232,7 +231,6 @@ github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
-github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
@@ -259,7 +257,6 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=


### PR DESCRIPTION
…toml for component buildpacks

## Summary
<!-- Provide a high-level summary of the change. -->

This change allows users to create buildpackages without a package.toml

It follows the behavior specified in https://github.com/buildpacks/pack/issues/1082

i.e.

If no package.toml is specified - 

it uses the current dir as the buildpack dir

if `--path` is specified it uses that dir

if both are specified it returns an error saying that their usage is incompatible together

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

```
pack buildpack package --help                                                                                                                                                                                             
buildpack package allows users to package (a) buildpack(s) into OCI format, which can then to be hosted in image repositories. You can also package a number of buildpacks together, to enable easier distribution of a set of buildpacks. Packaged buildpacks can be used as inputs to `pack build` (using the `--buildpack` flag), and they can be included in the configs used in `pack builder create` and `pack buildpack package`. For more on how to package a buildpack, see: https://buildpacks.io/docs/buildpack-author-guide/package-a-buildpack/.

Usage:
  pack buildpack package <name> --config <config-path> [flags]

Examples:
pack buildpack package my-buildpack --config ./package.toml

Flags:
  -r, --buildpack-registry string   Buildpack Registry name
  -c, --config string               Path to package TOML config (required)
  -f, --format string               Format to save package as ("image" or "file")
  -h, --help                        Help for 'package'
      --publish                     Publish to registry (applies to "--format=image" only)
      --pull-policy string          Pull policy to use. Accepted values are always, never, and if-not-present. The default is always

Global Flags:
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output
```

#### After

```
pack buildpack package --help    
buildpack package allows users to package (a) buildpack(s) into OCI format, which can then to be hosted in image repositories. You can also package a number of buildpacks together, to enable easier distribution of a set of buildpacks. Packaged buildpacks can be used as inputs to `pack build` (using the `--buildpack` flag), and they can be included in the configs used in `pack builder create` and `pack buildpack package`. For more on how to package a buildpack, see: https://buildpacks.io/docs/buildpack-author-guide/package-a-buildpack/.

Usage:
  pack buildpack package <name> --config <config-path> [flags]

Examples:
pack buildpack package my-buildpack --config ./package.toml

Flags:
  -r, --buildpack-registry string   Buildpack Registry name
  -c, --config string               Path to package TOML config
  -f, --format string               Format to save package as ("image" or "file")
  -h, --help                        Help for 'package'
  -p, --path string                 Path to the Buildpack that needs to be packaged
      --publish                     Publish to registry (applies to "--format=image" only)
      --pull-policy string          Pull policy to use. Accepted values are always, never, and if-not-present. The default is always

Global Flags:
      --no-color     Disable color output
  -q, --quiet        Show less output
      --timestamps   Enable timestamps in output
  -v, --verbose      Show more output
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see https://github.com/buildpacks/docs/issues/321
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves part of #1082 
