### PR TITLE
Add builder to project descriptor

### DIFF
--- a/project/project.go
+++ b/project/project.go
@@ -25,6 +25,7 @@ type Build struct {
 	Exclude    []string    `toml:"exclude"`
 	Buildpacks []Buildpack `toml:"buildpacks"`
 	Env        []EnvVar    `toml:"env"`
+	Builder    string      `toml:"builder"`
 }
 
 type Project struct {


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>

## Summary
<!-- Provide a high-level summary of the change. -->

Adds support for the builder key in project descriptor

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before



#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1114 
Implements https://github.com/buildpacks/rfcs/pull/138 (We should wait for that to be merged before merging this I guess?)