### PR TITLE
new errcheck fixes

### DIFF
--- a/internal/build/phase_test.go
+++ b/internal/build/phase_test.go
@@ -450,10 +450,10 @@ func assertAppModTimePreserved(t *testing.T, lifecycle *build.LifecycleExecution
 func assertRunSucceeds(t *testing.T, phase build.RunnerCleaner, outBuf *bytes.Buffer, errBuf *bytes.Buffer) {
 	t.Helper()
 	if err := phase.Run(context.TODO()); err != nil {
-		phase.Cleanup()
+		h.AssertNil(t, phase.Cleanup())
 		t.Fatalf("Failed to run phase: %s\nstdout:\n%s\nstderr:\n%s\n", err, outBuf.String(), errBuf.String())
 	}
-	phase.Cleanup()
+	h.AssertNil(t, phase.Cleanup())
 }
 
 func CreateFakeLifecycleExecution(logger logging.Logger, docker client.CommonAPIClient, appDir string, repoName string) (*build.LifecycleExecution, error) {

--- a/package_buildpack_test.go
+++ b/package_buildpack_test.go
@@ -729,9 +729,12 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNotNil(t, registryFixture)
 
 					packageImage := fakes.NewImage("example.com/some/package@sha256:74eb48882e835d8767f62940d453eb96ed2737de3a16573881dcea7dea769df7", "", nil)
-					packageImage.AddLayerWithDiffID("testdata/empty-file", "sha256:xxx")
-					packageImage.SetLabel("io.buildpacks.buildpackage.metadata", `{"id":"example/foo", "version":"1.1.0", "stacks":[{"id":"some.stack.id"}]}`)
-					packageImage.SetLabel("io.buildpacks.buildpack.layers", `{"example/foo":{"1.1.0":{"api": "0.2", "layerDiffID":"sha256:xxx", "stacks":[{"id":"some.stack.id"}]}}}`)
+					err = packageImage.AddLayerWithDiffID("testdata/empty-file", "sha256:xxx")
+					h.AssertNil(t, err)
+					err = packageImage.SetLabel("io.buildpacks.buildpackage.metadata", `{"id":"example/foo", "version":"1.1.0", "stacks":[{"id":"some.stack.id"}]}`)
+					h.AssertNil(t, err)
+					err = packageImage.SetLabel("io.buildpacks.buildpack.layers", `{"example/foo":{"1.1.0":{"api": "0.2", "layerDiffID":"sha256:xxx", "stacks":[{"id":"some.stack.id"}]}}}`)
+					h.AssertNil(t, err)
 					mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), true, pubcfg.PullAlways).Return(packageImage, nil)
 
 					packHome := filepath.Join(tmpDir, "packHome")

--- a/pull_buildpack_test.go
+++ b/pull_buildpack_test.go
@@ -91,8 +91,8 @@ func testPullBuildpack(t *testing.T, when spec.G, it spec.S) {
 	when("pulling from a docker registry", func() {
 		it("should fetch the image", func() {
 			packageImage := fakes.NewImage("example.com/some/package:1.0.0", "", nil)
-			packageImage.SetLabel("io.buildpacks.buildpackage.metadata", `{}`)
-			packageImage.SetLabel("io.buildpacks.buildpack.layers", `{}`)
+			h.AssertNil(t, packageImage.SetLabel("io.buildpacks.buildpackage.metadata", `{}`))
+			h.AssertNil(t, packageImage.SetLabel("io.buildpacks.buildpack.layers", `{}`))
 			mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), true, config.PullAlways).Return(packageImage, nil)
 
 			h.AssertNil(t, subject.PullBuildpack(context.TODO(), pack.PullBuildpackOptions{

--- a/rebase_test.go
+++ b/rebase_test.go
@@ -59,9 +59,9 @@ func testRebase(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it.After(func() {
-			fakeAppImage.Cleanup()
-			fakeRunImage.Cleanup()
-			fakeRunImageMirror.Cleanup()
+			h.AssertNil(t, fakeAppImage.Cleanup())
+			h.AssertNil(t, fakeRunImage.Cleanup())
+			h.AssertNil(t, fakeRunImageMirror.Cleanup())
 		})
 
 		when("#Rebase", func() {
@@ -76,7 +76,7 @@ func testRebase(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it.After(func() {
-						fakeCustomRunImage.Cleanup()
+						h.AssertNil(t, fakeCustomRunImage.Cleanup())
 					})
 
 					it("uses the run image provided by the user", func() {
@@ -132,7 +132,7 @@ func testRebase(t *testing.T, when spec.G, it spec.S) {
 						})
 
 						it.After(func() {
-							fakeLocalMirror.Cleanup()
+							h.AssertNil(t, fakeLocalMirror.Cleanup())
 						})
 
 						it("chooses a matching local mirror first", func() {
@@ -172,7 +172,7 @@ func testRebase(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it.After(func() {
-					fakeRemoteRunImage.Cleanup()
+					h.AssertNil(t, fakeRemoteRunImage.Cleanup())
 				})
 
 				when("is false", func() {


### PR DESCRIPTION
Signed-off-by: arcolife <archit.py@gmail.com>

## Summary

New fixes in addition to https://github.com/buildpacks/pack/pull/1159
adds error checks to fix golangci-lint's Error return value of <> is not checked

## Documentation

- Should this change be documented?
    - [x] No

