### PR TITLE
Make some AssertNils in it.After non-fatal

### DIFF
--- a/internal/build/phase_test.go
+++ b/internal/build/phase_test.go
@@ -450,10 +450,10 @@ func assertAppModTimePreserved(t *testing.T, lifecycle *build.LifecycleExecution
 func assertRunSucceeds(t *testing.T, phase build.RunnerCleaner, outBuf *bytes.Buffer, errBuf *bytes.Buffer) {
 	t.Helper()
 	if err := phase.Run(context.TODO()); err != nil {
-		h.AssertNil(t, phase.Cleanup())
+		h.AssertNilE(t, phase.Cleanup())
 		t.Fatalf("Failed to run phase: %s\nstdout:\n%s\nstderr:\n%s\n", err, outBuf.String(), errBuf.String())
 	}
-	h.AssertNil(t, phase.Cleanup())
+	h.AssertNilE(t, phase.Cleanup())
 }
 
 func CreateFakeLifecycleExecution(logger logging.Logger, docker client.CommonAPIClient, appDir string, repoName string) (*build.LifecycleExecution, error) {

--- a/rebase_test.go
+++ b/rebase_test.go
@@ -59,9 +59,9 @@ func testRebase(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it.After(func() {
-			h.AssertNil(t, fakeAppImage.Cleanup())
-			h.AssertNil(t, fakeRunImage.Cleanup())
-			h.AssertNil(t, fakeRunImageMirror.Cleanup())
+			h.AssertNilE(t, fakeAppImage.Cleanup())
+			h.AssertNilE(t, fakeRunImage.Cleanup())
+			h.AssertNilE(t, fakeRunImageMirror.Cleanup())
 		})
 
 		when("#Rebase", func() {
@@ -76,7 +76,7 @@ func testRebase(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it.After(func() {
-						h.AssertNil(t, fakeCustomRunImage.Cleanup())
+						h.AssertNilE(t, fakeCustomRunImage.Cleanup())
 					})
 
 					it("uses the run image provided by the user", func() {
@@ -132,7 +132,7 @@ func testRebase(t *testing.T, when spec.G, it spec.S) {
 						})
 
 						it.After(func() {
-							h.AssertNil(t, fakeLocalMirror.Cleanup())
+							h.AssertNilE(t, fakeLocalMirror.Cleanup())
 						})
 
 						it("chooses a matching local mirror first", func() {
@@ -172,7 +172,7 @@ func testRebase(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it.After(func() {
-					h.AssertNil(t, fakeRemoteRunImage.Cleanup())
+					h.AssertNilE(t, fakeRemoteRunImage.Cleanup())
 				})
 
 				when("is false", func() {

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -259,6 +259,15 @@ func AssertMatch(t *testing.T, actual string, expected string) {
 	}
 }
 
+// AssertNilE checks for nil value, if not nil it sets test as failed without stopping execution.
+func AssertNilE(t *testing.T, actual interface{}) {
+	t.Helper()
+	if !isNil(actual) {
+		t.Errorf("Expected nil: %s", actual)
+	}
+}
+
+// AssertNil checks for nil value, if not nil it fails the test and stops execution immediately.
 func AssertNil(t *testing.T, actual interface{}) {
 	t.Helper()
 	if !isNil(actual) {


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->

This is a follow up to the bug bash PRs that address static analysis reports where the error is being unchecked (ie. https://github.com/buildpacks/pack/pull/1160). 

Prior to this change any calls in `it.After` that use `h.AssertNil` will immediately stop all further "after" steps. This typically involved additional clean up. 

With this latest change, and the introduction of `h.AssertNilE`, we now check for errors but continue executing while marking the test as a failure to ensure we don't overlook the cleanup error.

## Output
<!-- If applicable, please provide examples of the output changes. -->

The following is a quick test based on the following test file:

```
package testhelpers_test

import (
	"errors"
	"testing"

	h "github.com/buildpacks/pack/testhelpers"
	"github.com/heroku/color"
	"github.com/sclevine/spec"
	"github.com/sclevine/spec/report"
)

func TestTestHelpers(t *testing.T) {
	color.Disable(true)
	defer color.Disable(false)
	spec.Run(t, "Test Helpers", testTestHelpers, spec.Sequential(), spec.Report(report.Terminal{}))
}

func testTestHelpers(t *testing.T, when spec.G, it spec.S) {
	when("2 non-fatals in after", func() {
		it.After(func() {
			h.AssertNilE(t, echoError(t, "after error 1"))
			h.AssertNilE(t, echoError(t, "after error 2"))
		})

		when("2 non-fatals in before", func() {
			it.Before(func() {
				h.AssertNilE(t, echoError(t, "before error 1"))
				h.AssertNilE(t, echoError(t, "before error 2"))
			})

			when("2 non-fatal in run", func() {
				it("run", func() {
					h.AssertNilE(t, echoError(t, "run error 1"))
					h.AssertNilE(t, echoError(t, "run error 2"))
				})
			})

			when("1 fatal + 1 non-fatal in run", func() {
				it("run", func() {
					h.AssertNil(t, echoError(t, "run error 1"))
					h.AssertNilE(t, echoError(t, "run error 2"))
				})
			})
		})

		when("1 fatal + 1 non-fatal in before", func() {
			it.Before(func() {
				h.AssertNil(t, echoError(t, "before error 1"))
				h.AssertNilE(t, echoError(t, "before error 2"))
			})

			when("2 non-fatal in run", func() {
				it("run", func() {
					h.AssertNilE(t, echoError(t, "run error 1"))
					h.AssertNilE(t, echoError(t, "run error 2"))
				})
			})
		})
	})

	when("fatal in after", func() {
		it.After(func() {
			h.AssertNil(t, echoError(t, "after error 1"))
			h.AssertNilE(t, echoError(t, "after error 2"))
		})

		it("run", func() {
			h.AssertNilE(t, echoError(t, "run error 1"))
			h.AssertNilE(t, echoError(t, "run error 2"))
		})
	})
}

func echoError(t *testing.T, msg string) error {
	t.Log(msg)
	return errors.New("oops, i failed")
}
```


```
Running tool: /usr/local/opt/go/libexec/bin/go test -timeout 30s -run ^TestTestHelpers$ github.com/buildpacks/pack/testhelpers -count=1 -v

=== RUN   TestTestHelpers
Suite: Test Helpers
Total: 4 | Focused: 0 | Pending: 0
=== RUN   TestTestHelpers/Test_Helpers
=== RUN   TestTestHelpers/Test_Helpers/2_non-fatals_in_after/2_non-fatals_in_before/2_non-fatal_in_run/run
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: before error 1
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:28: Expected nil: oops, i failed
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: before error 2
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:29: Expected nil: oops, i failed
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: run error 1
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:34: Expected nil: oops, i failed
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: run error 2
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:35: Expected nil: oops, i failed
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: after error 1
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:22: Expected nil: oops, i failed
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: after error 2
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:23: Expected nil: oops, i failed
=== RUN   TestTestHelpers/Test_Helpers/2_non-fatals_in_after/2_non-fatals_in_before/1_fatal_+_1_non-fatal_in_run/run
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: before error 1

    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:28: Expected nil: oops, i failed
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: before error 2
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:29: Expected nil: oops, i failed
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: run error 1
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:41: Expected nil: oops, i failed
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: after error 1
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:22: Expected nil: oops, i failed
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: after error 2
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:23: Expected nil: oops, i failed

=== RUN   TestTestHelpers/Test_Helpers/2_non-fatals_in_after/1_fatal_+_1_non-fatal_in_before/2_non-fatal_in_run/run
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: before error 1
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:49: Expected nil: oops, i failed
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: after error 1
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:22: Expected nil: oops, i failed
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: after error 2
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:23: Expected nil: oops, i failed
=== RUN   TestTestHelpers/Test_Helpers/fatal_in_after/run

    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: run error 1
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:69: Expected nil: oops, i failed
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: run error 2
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:70: Expected nil: oops, i failed
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:76: after error 1
    /Users/jromero/dev/buildpacks/pack/testhelpers/testhelpers_test.go:64: Expected nil: oops, i failed


Passed: 0 | Failed: 4 | Skipped: 0

--- FAIL: TestTestHelpers (0.00s)
    --- FAIL: TestTestHelpers/Test_Helpers (0.00s)
        --- FAIL: TestTestHelpers/Test_Helpers/2_non-fatals_in_after/2_non-fatals_in_before/2_non-fatal_in_run/run (0.00s)
        --- FAIL: TestTestHelpers/Test_Helpers/2_non-fatals_in_after/2_non-fatals_in_before/1_fatal_+_1_non-fatal_in_run/run (0.00s)
        --- FAIL: TestTestHelpers/Test_Helpers/2_non-fatals_in_after/1_fatal_+_1_non-fatal_in_before/2_non-fatal_in_run/run (0.00s)
        --- FAIL: TestTestHelpers/Test_Helpers/fatal_in_after/run (0.00s)
FAIL
FAIL	github.com/buildpacks/pack/testhelpers	0.465s
```
## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No
