### PR TITLE
Added workspace mount point as option to build

### DIFF
--- a/build.go
+++ b/build.go
@@ -156,7 +156,7 @@ type BuildOptions struct {
 	// when using an untrusted builder.
 	LifecycleImage string
 
-	// The location at with to mount the AppDir in the build image.
+	// The location at which to mount the AppDir in the build image.
 	Workspace string
 }
 

--- a/build.go
+++ b/build.go
@@ -155,6 +155,9 @@ type BuildOptions struct {
 	// The lifecycle image that will be used for the analysis, restore and export phases
 	// when using an untrusted builder.
 	LifecycleImage string
+
+	// The location at with to mount the AppDir in the build image.
+	Workspace string
 }
 
 // ProxyConfig specifies proxy setting to be set as environment variables in a container.
@@ -303,6 +306,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		DefaultProcessType: opts.DefaultProcessType,
 		FileFilter:         fileFilter,
 		CacheImage:         opts.CacheImage,
+		Workspace:          opts.Workspace,
 	}
 
 	lifecycleVersion := ephemeralBuilder.LifecycleDescriptor().Info.Version

--- a/build_test.go
+++ b/build_test.go
@@ -141,6 +141,17 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#Build", func() {
+		when("Workspace option", func() {
+			it("uses the specified dir", func() {
+				h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+					Workspace: "app",
+					Builder: defaultBuilderName,
+					Image:   "example.com/some/repo:tag",
+				}))
+				h.AssertEq(t, fakeLifecycle.Opts.Workspace, "app")
+			})
+		})
+
 		when("Image option", func() {
 			it("is required", func() {
 				h.AssertError(t, subject.Build(context.TODO(), BuildOptions{

--- a/build_test.go
+++ b/build_test.go
@@ -145,8 +145,8 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 			it("uses the specified dir", func() {
 				h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
 					Workspace: "app",
-					Builder: defaultBuilderName,
-					Image:   "example.com/some/repo:tag",
+					Builder:   defaultBuilderName,
+					Image:     "example.com/some/repo:tag",
 				}))
 				h.AssertEq(t, fakeLifecycle.Opts.Workspace, "app")
 			})

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -90,6 +90,10 @@ func (l *LifecycleExecution) AppPath() string {
 	return l.opts.AppPath
 }
 
+func (l LifecycleExecution) AppDir() string {
+	return l.mountPaths.appDir()
+}
+
 func (l *LifecycleExecution) AppVolume() string {
 	return l.appVolume
 }

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -56,7 +56,7 @@ func NewLifecycleExecution(logger logging.Logger, docker client.CommonAPIClient,
 		platformAPI:  latestSupportedPlatformAPI,
 		opts:         opts,
 		os:           osType,
-		mountPaths:   mountPathsForOS(osType),
+		mountPaths:   mountPathsForOS(osType, opts.Workspace),
 	}
 
 	return exec, nil

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -135,6 +136,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 
 				lifecycle, err := build.NewLifecycleExecution(logger, docker, opts)
 				h.AssertNil(t, err)
+				h.AssertEq(t, filepath.Base(lifecycle.AppDir()), "workspace")
 
 				err = lifecycle.Run(context.Background(), func(execution *build.LifecycleExecution) build.PhaseFactory {
 					return fakePhaseFactory
@@ -198,19 +200,12 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 
 				lifecycle, err := build.NewLifecycleExecution(logger, docker, opts)
 				h.AssertNil(t, err)
+				h.AssertEq(t, filepath.Base(lifecycle.AppDir()), "app")
 
 				err = lifecycle.Run(context.Background(), func(execution *build.LifecycleExecution) build.PhaseFactory {
 					return fakePhaseFactory
 				})
 				h.AssertNil(t, err)
-
-				h.AssertEq(t, len(fakePhaseFactory.NewCalledWithProvider), 1)
-
-				for _, entry := range fakePhaseFactory.NewCalledWithProvider {
-					if entry.Name() == "creator" {
-						h.AssertSliceContains(t, entry.ContainerConfig().Cmd, "/some/image")
-					}
-				}
 			})
 		})
 

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -68,6 +68,7 @@ type LifecycleOptions struct {
 	Volumes            []string
 	DefaultProcessType string
 	FileFilter         func(string) bool
+	Workspace          string
 }
 
 func NewLifecycleExecutor(logger logging.Logger, docker client.CommonAPIClient) *LifecycleExecutor {

--- a/internal/build/mount_paths.go
+++ b/internal/build/mount_paths.go
@@ -5,18 +5,24 @@ import "strings"
 type mountPaths struct {
 	volume    string
 	separator string
+	workspace string
 }
 
-func mountPathsForOS(os string) mountPaths {
+func mountPathsForOS(os, workspace string) mountPaths {
+	if workspace == "" {
+		workspace = "workspace"
+	}
 	if os == "windows" {
 		return mountPaths{
 			volume:    `c:`,
 			separator: `\`,
+			workspace: workspace,
 		}
 	}
 	return mountPaths{
 		volume:    "",
 		separator: "/",
+		workspace: workspace,
 	}
 }
 
@@ -33,7 +39,7 @@ func (m mountPaths) stackPath() string {
 }
 
 func (m mountPaths) appDirName() string {
-	return "workspace"
+	return m.workspace
 }
 
 func (m mountPaths) appDir() string {

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -40,6 +40,7 @@ type BuildFlags struct {
 	Buildpacks         []string
 	Volumes            []string
 	AdditionalTags     []string
+	Workspace          string
 }
 
 // Build an image from source code
@@ -143,6 +144,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				ProjectDescriptorBaseDir: filepath.Dir(actualDescriptorPath),
 				ProjectDescriptor:        descriptor,
 				CacheImage:               flags.CacheImage,
+				Workspace:                flags.Workspace,
 				LifecycleImage:           lifecycleImage,
 			}); err != nil {
 				return errors.Wrap(err, "failed to build")
@@ -181,6 +183,7 @@ This option may set DOCKER_HOST environment variable for the build container if 
 	cmd.Flags().StringSliceVarP(&buildFlags.AdditionalTags, "tag", "t", nil, "Additional tags to push the output image to."+multiValueHelp("tag"))
 	cmd.Flags().BoolVar(&buildFlags.TrustBuilder, "trust-builder", false, "Trust the provided builder\nAll lifecycle phases will be run in a single container (if supported by the lifecycle).")
 	cmd.Flags().StringArrayVar(&buildFlags.Volumes, "volume", nil, "Mount host volume into the build container, in the form '<host path>:<target path>[:<options>]'.\n- 'host path': Name of the volume or absolute directory path to mount.\n- 'target path': The path where the file or directory is available in the container.\n- 'options' (default \"ro\"): An optional comma separated list of mount options.\n    - \"ro\", volume contents are read-only.\n    - \"rw\", volume contents are readable and writeable.\n    - \"volume-opt=<key>=<value>\", can be specified more than once, takes a key-value pair consisting of the option name and its value."+multiValueHelp("volume"))
+	cmd.Flags().StringVar(&buildFlags.Workspace, "workspace", "", "Location at which to mount the app dir in the build image")
 }
 
 func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackClient, logger logging.Logger) error {


### PR DESCRIPTION
## Summary

Allow the `workspace` directory to be configurable. 

## Output

#### Before

```
$ pack build ...
```

#### After

```
$ pack build --workspace app ...
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1121
