### PR TITLE
Change file permissions to 0600.

### DIFF
--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -286,7 +286,7 @@ func (r *Cache) writeEntry(b Buildpack) (string, error) {
 		}
 	}
 
-	f, err := os.OpenFile(index, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
+	f, err := os.OpenFile(index, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return "", errors.Wrapf(err, "creating buildpack file: %s/%s", ns, name)
 	}

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -588,7 +588,7 @@ func RecursiveCopyE(src, dst string) error {
 		return err
 	}
 
-	return os.Chmod(dst, 0775)
+	return os.Chmod(dst, 0600)
 }
 
 func RequireDocker(t *testing.T) {
@@ -697,7 +697,7 @@ func RecursiveCopyNow(t *testing.T, src, dst string) {
 			modifiedTime := time.Now().Local()
 			err = os.Chtimes(filepath.Join(dst, fi.Name()), modifiedTime, modifiedTime)
 			AssertNil(t, err)
-			err = os.Chmod(filepath.Join(dst, fi.Name()), 0664)
+			err = os.Chmod(filepath.Join(dst, fi.Name()), 0600)
 			AssertNil(t, err)
 		}
 		if fi.IsDir() {
@@ -709,7 +709,7 @@ func RecursiveCopyNow(t *testing.T, src, dst string) {
 	modifiedTime := time.Now().Local()
 	err = os.Chtimes(dst, modifiedTime, modifiedTime)
 	AssertNil(t, err)
-	err = os.Chmod(dst, 0775)
+	err = os.Chmod(dst, 0600)
 	AssertNil(t, err)
 }
 


### PR DESCRIPTION
Signed-off-by: Rahul Grover <rahulgrover99@gmail.com>

## Summary
Changes to use correct file permissions while using chmod.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
`os.Chmod(dst, 0775)`
`os.OpenFile(index, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)`

#### After
`os.Chmod(dst, 0600)`
`os.OpenFile(index, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)`
## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves 
G302: Poor file permissions used with chmod.
