### PR TITLE
Fixing Gosec HIGH warnings

### DIFF
--- a/build.go
+++ b/build.go
@@ -2,8 +2,8 @@ package pack
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -842,10 +842,15 @@ func (c *Client) createEphemeralBuilder(rawBuilderImage imgutil.Image, env map[s
 	return bldr, nil
 }
 
+// Returns a string iwith lowercase a-z, of length n
 func randString(n int) string {
 	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
 	for i := range b {
-		b[i] = 'a' + byte(rand.Intn(26))
+		b[i] = 'a' + (b[i] % 26)
 	}
 	return string(b)
 }

--- a/new_buildpack.go
+++ b/new_buildpack.go
@@ -63,6 +63,9 @@ func (c *Client) NewBuildpack(ctx context.Context, opts NewBuildpackOptions) err
 		},
 	}
 
+	// The following line's comment is for gosec, it will ignore rule 301 in this case
+	// G301: Expect directory permissions to be 0750 or less
+	/* #nosec G301 */
 	if err := os.MkdirAll(opts.Path, 0755); err != nil {
 		return err
 	}
@@ -102,6 +105,9 @@ func createBinScript(path, name, contents string, c *Client) error {
 
 	_, err := os.Stat(binFile)
 	if os.IsNotExist(err) {
+		// The following line's comment is for gosec, it will ignore rule 301 in this case
+		// G301: Expect directory permissions to be 0750 or less
+		/* #nosec G301 */
 		if err := os.MkdirAll(binDir, 0755); err != nil {
 			return err
 		}

--- a/new_buildpack.go
+++ b/new_buildpack.go
@@ -111,7 +111,9 @@ func createBinScript(path, name, contents string, c *Client) error {
 		if err := os.MkdirAll(binDir, 0755); err != nil {
 			return err
 		}
-
+		// The following line's comment is for gosec, it will ignore rule 306 in this case
+		// G306: Expect WriteFile permissions to be 0600 or less
+		/* #nosec G306 */
 		err = ioutil.WriteFile(binFile, []byte(contents), 0755)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary
Clears a few HIGH warnings from the [gosec](https://github.com/securego/gosec) report, namely:

- G301 : Poor file permissions used when creating a directory
- G306 : Poor file permissions used when writing to a new file
- G404 : Insecure random number source (rand)

There are three remaining MEDIUM ones that I will look into separately. (G304, G307)

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [X] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
