### PR TITLE
Enables directory-buildpack support for WCOW/LCOW

### DIFF
--- a/create_builder.go
+++ b/create_builder.go
@@ -254,11 +254,6 @@ func (c *Client) addBuildpacksToBuilder(ctx context.Context, opts CreateBuilderO
 
 			c.logger.Debugf("Downloading buildpack from URI: %s", style.Symbol(b.URI))
 
-			err = ensureBPSupport(b.URI)
-			if err != nil {
-				return err
-			}
-
 			blob, err := c.downloader.Download(ctx, b.URI)
 			if err != nil {
 				return errors.Wrapf(err, "downloading buildpack from %s", style.Symbol(b.URI))


### PR DESCRIPTION
- Re-enabled for `pack build ... --buildpack <directory>` and `pack builder create ...` with `builder.toml` containing buildpacks with directories.
- Previously disabled due to needing to handle file permission however pack already sets appropriate default permissions, though further improvements can be added based on feedback.

Signed-off-by: Micah Young <ymicah@vmware.com>

## Summary
This removes the guard disabling directory buildpacks on LCOW/WCOW. Directory-based buildpacks can now be used for builders and within apps with appropriate project.toml. Test coverage that previously only ran on Linux, now also runs on Windows (LCOW & WCOW).

## Output
#### Before
```powershell
cd samples

# builder create
pack builder create mynanoserver --config .\builders\nanoserver-1809\builder.toml

# output
ERROR: failed to add buildpacks to builder: buildpack file:///W:/samples/buildpacks/hello-universe-windows: directory-b
ased buildpacks are not currently supported on Windows

# build
pack build myapp --path .\apps\batch-script\ --builder cnbs/sample-builder:nanoserver-1809        

# output
ERROR: failed to build: checking support: buildpack file:///W:/samples/apps/batch-script/batch-script-buildpack: direct
ory-based buildpacks are not currently supported on Windows
```

#### After
The images generated are equivalent to current sample images in terms of the relevant buildpack files. The image IDs are different due to unrelated metadata causing slightly different image digests.

This example generates tarball saves of sample builders and compares the tarball entries using gnu-tar verbose output:

##### nanoserver sample builder on Windows host with local WCOW daemon
```powershell
cd samples
.\pack-pr.exe builder create mynanoserver --config .\builders\nanoserver-1809\builder.toml
docker save mynanoserver -o nanoserver-pr.tar 
docker save cnbs/sample-builder:nanoserver-1809 -o nanoserver-cnbs.tar
```

##### alpine sample builder on Windows host with local LCOW daemon
```powershell
cd samples
.\pack-pr.exe builder create myalpine --config .\builders\alpine\builder.toml
docker save myalpine -o alpine-pr.tar 
docker save cnbs/sample-builder:alpine -o alpine-cnbs.tar
```

##### compare builder image tarballs in POSIX environment (for gnu-tar) containing copied tarballs:
```bash
diff --report-identical-files   \
  <(gtar x -O -f alpine-cnbs.tar --wildcards '*/layer.tar' | gtar -t -i -v) \
  <(gtar x -O -f alpine-pr.tar   --wildcards '*/layer.tar' | gtar -t -i -v)

# output
Files /dev/fd/63 and /dev/fd/62 are identical

diff --report-identical-files   \
  <(gtar x -O -f nanoserver-cnbs.tar --wildcards '*/layer.tar' | gtar -t -i -v --pax-option "delete=*I*")  \
  <(gtar x -O -f nanoserver-pr.tar   --wildcards '*/layer.tar' | gtar -t -i -v --pax-option "delete=*I*")

# output
Files /dev/fd/63 and /dev/fd/62 are identical
```

## Documentation
The only needed change I could find would be to remove this line:

https://github.com/buildpacks/docs/blame/71f3b301ad809341b0e84e9363a4024694b9eb65/content/docs/app-developer-guide/specific-buildpacks.md#L104

Other existing [documentation](https://buildpacks.io/docs/buildpack-author-guide/create-buildpack/building-blocks-cnb#:~:text=The%20pack%20build%20command) and walkthroughs accurately describing the behavior.

- Should this change be documented?
    - [x] Yes, see #___
    - [ ] No

## Related

Resolves: N/A no existing issue
