### PR TITLE
update ppa release by pinning go version to enable building for i386 arch

### DIFF
--- a/.github/workflows/deliver-ubuntu.yml
+++ b/.github/workflows/deliver-ubuntu.yml
@@ -25,12 +25,15 @@ jobs:
             - target: xenial
               runner: ubuntu-16.04
               image: docker://ubuntu:16.04
+              i386-go-version: 1.13
             - target: bionic
               runner: ubuntu-18.04
               image: docker://ubuntu:18.04
+              i386-go-version: 1.15
             - target: focal
               runner: ubuntu-20.04
               image: docker://ubuntu:20.04
+              i386-go-version: none
       name: create-ppa
       runs-on:  ${{ matrix.runner }}
 
@@ -71,6 +74,7 @@ jobs:
               tokenSuffix: '}}'
             env:
               ARCH: "any"
+              I386_GO_VERSION: ${{matrix.i386-go-version}}
               PACKAGE_NAME: "pack-cli"
               UBUNTU_VERSION:  ${{ matrix.target }}
               HOMEPAGE: "https://buildpacks.io"

--- a/.github/workflows/delivery/ubuntu/debian/control
+++ b/.github/workflows/delivery/ubuntu/debian/control
@@ -2,7 +2,7 @@ Source: {{PACKAGE_NAME}}
 Section: utils
 Priority: optional
 Maintainer: {{MAINTAINER_NAME}} <{{MAINTAINER_EMAIL}}>
-Build-Depends: debhelper (>=9), git, golang (>=1.13)
+Build-Depends: debhelper (>=9), git, golang (>=1.13) [!i386], golang-{{I386_GO_VERSION}} [i386]
 Standards-Version: 3.9.8
 Vcs-Git: git@github.com/{{REPO}}.git
 Vcs-Browser: https://github.com/{{REPO}}

--- a/.github/workflows/delivery/ubuntu/debian/rules
+++ b/.github/workflows/delivery/ubuntu/debian/rules
@@ -10,7 +10,7 @@ override_dh_auto_test:
 
 override_dh_auto_build:
 	mkdir -p /tmp/.cache/go-build
-	GOCACHE=/tmp/.cache/go-build GOFLAGS="-mod=vendor" LDFLAGS="" PACK_VERSION='{{PACK_VERSION}}' dh_auto_build -- build
+	GOCACHE=/tmp/.cache/go-build GOFLAGS="-mod=vendor" LDFLAGS="" PACK_VERSION='{{PACK_VERSION}}' PATH="${PATH}:/usr/lib/go-{{I386_GO_VERSION}}/bin" dh_auto_build -- build
 	rm -r /tmp/.cache/go-build
 
 


### PR DESCRIPTION
Signed-off-by: dwillist <dthornton@vmware.com>

## Summary
this pins the go-version used to build `pack` for the `i386` arch on ubuntu `bionic` and `xenial`.
The respective pins are `xenial` -> `go-1.13` 
The respective pins are `bionic` -> `go-1.15` 

These are the most up to date versions of go that have been backported as ppa packages.

## Output
Restore successful building for `bionic-i386` ppa releases.

#### Before
Unable to successfully build `pack` for `bionic-i386` ppa releases.

#### After
Restore successful building for `bionic-i386` ppa releases.

Here are some trial runs of these changes on a test ppa for `focal`, `bionic`, and `xenial` ppa releases.
https://launchpad.net/~thorntondwt/+archive/ubuntu/testppa/+sourcepub/12295367/+listing-archive-extra
https://launchpad.net/~thorntondwt/+archive/ubuntu/testppa/+sourcepub/12295378/+listing-archive-extra
https://launchpad.net/~thorntondwt/+archive/ubuntu/testppa/+sourcepub/12295368/+listing-archive-extra

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No
Resolves #1117 
