### PR TITLE
Added support for inline buildpacks

### DIFF
--- a/build.go
+++ b/build.go
@@ -670,10 +670,10 @@ func (c *Client) processBuildpacks(ctx context.Context, builderImage imgutil.Ima
 				}
 				println(pathToInlineBuildpack)
 				declaredBPs = append(declaredBPs, pathToInlineBuildpack)
-			case bp.URI == "":
-				declaredBPs = append(declaredBPs, fmt.Sprintf("%s@%s", bp.ID, bp.Version))
-			case bp.Version != "":
+			case bp.URI != "":
 				declaredBPs = append(declaredBPs, bp.URI)
+			case bp.ID != "" && bp.Version != "":
+				declaredBPs = append(declaredBPs, fmt.Sprintf("%s@%s", bp.ID, bp.Version))
 			default:
 				return nil, nil, errors.New("Invalid buildpack defined in project descriptor")
 			}

--- a/build.go
+++ b/build.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -235,7 +236,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		return err
 	}
 
-	fetchedBPs, order, err := c.processBuildpacks(ctx, bldr.Image(), bldr.Buildpacks(), bldr.Order(), opts)
+	fetchedBPs, order, err := c.processBuildpacks(ctx, bldr.Image(), bldr.Buildpacks(), bldr.Order(), bldr.StackID, opts)
 	if err != nil {
 		return err
 	}
@@ -645,7 +646,7 @@ func (c *Client) processProxyConfig(config *ProxyConfig) ProxyConfig {
 // 	----------
 // 	- group:
 //		- A
-func (c *Client) processBuildpacks(ctx context.Context, builderImage imgutil.Image, builderBPs []dist.BuildpackInfo, builderOrder dist.Order, opts BuildOptions) (fetchedBPs []dist.Buildpack, order dist.Order, err error) {
+func (c *Client) processBuildpacks(ctx context.Context, builderImage imgutil.Image, builderBPs []dist.BuildpackInfo, builderOrder dist.Order, stackID string, opts BuildOptions) (fetchedBPs []dist.Buildpack, order dist.Order, err error) {
 	pullPolicy := opts.PullPolicy
 	publish := opts.Publish
 	registry := opts.Registry
@@ -657,10 +658,24 @@ func (c *Client) processBuildpacks(ctx context.Context, builderImage imgutil.Ima
 		relativeBaseDir = opts.ProjectDescriptorBaseDir
 
 		for _, bp := range opts.ProjectDescriptor.Build.Buildpacks {
-			if bp.URI == "" {
+			switch {
+			case bp.ID != "" && bp.Script.Inline != "":
+				if bp.Script.API == "" {
+					return nil, nil, errors.New("Missing API version for inline buildpack")
+				}
+
+				pathToInlineBuildpack, err := createInlineBuildpack(bp, stackID)
+				if err != nil {
+					return nil, nil, errors.Wrap(err, "Could not create temporary inline buildpack")
+				}
+				println(pathToInlineBuildpack)
+				declaredBPs = append(declaredBPs, pathToInlineBuildpack)
+			case bp.URI == "":
 				declaredBPs = append(declaredBPs, fmt.Sprintf("%s@%s", bp.ID, bp.Version))
-			} else {
+			case bp.Version != "":
 				declaredBPs = append(declaredBPs, bp.URI)
+			default:
+				return nil, nil, errors.New("Invalid buildpack defined in project descriptor")
 			}
 		}
 	}
@@ -904,4 +919,40 @@ func parseDigestFromImageID(id imgutil.Identifier) string {
 
 	digest = strings.TrimPrefix(digest, "sha256:")
 	return fmt.Sprintf("sha256:%s", digest)
+}
+
+func createInlineBuildpack(bp project.Buildpack, stackID string) (string, error) {
+	pathToInlineBuilpack, err := ioutil.TempDir("", "inline-cnb")
+	if err != nil {
+		return pathToInlineBuilpack, err
+	}
+
+	if err = createBuildpackTOML(pathToInlineBuilpack, bp.ID, "0.0.0", bp.Script.API, []dist.Stack{{ID: stackID}}, nil); err != nil {
+		return pathToInlineBuilpack, err
+	}
+
+	shell := bp.Script.Shell
+	if shell == "" {
+		shell = "bash"
+	}
+
+	binBuild := fmt.Sprintf(`#!/usr/bin/env %s
+
+%s
+`, shell, bp.Script.Inline)
+
+	binDetect := fmt.Sprintf(`#!/usr/bin/env %s
+
+exit 0
+`, shell)
+
+	if err = createBinScript(pathToInlineBuilpack, "build", binBuild, nil); err != nil {
+		return pathToInlineBuilpack, err
+	}
+
+	if err = createBinScript(pathToInlineBuilpack, "detect", binDetect, nil); err != nil {
+		return pathToInlineBuilpack, err
+	}
+
+	return pathToInlineBuilpack, nil
 }

--- a/build.go
+++ b/build.go
@@ -668,7 +668,6 @@ func (c *Client) processBuildpacks(ctx context.Context, builderImage imgutil.Ima
 				if err != nil {
 					return nil, nil, errors.Wrap(err, "Could not create temporary inline buildpack")
 				}
-				println(pathToInlineBuildpack)
 				declaredBPs = append(declaredBPs, pathToInlineBuildpack)
 			case bp.URI != "":
 				declaredBPs = append(declaredBPs, bp.URI)

--- a/build.go
+++ b/build.go
@@ -949,7 +949,7 @@ exit 0
 		return pathToInlineBuilpack, err
 	}
 
-	if err = createBinScript(pathToInlineBuilpack, "build.bat", binBuild, nil); err != nil {
+	if err = createBinScript(pathToInlineBuilpack, "build.bat", bp.Script.Inline, nil); err != nil {
 		return pathToInlineBuilpack, err
 	}
 
@@ -957,7 +957,7 @@ exit 0
 		return pathToInlineBuilpack, err
 	}
 
-	if err = createBinScript(pathToInlineBuilpack, "detect.bat", binDetect, nil); err != nil {
+	if err = createBinScript(pathToInlineBuilpack, "detect.bat", bp.Script.Inline, nil); err != nil {
 		return pathToInlineBuilpack, err
 	}
 

--- a/build.go
+++ b/build.go
@@ -659,7 +659,7 @@ func (c *Client) processBuildpacks(ctx context.Context, builderImage imgutil.Ima
 
 		for _, bp := range opts.ProjectDescriptor.Build.Buildpacks {
 			switch {
-			case bp.ID != "" && bp.Script.Inline != "":
+			case bp.ID != "" && bp.Script.Inline != "" && bp.Version == "" && bp.URI == "":
 				if bp.Script.API == "" {
 					return nil, nil, errors.New("Missing API version for inline buildpack")
 				}

--- a/build.go
+++ b/build.go
@@ -949,7 +949,15 @@ exit 0
 		return pathToInlineBuilpack, err
 	}
 
+	if err = createBinScript(pathToInlineBuilpack, "build.bat", binBuild, nil); err != nil {
+		return pathToInlineBuilpack, err
+	}
+
 	if err = createBinScript(pathToInlineBuilpack, "detect", binDetect, nil); err != nil {
+		return pathToInlineBuilpack, err
+	}
+
+	if err = createBinScript(pathToInlineBuilpack, "detect.bat", binDetect, nil); err != nil {
 		return pathToInlineBuilpack, err
 	}
 

--- a/build.go
+++ b/build.go
@@ -932,15 +932,15 @@ func createInlineBuildpack(bp project.Buildpack, stackID string) (string, error)
 
 	shell := bp.Script.Shell
 	if shell == "" {
-		shell = "bash"
+		shell = "/bin/sh"
 	}
 
-	binBuild := fmt.Sprintf(`#!/usr/bin/env %s
+	binBuild := fmt.Sprintf(`#!%s
 
 %s
 `, shell, bp.Script.Inline)
 
-	binDetect := fmt.Sprintf(`#!/usr/bin/env %s
+	binDetect := fmt.Sprintf(`#!%s
 
 exit 0
 `, shell)

--- a/build_test.go
+++ b/build_test.go
@@ -1302,6 +1302,48 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 							{ID: "my/inline", Version: "0.0.0"},
 						})
 					})
+
+					it("fails if there is no API", func() {
+						err := subject.Build(context.TODO(), BuildOptions{
+							Image:      "some/app",
+							Builder:    defaultBuilderName,
+							ClearCache: true,
+							ProjectDescriptor: project.Descriptor{
+								Build: project.Build{
+									Buildpacks: []project.Buildpack{{
+										ID: "my/inline",
+										Script: project.Script{
+											Inline: "touch foo.txt",
+										},
+									}},
+								},
+							},
+							ProjectDescriptorBaseDir: tmpDir,
+						})
+
+						h.AssertEq(t, "Missing API version for inline buildpack", err.Error())
+					})
+
+					it("fails if there is no ID", func() {
+						err := subject.Build(context.TODO(), BuildOptions{
+							Image:      "some/app",
+							Builder:    defaultBuilderName,
+							ClearCache: true,
+							ProjectDescriptor: project.Descriptor{
+								Build: project.Build{
+									Buildpacks: []project.Buildpack{{
+										Script: project.Script{
+											API:    "0.4",
+											Inline: "touch foo.txt",
+										},
+									}},
+								},
+							},
+							ProjectDescriptorBaseDir: tmpDir,
+						})
+
+						h.AssertEq(t, "Invalid buildpack defined in project descriptor", err.Error())
+					})
 				})
 
 				when("buildpack is from a registry", func() {

--- a/build_test.go
+++ b/build_test.go
@@ -1232,7 +1232,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 						})
 					})
 
-					it("adds the buildpack form the project descriptor", func() {
+					it("adds the buildpack from the project descriptor", func() {
 						err := subject.Build(context.TODO(), BuildOptions{
 							Image:      "some/app",
 							Builder:    defaultBuilderName,

--- a/build_test.go
+++ b/build_test.go
@@ -1383,8 +1383,8 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 							ProjectDescriptor: project.Descriptor{
 								Build: project.Build{
 									Buildpacks: []project.Buildpack{{
-										ID:      "my/inline",
-										Version: "1.0.0",
+										ID:      "buildpack.1.id",
+										Version: "buildpack.1.version",
 										Script: project.Script{
 											Inline: "touch foo.txt",
 										},
@@ -1400,13 +1400,12 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 						h.AssertNil(t, err)
 						h.AssertEq(t, bldr.Order(), dist.Order{
 							{Group: []dist.BuildpackRef{
-								{BuildpackInfo: dist.BuildpackInfo{ID: "my/inline", Version: "1.0.0"}},
+								{BuildpackInfo: dist.BuildpackInfo{ID: "buildpack.1.id", Version: "buildpack.1.version"}},
 							}},
 						})
 						h.AssertEq(t, bldr.Buildpacks(), []dist.BuildpackInfo{
 							{ID: "buildpack.1.id", Version: "buildpack.1.version"},
 							{ID: "buildpack.2.id", Version: "buildpack.2.version"},
-							{ID: "my/inline", Version: "1.0.0"},
 						})
 					})
 				})

--- a/new_buildpack.go
+++ b/new_buildpack.go
@@ -49,7 +49,10 @@ type NewBuildpackOptions struct {
 }
 
 func (c *Client) NewBuildpack(ctx context.Context, opts NewBuildpackOptions) error {
-	createBuildpackTOML(opts.Path, opts.ID, opts.Version, opts.API, opts.Stacks, nil)
+	err := createBuildpackTOML(opts.Path, opts.ID, opts.Version, opts.API, opts.Stacks, c)
+	if err != nil {
+		return err
+	}
 	return createBashBuildpack(opts.Path, c)
 }
 

--- a/new_buildpack.go
+++ b/new_buildpack.go
@@ -49,41 +49,7 @@ type NewBuildpackOptions struct {
 }
 
 func (c *Client) NewBuildpack(ctx context.Context, opts NewBuildpackOptions) error {
-	api, err := api.NewVersion(opts.API)
-	if err != nil {
-		return err
-	}
-
-	buildpackTOML := dist.BuildpackDescriptor{
-		API:    api,
-		Stacks: opts.Stacks,
-		Info: dist.BuildpackInfo{
-			ID:      opts.ID,
-			Version: opts.Version,
-		},
-	}
-
-	// The following line's comment is for gosec, it will ignore rule 301 in this case
-	// G301: Expect directory permissions to be 0750 or less
-	/* #nosec G301 */
-	if err := os.MkdirAll(opts.Path, 0755); err != nil {
-		return err
-	}
-
-	buildpackTOMLPath := filepath.Join(opts.Path, "buildpack.toml")
-	_, err = os.Stat(buildpackTOMLPath)
-	if os.IsNotExist(err) {
-		f, err := os.Create(buildpackTOMLPath)
-		if err != nil {
-			return err
-		}
-		if err := toml.NewEncoder(f).Encode(buildpackTOML); err != nil {
-			return err
-		}
-		defer f.Close()
-		c.logger.Infof("    %s  buildpack.toml", style.Symbol("create"))
-	}
-
+	createBuildpackTOML(opts.Path, opts.ID, opts.Version, opts.API, opts.Stacks, nil)
 	return createBashBuildpack(opts.Path, c)
 }
 
@@ -119,7 +85,50 @@ func createBinScript(path, name, contents string, c *Client) error {
 			return err
 		}
 
-		c.logger.Infof("    %s  bin/%s", style.Symbol("create"), name)
+		if c != nil {
+			c.logger.Infof("    %s  bin/%s", style.Symbol("create"), name)
+		}
 	}
+	return nil
+}
+
+func createBuildpackTOML(path, id, version, apiStr string, stacks []dist.Stack, c *Client) error {
+	api, err := api.NewVersion(apiStr)
+	if err != nil {
+		return err
+	}
+
+	buildpackTOML := dist.BuildpackDescriptor{
+		API:    api,
+		Stacks: stacks,
+		Info: dist.BuildpackInfo{
+			ID:      id,
+			Version: version,
+		},
+	}
+
+	// The following line's comment is for gosec, it will ignore rule 301 in this case
+	// G301: Expect directory permissions to be 0750 or less
+	/* #nosec G301 */
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return err
+	}
+
+	buildpackTOMLPath := filepath.Join(path, "buildpack.toml")
+	_, err = os.Stat(buildpackTOMLPath)
+	if os.IsNotExist(err) {
+		f, err := os.Create(buildpackTOMLPath)
+		if err != nil {
+			return err
+		}
+		if err := toml.NewEncoder(f).Encode(buildpackTOML); err != nil {
+			return err
+		}
+		defer f.Close()
+		if c != nil {
+			c.logger.Infof("    %s  buildpack.toml", style.Symbol("create"))
+		}
+	}
+
 	return nil
 }

--- a/project/project.go
+++ b/project/project.go
@@ -10,10 +10,17 @@ import (
 	"github.com/buildpacks/pack/internal/dist"
 )
 
+type Script struct {
+	API    string `toml:"api"`
+	Inline string `toml:"inline"`
+	Shell  string `toml:"shell"`
+}
+
 type Buildpack struct {
 	ID      string `toml:"id"`
 	Version string `toml:"version"`
 	URI     string `toml:"uri"`
+	Script  Script `toml:"script"`
 }
 
 type EnvVar struct {


### PR DESCRIPTION
## Summary

This is an implementation of Inline Buildpacks described in [RFC-0048](https://github.com/buildpacks/rfcs/blob/main/text/0048-inline-buildpack.md).

## Output

Give an app with a `project.toml` containing:

```
[project]
id = "my-app"

[[build.buildpacks]]
id = "my/inline"

  [build.buildpacks.script]
  api = "0.4"
  inline = "echo 'hello!'"
```

#### Before

```
$ pack build inline-test
...
ERROR: failed to build: invalid buildpack string my/inline@
```

#### After

```
$ pack build inline-test
...
===> DETECTING
my/inline 0.0.0
===> ANALYZING
===> RESTORING
===> BUILDING
hello!
...
Successfully built image inline-test
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see https://github.com/buildpacks/docs/pull/365
    - [ ] No
