### PR TITLE
Removing redundant error checks before return

### DIFF
--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -547,12 +547,7 @@ func CopyFileE(src, dst string) error {
 	}
 
 	modifiedtime := time.Time{}
-	err = os.Chtimes(dst, modifiedtime, modifiedtime)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return os.Chtimes(dst, modifiedtime, modifiedtime)
 }
 
 func RecursiveCopy(t *testing.T, src, dst string) {
@@ -592,12 +587,8 @@ func RecursiveCopyE(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	err = os.Chmod(dst, 0775)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return os.Chmod(dst, 0775)
 }
 
 func RequireDocker(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Sreehari Mohan <sreeharimohan11@gmail.com>

## Summary
Simple bug fix to ensure there is no redundant code while returning `error`. Since the last function was only returning an `error` the error check is superfluous.

## Output
No change to the output


## Documentation
NA

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
NA

Resolves #___
