### PR TITLE
Changes build flag to --lifecycle-docker-host

### DIFF
--- a/build.go
+++ b/build.go
@@ -88,9 +88,9 @@ type BuildOptions struct {
 	// built atop.
 	RunImage string
 
-	// Address of docker daemon exposed to build container
-	// e.g. tcp://example.com:1234, unix:///run/user/1000/podman/podman.sock
-	DockerHost string
+	// Address of docker daemon exposed to lifecycle in the build container
+	// e.g. host-socket, inherit, tcp://example.com:1234, unix:///run/user/1000/podman/podman.sock
+	LifecycleDockerHost string
 
 	// Used to determine a run-image mirror if Run Image is empty.
 	// Used in combination with Builder metadata to determine to the the 'best' mirror.
@@ -284,25 +284,25 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 	}
 
 	lifecycleOpts := build.LifecycleOptions{
-		AppPath:            appPath,
-		Image:              imageRef,
-		Builder:            ephemeralBuilder,
-		RunImage:           runImageName,
-		ClearCache:         opts.ClearCache,
-		Publish:            opts.Publish,
-		DockerHost:         opts.DockerHost,
-		UseCreator:         false,
-		TrustBuilder:       opts.TrustBuilder,
-		LifecycleImage:     ephemeralBuilder.Name(),
-		HTTPProxy:          proxyConfig.HTTPProxy,
-		HTTPSProxy:         proxyConfig.HTTPSProxy,
-		NoProxy:            proxyConfig.NoProxy,
-		Network:            opts.ContainerConfig.Network,
-		AdditionalTags:     opts.AdditionalTags,
-		Volumes:            processedVolumes,
-		DefaultProcessType: opts.DefaultProcessType,
-		FileFilter:         fileFilter,
-		CacheImage:         opts.CacheImage,
+		AppPath:             appPath,
+		Image:               imageRef,
+		Builder:             ephemeralBuilder,
+		RunImage:            runImageName,
+		ClearCache:          opts.ClearCache,
+		Publish:             opts.Publish,
+		UseCreator:          false,
+		TrustBuilder:        opts.TrustBuilder,
+		HTTPProxy:           proxyConfig.HTTPProxy,
+		HTTPSProxy:          proxyConfig.HTTPSProxy,
+		NoProxy:             proxyConfig.NoProxy,
+		Network:             opts.ContainerConfig.Network,
+		AdditionalTags:      opts.AdditionalTags,
+		Volumes:             processedVolumes,
+		DefaultProcessType:  opts.DefaultProcessType,
+		FileFilter:          fileFilter,
+		CacheImage:          opts.CacheImage,
+		LifecycleImage:      ephemeralBuilder.Name(),
+		LifecycleDockerHost: opts.LifecycleDockerHost,
 	}
 
 	lifecycleVersion := ephemeralBuilder.LifecycleDescriptor().Info.Version

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -132,7 +132,7 @@ func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseF
 		}
 
 		l.logger.Info(style.Step("ANALYZING"))
-		if err := l.Analyze(ctx, l.opts.Image.String(), l.opts.Network, l.opts.Publish, l.opts.DockerHost, l.opts.ClearCache, buildCache, phaseFactory); err != nil {
+		if err := l.Analyze(ctx, l.opts.Image.String(), l.opts.Network, l.opts.Publish, l.opts.LifecycleDockerHost, l.opts.ClearCache, buildCache, phaseFactory); err != nil {
 			return err
 		}
 
@@ -150,10 +150,10 @@ func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseF
 		}
 
 		l.logger.Info(style.Step("EXPORTING"))
-		return l.Export(ctx, l.opts.Image.String(), l.opts.RunImage, l.opts.Publish, l.opts.DockerHost, l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, phaseFactory)
+		return l.Export(ctx, l.opts.Image.String(), l.opts.RunImage, l.opts.Publish, l.opts.LifecycleDockerHost, l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, phaseFactory)
 	}
 
-	return l.Create(ctx, l.opts.Publish, l.opts.DockerHost, l.opts.ClearCache, l.opts.RunImage, l.opts.Image.String(), l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, l.opts.Volumes, phaseFactory)
+	return l.Create(ctx, l.opts.Publish, l.opts.LifecycleDockerHost, l.opts.ClearCache, l.opts.RunImage, l.opts.Image.String(), l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, l.opts.Volumes, phaseFactory)
 }
 
 func (l *LifecycleExecution) Cleanup() error {

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -537,7 +537,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := lifecycle.Create(context.Background(), false, "", false, "test", "test", "test", fakeBuildCache, fakeLaunchCache, []string{}, []string{}, fakePhaseFactory)
+				err := lifecycle.Create(context.Background(), false, "host-socket", false, "test", "test", "test", fakeBuildCache, fakeLaunchCache, []string{}, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1030,7 +1030,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := lifecycle.Analyze(context.Background(), "test", "test", false, "", false, fakeCache, fakePhaseFactory)
+				err := lifecycle.Analyze(context.Background(), "test", "test", false, "host-socket", false, fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1656,7 +1656,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-				err := lifecycle.Export(context.Background(), "test", "test", false, "", "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
+				err := lifecycle.Export(context.Background(), "test", "test", false, "host-socket", "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -548,7 +548,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				h.AssertSliceContains(t, configProvider.HostConfig().Binds, "/var/run/docker.sock:/var/run/docker.sock")
 			})
 
-			it("configures the phase with daemon access with tcp docker-host", func() {
+			it("configures the phase with daemon access with tcp lifecycle-docker-host", func() {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
@@ -563,7 +563,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				h.AssertSliceContains(t, configProvider.ContainerConfig().Env, "DOCKER_HOST=tcp://localhost:1234")
 			})
 
-			it("configures the phase with daemon access with alternative unix socket docker-host", func() {
+			it("configures the phase with daemon access with alternative unix socket lifecycle-docker-host", func() {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
@@ -577,7 +577,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				h.AssertSliceContains(t, configProvider.HostConfig().Binds, "/home/user/docker.sock:/var/run/docker.sock")
 			})
 
-			it("configures the phase with daemon access with alternative windows pipe docker-host", func() {
+			it("configures the phase with daemon access with alternative windows pipe lifecycle-docker-host", func() {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
@@ -608,7 +608,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 						os.Unsetenv("DOCKER_HOST")
 					}
 				})
-				it("configures the phase with daemon access with inherited docker-host", func() {
+				it("configures the phase with daemon access with inherited lifecycle-docker-host", func() {
 					lifecycle := newTestLifecycleExec(t, false)
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
@@ -623,7 +623,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 
-			it("configures the phase with daemon access with docker-host with unknown protocol", func() {
+			it("configures the phase with daemon access with lifecycle-docker-host with unknown protocol", func() {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 				err := lifecycle.Create(context.Background(), false, `withoutprotocol`, false, "test", "test", "test", fakeBuildCache, fakeLaunchCache, []string{}, []string{}, fakePhaseFactory)
@@ -1041,7 +1041,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				h.AssertSliceContains(t, configProvider.HostConfig().Binds, "/var/run/docker.sock:/var/run/docker.sock")
 			})
 
-			it("configures the phase with daemon access with TCP docker-host", func() {
+			it("configures the phase with daemon access with TCP lifecycle-docker-host", func() {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 
@@ -1667,7 +1667,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				h.AssertSliceContains(t, configProvider.HostConfig().Binds, "/var/run/docker.sock:/var/run/docker.sock")
 			})
 
-			it("configures the phase with daemon access with tcp docker-host", func() {
+			it("configures the phase with daemon access with tcp lifecycle-docker-host", func() {
 				lifecycle := newTestLifecycleExec(t, false)
 				fakePhaseFactory := fakes.NewFakePhaseFactory()
 

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -49,25 +49,25 @@ func init() {
 }
 
 type LifecycleOptions struct {
-	AppPath            string
-	Image              name.Reference
-	Builder            Builder
-	LifecycleImage     string
-	RunImage           string
-	ClearCache         bool
-	Publish            bool
-	TrustBuilder       bool
-	UseCreator         bool
-	DockerHost         string
-	CacheImage         string
-	HTTPProxy          string
-	HTTPSProxy         string
-	NoProxy            string
-	Network            string
-	AdditionalTags     []string
-	Volumes            []string
-	DefaultProcessType string
-	FileFilter         func(string) bool
+	AppPath             string
+	Image               name.Reference
+	Builder             Builder
+	RunImage            string
+	ClearCache          bool
+	Publish             bool
+	TrustBuilder        bool
+	UseCreator          bool
+	CacheImage          string
+	LifecycleImage      string
+	LifecycleDockerHost string
+	HTTPProxy           string
+	HTTPSProxy          string
+	NoProxy             string
+	Network             string
+	AdditionalTags      []string
+	Volumes             []string
+	DefaultProcessType  string
+	FileFilter          func(string) bool
 }
 
 func NewLifecycleExecutor(logger logging.Logger, docker client.CommonAPIClient) *LifecycleExecutor {

--- a/internal/build/phase_config_provider.go
+++ b/internal/build/phase_config_provider.go
@@ -130,7 +130,7 @@ func WithDaemonAccess(dockerHost string) PhaseConfigProviderOperation {
 			dockerHost = os.Getenv("DOCKER_HOST")
 		}
 		var bind string
-		if dockerHost == "" {
+		if dockerHost == "host-socket" {
 			bind = "/var/run/docker.sock:/var/run/docker.sock"
 			if provider.os == "windows" {
 				bind = `\\.\pipe\docker_engine:\\.\pipe\docker_engine`

--- a/internal/build/phase_config_provider_test.go
+++ b/internal/build/phase_config_provider_test.go
@@ -133,7 +133,7 @@ func testPhaseConfigProvider(t *testing.T, when spec.G, it spec.S) {
 					phaseConfigProvider := build.NewPhaseConfigProvider(
 						"some-name",
 						lifecycle,
-						build.WithDaemonAccess(""),
+						build.WithDaemonAccess("host-socket"),
 					)
 
 					h.AssertEq(t, phaseConfigProvider.ContainerConfig().User, "root")
@@ -152,7 +152,7 @@ func testPhaseConfigProvider(t *testing.T, when spec.G, it spec.S) {
 					phaseConfigProvider := build.NewPhaseConfigProvider(
 						"some-name",
 						lifecycle,
-						build.WithDaemonAccess(""),
+						build.WithDaemonAccess("host-socket"),
 					)
 
 					h.AssertEq(t, phaseConfigProvider.ContainerConfig().User, "ContainerAdministrator")

--- a/internal/build/phase_test.go
+++ b/internal/build/phase_test.go
@@ -265,7 +265,7 @@ func testPhase(t *testing.T, when spec.G, it spec.S) {
 			when("#WithDaemonAccess", func() {
 				when("with standard docker socket", func() {
 					it("allows daemon access inside the container", func() {
-						configProvider := build.NewPhaseConfigProvider(phaseName, lifecycleExec, build.WithArgs("daemon"), build.WithDaemonAccess(""))
+						configProvider := build.NewPhaseConfigProvider(phaseName, lifecycleExec, build.WithArgs("daemon"), build.WithDaemonAccess("host-socket"))
 						phase := phaseFactory.New(configProvider)
 						assertRunSucceeds(t, phase, &outBuf, &errBuf)
 						h.AssertContains(t, outBuf.String(), "daemon test")

--- a/internal/build/phase_test.go
+++ b/internal/build/phase_test.go
@@ -296,7 +296,7 @@ func testPhase(t *testing.T, when spec.G, it spec.S) {
 					})
 				})
 
-				when("with TCP docker-host", func() {
+				when("with TCP lifecycle-docker-host", func() {
 					it.Before(func() {
 						h.SkipIf(t, runtime.GOOS != "linux", "Skipped on non-linux")
 					})
@@ -379,6 +379,7 @@ func testPhase(t *testing.T, when spec.G, it spec.S) {
 						build.WithArgs("registry", repoName),
 						build.WithRegistryAccess(authConfig),
 						build.WithNetwork("host"),
+						build.WithDaemonAccess("host-socket"),
 					)
 					phase := phaseFactory.New(configProvider)
 					assertRunSucceeds(t, phase, &outBuf, &errBuf)

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -156,9 +156,9 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringArrayVar(&buildFlags.EnvFiles, "env-file", []string{}, "Build-time environment variables file\nOne variable per line, of the form 'VAR=VALUE' or 'VAR'\nWhen using latter value-less form, value will be taken from current\n  environment at the time this command is executed\nNOTE: These are NOT available at image runtime.\"")
 	cmd.Flags().StringVar(&buildFlags.Network, "network", "", "Connect detect and build containers to network")
 	cmd.Flags().BoolVar(&buildFlags.Publish, "publish", false, "Publish to registry")
-	cmd.Flags().StringVar(&buildFlags.DockerHost, "docker-host", "",
+	cmd.Flags().StringVar(&buildFlags.DockerHost, "docker-host", "host-socket",
 		`Address to docker daemon that will be exposed to the build container.
-If not set (or set to empty string) the standard socket location will be used.
+If not set (or set to 'host-socket') the standard socket location will be used.
 Special value 'inherit' may be used in which case DOCKER_HOST environment variable will be used.
 This option may set DOCKER_HOST environment variable for the build container if needed.
 `)


### PR DESCRIPTION
- Change build flag `--docker-host` to `--lifecycle-docker-host`
- Adds explicit `host-socket` for default behavior value

Signed-off-by: Micah Young <ymicah@vmware.com>

## Summary
The `pack build` flag `--docker-host` introduced in https://github.com/buildpacks/pack/pull/988 works as designed but user feedback (https://github.com/buildpacks/pack/issues/1093) suggests the naming implies not only `DOCKER_HOST` for lifecycle is changed, but also `DOCKER_HOST` for `pack` (which could eventually be implemented, but is independent of the original purpose).

Here I change the name to `--lifecycle-docker-host` and cleanup some additional details:
* Make the default value and behavior have explicit value: `host-socket`
* Make `--lifecycle-docker-host` and `--publish` mutually exclusive and fail when used together (for publishing, lifecycle never has a dependency on daemon) 

Out of scope for this, but potential next steps are:
* Add `--docker-host` flag which would effectively set's `pack`'s `DOCKER_HOST`
* Make `inherit` be the default for `--lifecycle-docker-host` when `pack`'s `DOCKER_HOST` is set

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
##### Usage output
```
--docker-host string          Address to docker daemon that will be exposed to the build container.
```
#### After
##### Usage output
```
--lifecycle-docker-host string   Address to docker daemon to expose for lifecycle in the build container.
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1093
