### PR TITLE
Remove leading whitespace in scripts generated by 'buildpack new'

### DIFF
--- a/new_buildpack.go
+++ b/new_buildpack.go
@@ -15,8 +15,7 @@ import (
 )
 
 var (
-	bashBinBuild = `
-#!/usr/bin/env bash
+	bashBinBuild = `#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -26,8 +25,7 @@ plan_path="$3"
 
 exit 0
 `
-	bashBinDetect = `
-#!/usr/bin/env bash
+	bashBinDetect = `#!/usr/bin/env bash
 
 exit 0
 `


### PR DESCRIPTION
## Summary
Previously the `bin/detect` and `bin/build` bash scripts generated by `pack buildpack new` had a stray blank line as the first line of the script. This line has now been removed.

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [X] No