### PR TITLE
Pass mountPaths.appDirName to lifecycle as -app arg

### DIFF
--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -193,7 +193,7 @@ func (l *LifecycleExecution) Create(ctx context.Context, publish bool, dockerHos
 
 	opts := []PhaseConfigProviderOperation{
 		WithFlags(l.withLogLevel(flags...)...),
-		WithArgs(repoName),
+		WithArgs("-app", l.mountPaths.appDirName(), repoName),
 		WithNetwork(networkMode),
 		cacheOpts,
 		WithContainerOperations(CopyDir(l.opts.AppPath, l.mountPaths.appDir(), l.opts.Builder.UID(), l.opts.Builder.GID(), l.os, l.opts.FileFilter)),
@@ -225,7 +225,7 @@ func (l *LifecycleExecution) Detect(ctx context.Context, networkMode string, vol
 		l,
 		WithLogPrefix("detector"),
 		WithArgs(
-			l.withLogLevel()...,
+			l.withLogLevel("-app", l.mountPaths.appDirName())...,
 		),
 		WithNetwork(networkMode),
 		WithBinds(volumes...),
@@ -357,7 +357,7 @@ func (l *LifecycleExecution) Build(ctx context.Context, networkMode string, volu
 		"builder",
 		l,
 		WithLogPrefix("builder"),
-		WithArgs(l.withLogLevel()...),
+		WithArgs(l.withLogLevel("-app", l.mountPaths.appDirName())...),
 		WithNetwork(networkMode),
 		WithBinds(volumes...),
 	)

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -193,7 +193,7 @@ func (l *LifecycleExecution) Create(ctx context.Context, publish bool, dockerHos
 
 	opts := []PhaseConfigProviderOperation{
 		WithFlags(l.withLogLevel(flags...)...),
-		WithArgs("-app", l.mountPaths.appDirName(), repoName),
+		WithArgs("-app", l.mountPaths.appDir(), repoName),
 		WithNetwork(networkMode),
 		cacheOpts,
 		WithContainerOperations(CopyDir(l.opts.AppPath, l.mountPaths.appDir(), l.opts.Builder.UID(), l.opts.Builder.GID(), l.os, l.opts.FileFilter)),
@@ -225,7 +225,7 @@ func (l *LifecycleExecution) Detect(ctx context.Context, networkMode string, vol
 		l,
 		WithLogPrefix("detector"),
 		WithArgs(
-			l.withLogLevel("-app", l.mountPaths.appDirName())...,
+			l.withLogLevel("-app", l.mountPaths.appDir())...,
 		),
 		WithNetwork(networkMode),
 		WithBinds(volumes...),
@@ -357,7 +357,7 @@ func (l *LifecycleExecution) Build(ctx context.Context, networkMode string, volu
 		"builder",
 		l,
 		WithLogPrefix("builder"),
-		WithArgs(l.withLogLevel("-app", l.mountPaths.appDirName())...),
+		WithArgs(l.withLogLevel("-app", l.mountPaths.appDir())...),
 		WithNetwork(networkMode),
 		WithBinds(volumes...),
 	)

--- a/internal/build/mount_paths.go
+++ b/internal/build/mount_paths.go
@@ -1,6 +1,9 @@
 package build
 
-import "strings"
+import (
+	"path"
+	"strings"
+)
 
 type mountPaths struct {
 	volume    string
@@ -39,7 +42,7 @@ func (m mountPaths) stackPath() string {
 }
 
 func (m mountPaths) appDirName() string {
-	return m.separator + m.workspace
+	return path.Join(m.separator, m.workspace)
 }
 
 func (m mountPaths) appDir() string {

--- a/internal/build/mount_paths.go
+++ b/internal/build/mount_paths.go
@@ -39,7 +39,7 @@ func (m mountPaths) stackPath() string {
 }
 
 func (m mountPaths) appDirName() string {
-	return m.workspace
+	return m.separator + m.workspace
 }
 
 func (m mountPaths) appDir() string {

--- a/internal/build/mount_paths.go
+++ b/internal/build/mount_paths.go
@@ -1,9 +1,6 @@
 package build
 
-import (
-	"path"
-	"strings"
-)
+import "strings"
 
 type mountPaths struct {
 	volume    string
@@ -42,7 +39,7 @@ func (m mountPaths) stackPath() string {
 }
 
 func (m mountPaths) appDirName() string {
-	return path.Join(m.separator, m.workspace)
+	return m.workspace
 }
 
 func (m mountPaths) appDir() string {


### PR DESCRIPTION
## Summary

Fast follow fix for #1141

## Output

#### Before

app dir was mounted, but lifecycle was not `cd`-ing into it.

#### After

The provide workspace becomes the `CNB_APP_DIR`

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

