### PR TITLE
Add Heroku-20 to suggested stacks list

### DIFF
--- a/internal/commands/stack_suggest.go
+++ b/internal/commands/stack_suggest.go
@@ -27,6 +27,13 @@ var suggestedStacks = []suggestedStack{
 		RunImage:    "heroku/pack:18",
 	},
 	{
+		ID:          "heroku-20",
+		Description: "The official Heroku stack based on Ubuntu 20.04",
+		Maintainer:  "Heroku",
+		BuildImage:  "heroku/pack:20-build",
+		RunImage:    "heroku/pack:20",
+	},
+	{
 		ID:          "io.buildpacks.stacks.bionic",
 		Description: "A minimal Paketo stack based on Ubuntu 18.04",
 		Maintainer:  "Paketo Project",

--- a/internal/commands/stack_suggest_test.go
+++ b/internal/commands/stack_suggest_test.go
@@ -38,6 +38,12 @@ func testStacksSuggestCommand(t *testing.T, when spec.G, it spec.S) {
     Build Image: heroku/pack:18-build
     Run Image: heroku/pack:18
 
+    Stack ID: heroku-20
+    Description: The official Heroku stack based on Ubuntu 20.04
+    Maintainer: Heroku
+    Build Image: heroku/pack:20-build
+    Run Image: heroku/pack:20
+
     Stack ID: io.buildpacks.stacks.bionic
     Description: A minimal Paketo stack based on Ubuntu 18.04
     Maintainer: Paketo Project

--- a/internal/commands/suggest_stacks_test.go
+++ b/internal/commands/suggest_stacks_test.go
@@ -43,6 +43,12 @@ Stacks maintained by the community:
     Build Image: heroku/pack:18-build
     Run Image: heroku/pack:18
 
+    Stack ID: heroku-20
+    Description: The official Heroku stack based on Ubuntu 20.04
+    Maintainer: Heroku
+    Build Image: heroku/pack:20-build
+    Run Image: heroku/pack:20
+
     Stack ID: io.buildpacks.stacks.bionic
     Description: A minimal Paketo stack based on Ubuntu 18.04
     Maintainer: Paketo Project


### PR DESCRIPTION
## Summary
Heroku-20 is now Heroku's default stack, and was previously added to the suggested builders list in #1052, however was not yet listed in the suggested stacks list.

See:
https://github.com/heroku/pack-images#heroku-pack-base-images

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
```
$ pack stack suggest
Stacks maintained by the community:

    Stack ID: heroku-18
    Description: The official Heroku stack based on Ubuntu 18.04
    Maintainer: Heroku
    Build Image: heroku/pack:18-build
    Run Image: heroku/pack:18

    Stack ID: io.buildpacks.stacks.bionic
    Description: A minimal Paketo stack based on Ubuntu 18.04
    Maintainer: Paketo Project
    Build Image: paketobuildpacks/build:base-cnb
    Run Image: paketobuildpacks/run:base-cnb

    Stack ID: io.buildpacks.stacks.bionic
    Description: A large Paketo stack based on Ubuntu 18.04
    Maintainer: Paketo Project
    Build Image: paketobuildpacks/build:full-cnb
    Run Image: paketobuildpacks/run:full-cnb

    Stack ID: io.paketo.stacks.tiny
    Description: A tiny Paketo stack based on Ubuntu 18.04, similar to distroless
    Maintainer: Paketo Project
    Build Image: paketobuildpacks/build:tiny-cnb
    Run Image: paketobuildpacks/run:tiny-cnb
```

#### After
```
$ go run cmd/pack/main.go stack suggest
Stacks maintained by the community:

    Stack ID: heroku-18
    Description: The official Heroku stack based on Ubuntu 18.04
    Maintainer: Heroku
    Build Image: heroku/pack:18-build
    Run Image: heroku/pack:18

    Stack ID: heroku-20
    Description: The official Heroku stack based on Ubuntu 20.04
    Maintainer: Heroku
    Build Image: heroku/pack:20-build
    Run Image: heroku/pack:20

    Stack ID: io.buildpacks.stacks.bionic
    Description: A minimal Paketo stack based on Ubuntu 18.04
    Maintainer: Paketo Project
    Build Image: paketobuildpacks/build:base-cnb
    Run Image: paketobuildpacks/run:base-cnb

    Stack ID: io.buildpacks.stacks.bionic
    Description: A large Paketo stack based on Ubuntu 18.04
    Maintainer: Paketo Project
    Build Image: paketobuildpacks/build:full-cnb
    Run Image: paketobuildpacks/run:full-cnb

    Stack ID: io.paketo.stacks.tiny
    Description: A tiny Paketo stack based on Ubuntu 18.04, similar to distroless
    Maintainer: Paketo Project
    Build Image: paketobuildpacks/build:tiny-cnb
    Run Image: paketobuildpacks/run:tiny-cnb
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [X] No