### PR TITLE
Set build-image metadata in stack.toml of builder

### DIFF
--- a/create_builder_test.go
+++ b/create_builder_test.go
@@ -288,6 +288,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 
 			it("should warn when the run image cannot be found", func() {
 				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(fakeBuildImage, nil)
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", true, config.PullAlways).Return(fakeBuildImage, nil)
 
 				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", false, config.PullAlways).Return(nil, errors.Wrap(image.ErrNotFound, "yikes"))
 				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", true, config.PullAlways).Return(nil, errors.Wrap(image.ErrNotFound, "yikes"))

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -242,11 +242,15 @@ func (b *Builder) SetDescription(description string) {
 }
 
 // SetStack sets the stack of the builder
-func (b *Builder) SetStack(stackConfig builder.StackConfig) {
+func (b *Builder) SetStack(stackConfig builder.StackConfig, buildMixins []string) {
 	b.metadata.Stack = StackMetadata{
 		RunImage: RunImageMetadata{
 			Image:   stackConfig.RunImage,
 			Mirrors: stackConfig.RunImageMirrors,
+		},
+		BuildImage: BuildImageMetadata{
+			StackID: stackConfig.ID,
+			Mixins: buildMixins,
 		},
 	}
 }

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -1010,9 +1010,11 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 		when("#SetStack", func() {
 			it.Before(func() {
 				subject.SetStack(pubbldr.StackConfig{
+					ID:              "some-stack",
 					RunImage:        "some/run",
 					RunImageMirrors: []string{"some/mirror", "other/mirror"},
-				})
+					BuildImage:      "some/build",
+				}, []string{"none"})
 				h.AssertNil(t, subject.Save(logger, builder.CreatorMetadata{}))
 				h.AssertEq(t, baseImage.IsSaved(), true)
 			})
@@ -1024,6 +1026,10 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 					h.ContentEquals(`[run-image]
   image = "some/run"
   mirrors = ["some/mirror", "other/mirror"]
+
+[build-image]
+  mixins = ["none"]
+  stack-id = "some-stack"
 `),
 					h.HasModTime(archive.NormalizedDateTime),
 				)

--- a/internal/builder/metadata.go
+++ b/internal/builder/metadata.go
@@ -27,10 +27,16 @@ type LifecycleMetadata struct {
 }
 
 type StackMetadata struct {
-	RunImage RunImageMetadata `json:"runImage" toml:"run-image"`
+	RunImage   RunImageMetadata   `json:"runImage" toml:"run-image"`
+	BuildImage BuildImageMetadata `json:"buildImage" toml:"build-image"`
 }
 
 type RunImageMetadata struct {
 	Image   string   `json:"image" toml:"image"`
 	Mirrors []string `json:"mirrors" toml:"mirrors"`
+}
+
+type BuildImageMetadata struct {
+	Mixins  []string `json:"mixins" toml:"mixins"`
+	StackID string   `json:"stack-id" toml:"stack-id"`
 }


### PR DESCRIPTION
## Summary

This change introduces new metadata to `stack.toml` that is required for implementation of https://github.com/buildpacks/spec/pull/197

## Output

#### Before

`stack.toml`

```
[run-image]
  image = "some/run"
  mirrors = ["some/mirror", "other/mirror"]
```

#### After

`stack.toml`

```
[run-image]
  image = "some/run"
  mirrors = ["some/mirror", "other/mirror"]

[build-image]
  mixins = ["libpq"]
  stack-id = "some-stack"
```

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

