### PR TITLE
`pack buildpack inspect` now works when no docker daemon is available

### DIFF
--- a/internal/commands/buildpack_inspect_test.go
+++ b/internal/commands/buildpack_inspect_test.go
@@ -647,7 +647,7 @@ func testBuildpackInspectCommand(t *testing.T, when spec.G, it spec.S) {
 				err := command.Execute()
 
 				assert.Error(err)
-				assert.Contains(err.Error(), "error writing buildpack output: \"no buildpacks found\"")
+				assert.Contains(err.Error(), "error writing buildpack output: \"error inspecting local archive: not found, error inspecting remote archive: not found\"")
 			})
 		})
 
@@ -656,6 +656,12 @@ func testBuildpackInspectCommand(t *testing.T, when spec.G, it spec.S) {
 				mockClient.EXPECT().InspectBuildpack(pack.InspectBuildpackOptions{
 					BuildpackName: "urn:cnb:registry:registry-failure/buildpack",
 					Daemon:        true,
+					Registry:      "some-registry",
+				}).Return(&pack.BuildpackInfo{}, errors.New("error inspecting registry image"))
+
+				mockClient.EXPECT().InspectBuildpack(pack.InspectBuildpackOptions{
+					BuildpackName: "urn:cnb:registry:registry-failure/buildpack",
+					Daemon:        false,
 					Registry:      "some-registry",
 				}).Return(&pack.BuildpackInfo{}, errors.New("error inspecting registry image"))
 			})

--- a/internal/commands/inspect_buildpack.go
+++ b/internal/commands/inspect_buildpack.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/buildpacks/pack/internal/image"
-
 	"github.com/buildpacks/pack/internal/buildpack"
 
 	"github.com/spf13/cobra"
@@ -94,15 +92,12 @@ func InspectBuildpack(logger logging.Logger, cfg config.Config, client PackClien
 
 func inspectAllBuildpacks(client PackClient, flags BuildpackInspectFlags, options ...pack.InspectBuildpackOptions) (string, error) {
 	buf := bytes.NewBuffer(nil)
-	skipCount := 0
+	errArray := []error{}
 	for _, option := range options {
 		nextResult, err := client.InspectBuildpack(option)
 		if err != nil {
-			if errors.Is(err, image.ErrNotFound) {
-				skipCount++
-				continue
-			}
-			return "", err
+			errArray = append(errArray, err)
+			continue
 		}
 
 		prefix := determinePrefix(option.BuildpackName, nextResult.Location, option.Daemon)
@@ -120,8 +115,8 @@ func inspectAllBuildpacks(client PackClient, flags BuildpackInspectFlags, option
 			return buf.String(), nil
 		}
 	}
-	if skipCount == len(options) {
-		return "", errors.New("no buildpacks found")
+	if len(errArray) == len(options) {
+		return "", joinErrors(errArray)
 	}
 	return buf.String(), nil
 }
@@ -307,4 +302,13 @@ func displayBuildpack(w io.Writer, prefix string, entry dist.BuildpackRef, visit
 
 	_, err := fmt.Fprintf(w, "%s%s%s\t%s%s\n", prefix, treePrefix, bpRef, optional, visitedStatus)
 	return err
+}
+
+func joinErrors(errs []error) error {
+	errStrings := make([]string, len(errs))
+	for idx, err := range errs {
+		errStrings[idx] = err.Error()
+	}
+
+	return errors.New(strings.Join(errStrings, ", "))
 }

--- a/internal/commands/inspect_buildpack_test.go
+++ b/internal/commands/inspect_buildpack_test.go
@@ -363,6 +363,36 @@ func testInspectBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 					assert.AssertTrimmedContains(outBuf.String(), expectedOutput)
 				})
 			})
+			when("local docker daemon is not running", func() {
+				it.Before(func() {
+					complexInfo.Location = buildpack.PackageLocator
+					simpleInfo.Location = buildpack.PackageLocator
+
+					mockClient.EXPECT().InspectBuildpack(pack.InspectBuildpackOptions{
+						BuildpackName: "only-remote-test/buildpack",
+						Daemon:        false,
+						Registry:      "default-registry",
+					}).Return(complexInfo, nil)
+
+					mockClient.EXPECT().InspectBuildpack(pack.InspectBuildpackOptions{
+						BuildpackName: "only-remote-test/buildpack",
+						Daemon:        true,
+						Registry:      "default-registry",
+					}).Return(nil, errors.New("the docker daemon is not running"))
+				})
+
+				it("displays output for remote image", func() {
+					command.SetArgs([]string{"only-remote-test/buildpack"})
+					assert.Nil(command.Execute())
+
+					expectedOutput := fmt.Sprintf(inspectOutputTemplate,
+						"only-remote-test/buildpack",
+						"REMOTE IMAGE:",
+						complexOutputSection)
+
+					assert.AssertTrimmedContains(outBuf.String(), expectedOutput)
+				})
+			})
 		})
 
 		when("inspecting a buildpack uri", func() {
@@ -557,7 +587,7 @@ func testInspectBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 				err := command.Execute()
 
 				assert.Error(err)
-				assert.Contains(err.Error(), "error writing buildpack output: \"no buildpacks found\"")
+				assert.Contains(err.Error(), "error writing buildpack output: \"error inspecting local archive: not found, error inspecting remote archive: not found\"")
 			})
 		})
 
@@ -566,6 +596,12 @@ func testInspectBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 				mockClient.EXPECT().InspectBuildpack(pack.InspectBuildpackOptions{
 					BuildpackName: "urn:cnb:registry:registry-failure/buildpack",
 					Daemon:        true,
+					Registry:      "some-registry",
+				}).Return(&pack.BuildpackInfo{}, errors.New("error inspecting registry image"))
+
+				mockClient.EXPECT().InspectBuildpack(pack.InspectBuildpackOptions{
+					BuildpackName: "urn:cnb:registry:registry-failure/buildpack",
+					Daemon:        false,
 					Registry:      "some-registry",
 				}).Return(&pack.BuildpackInfo{}, errors.New("error inspecting registry image"))
 			})

--- a/internal/inspectimage/bom_display.go
+++ b/internal/inspectimage/bom_display.go
@@ -10,8 +10,8 @@ import (
 type BOMDisplay struct {
 	Remote    []BOMEntryDisplay `json:"remote" yaml:"remote"`
 	Local     []BOMEntryDisplay `json:"local" yaml:"local"`
-	RemoteErr string            `json:"remoteError,omitempty" yaml:"remoteError,omitempty"`
-	LocalErr  string            `json:"localError,omitempty" yaml:"localError,omitempty"`
+	RemoteErr string            `json:"remote_error,omitempty" yaml:"remoteError,omitempty"`
+	LocalErr  string            `json:"local_error,omitempty" yaml:"localError,omitempty"`
 }
 
 type BOMEntryDisplay struct {


### PR DESCRIPTION
Signed-off-by: dwillist <dthornton@vmware.com>

## Summary
Resolves a bug around inspecting buildpacks when no docker daemon is running. 

Previously this just returned an error indicating the docker daemon was not running. 
Now it returns the result of the remote inspection.

PS.
There is some work to do around standardizing these inspection commands. Seems like we should not show errors unless users explicitly ask for them.

## Related
Resolves #1095
