### PR TITLE
Gitpodified the repository

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,14 @@
+
+tasks:
+  - init: make build
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: true
+
+vscode:
+  extensions:
+    - golang.go

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,6 +17,11 @@
         * `choco install cygwin make -y`
         * `[Environment]::SetEnvironmentVariable("PATH", "C:\tools\cygwin\bin;$ENV:PATH", "MACHINE")`
 
+Alternatively, you can use Gitpod to run pre-configured dev envrionment in the cloud right from your browser
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/buildpacks/pack)
+
+
 ### Windows Caveats
 
 * Symlinks - Some of our tests attempt to create symlinks. On Windows, this requires the [permission to be provided](https://stackoverflow.com/a/24353758).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![GitHub license](https://img.shields.io/github/license/buildpacks/pack)](https://github.com/buildpacks/pack/blob/main/LICENSE)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4748/badge)](https://bestpractices.coreinfrastructure.org/projects/4748)
 [![Slack](https://img.shields.io/badge/slack-join-ff69b4.svg?logo=slack)](https://slack.buildpacks.io/)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/buildpacks/pack)
 
 `pack` makes it easy for...
 - [**App Developers**][app-dev] to use buildpacks to convert code into runnable images.


### PR DESCRIPTION
Hi buildpacks team! 👋

here is a PR that fully-automates the dev setup of buildpacks with Gitpod, providing anyone with a pre-built, browser-based development environment in one click:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/buildpacks/pack)

<img width="1377" alt="Screen Shot 2021-05-04 at 17 20 44" src="https://user-images.githubusercontent.com/377752/117027935-7b48bd00-acfd-11eb-8cf3-d7fe43e0940f.png">

### What it does

* Comes with all buildpacks dependencies pre-installed
* Runs `make build` ahead-of-time so you don't need to wait
* Gives anyone immediate access to the pre-compiled buildpacks CLI, and allows to easily edit & rebuild the code

I hope this can make life easier for contributors, and for maintainers who need to review many PRs (hint: you can already open this PR in Gitpod to easily review & test it without messing up your local checkout).

### Notes & caveats
- The unit tests seem to fail eventually on Gitpod, but I have no indication why. This would be worthwhile investigating deeper.

And I'm looking forward to your feedback on this PR! 🚀

Signed-off-by: Jan Koehnlein <jan@gitpod.io>

