### PR TITLE
errcheck fixes for build

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -132,12 +132,12 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it.After(func() {
-		defaultBuilderImage.Cleanup()
-		fakeDefaultRunImage.Cleanup()
-		fakeMirror1.Cleanup()
-		fakeMirror2.Cleanup()
+		h.AssertNil(t, defaultBuilderImage.Cleanup())
+		h.AssertNil(t, fakeDefaultRunImage.Cleanup())
+		h.AssertNil(t, fakeMirror1.Cleanup())
+		h.AssertNil(t, fakeMirror2.Cleanup())
 		os.RemoveAll(tmpDir)
-		fakeLifecycleImage.Cleanup()
+		h.AssertNil(t, fakeLifecycleImage.Cleanup())
 	})
 
 	when("#Build", func() {
@@ -226,8 +226,8 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it.After(func() {
-					remoteRunImage.Cleanup()
-					builderWithoutLifecycleImageOrCreator.Cleanup()
+					h.AssertNil(t, remoteRunImage.Cleanup())
+					h.AssertNil(t, builderWithoutLifecycleImageOrCreator.Cleanup())
 					h.AssertNil(t, builtImage.Cleanup())
 				})
 
@@ -254,7 +254,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it.After(func() {
-					builtImage.Cleanup()
+					h.AssertNil(t, builtImage.Cleanup())
 				})
 
 				it("only prints app name and sha", func() {
@@ -462,8 +462,8 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it.After(func() {
-					customBuilderImage.Cleanup()
-					fakeRunImage.Cleanup()
+					h.AssertNil(t, customBuilderImage.Cleanup())
+					h.AssertNil(t, fakeRunImage.Cleanup())
 				})
 
 				it("it uses the provided builder", func() {
@@ -489,7 +489,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it.After(func() {
-				fakeRunImage.Cleanup()
+				h.AssertNil(t, fakeRunImage.Cleanup())
 			})
 
 			when("run image stack matches the builder stack", func() {
@@ -588,8 +588,8 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it.After(func() {
-						fakeLocalMirror.Cleanup()
-						fakeLocalMirror1.Cleanup()
+						h.AssertNil(t, fakeLocalMirror.Cleanup())
+						h.AssertNil(t, fakeLocalMirror1.Cleanup())
 					})
 
 					when("Publish is true", func() {

--- a/internal/build/container_ops_test.go
+++ b/internal/build/container_ops_test.go
@@ -352,12 +352,18 @@ func cleanupContainer(ctx context.Context, ctrID string) {
 	}
 
 	// remove container
-	ctrClient.ContainerRemove(ctx, ctrID, types.ContainerRemoveOptions{})
+	err = ctrClient.ContainerRemove(ctx, ctrID, types.ContainerRemoveOptions{})
+	if err != nil {
+		return
+	}
 
 	// remove volumes
 	for _, m := range inspect.Mounts {
 		if m.Type == mount.TypeVolume {
-			ctrClient.VolumeRemove(ctx, m.Name, true)
+			err = ctrClient.VolumeRemove(ctx, m.Name, true)
+			if err != nil {
+				return
+			}
 		}
 	}
 }

--- a/internal/build/phase_test.go
+++ b/internal/build/phase_test.go
@@ -167,7 +167,7 @@ func testPhase(t *testing.T, when spec.G, it spec.S) {
 				configProvider = build.NewPhaseConfigProvider(phaseName, lifecycleExec, build.WithArgs("read", "/workspace/fake-app-file"))
 				readPhase2 := phaseFactory.New(configProvider)
 				err := readPhase2.Run(context.TODO())
-				readPhase2.Cleanup()
+				h.AssertNil(t, readPhase2.Cleanup())
 				h.AssertNotNil(t, err)
 				h.AssertContains(t, outBuf.String(), "failed to read file")
 			})
@@ -335,7 +335,8 @@ func testPhase(t *testing.T, when spec.G, it spec.S) {
 
 			when("#WithBinds", func() {
 				it.After(func() {
-					docker.VolumeRemove(context.TODO(), "some-volume", true)
+					err := docker.VolumeRemove(context.TODO(), "some-volume", true)
+					h.AssertNil(t, err)
 				})
 
 				it("mounts volumes inside container", func() {
@@ -450,7 +451,7 @@ func assertAppModTimePreserved(t *testing.T, lifecycle *build.LifecycleExecution
 func assertRunSucceeds(t *testing.T, phase build.RunnerCleaner, outBuf *bytes.Buffer, errBuf *bytes.Buffer) {
 	t.Helper()
 	if err := phase.Run(context.TODO()); err != nil {
-		phase.Cleanup()
+		h.AssertNil(t, phase.Cleanup())
 		t.Fatalf("Failed to run phase: %s\nstdout:\n%s\nstderr:\n%s\n", err, outBuf.String(), errBuf.String())
 	}
 	phase.Cleanup()

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -136,7 +136,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it.After(func() {
-		baseImage.Cleanup()
+		h.AssertNil(t, baseImage.Cleanup())
 		mockController.Finish()
 	})
 
@@ -266,7 +266,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it.After(func() {
-			baseImage.Cleanup()
+			h.AssertNil(t, baseImage.Cleanup())
 		})
 
 		when("#Save", func() {
@@ -405,7 +405,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 
 				h.AssertNil(t, baseImage.AddLayer(layerFile))
-				baseImage.Save()
+				h.AssertNil(t, baseImage.Save())
 
 				h.AssertNil(t, subject.Save(logger, builder.CreatorMetadata{}))
 				h.AssertEq(t, baseImage.IsSaved(), true)


### PR DESCRIPTION
Signed-off-by: arcolife <archit.py@gmail.com>

## Summary

adds error checks to fix golangci-lint's `Error return value of <> is not checked `

## Output
<!-- If applicable, please provide examples of the output changes. -->

- Should this change be documented?
    - [x] No

