### PR TITLE
Provide host port when starting the test registry

### DIFF
--- a/testhelpers/registry.go
+++ b/testhelpers/registry.go
@@ -161,7 +161,7 @@ func startRegistry(t *testing.T, runRegistryName, username, password string) (st
 	}, &dockercontainer.HostConfig{
 		AutoRemove: true,
 		PortBindings: nat.PortMap{
-			"5000/tcp": []nat.PortBinding{{}},
+			"5000/tcp": []nat.PortBinding{{HostPort: "0"}},
 		},
 	}, nil, nil, runRegistryName)
 	AssertNil(t, err)


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->

The latest version of Docker Desktop for Mac (>= 3.2.X) introduced a bug
where the `localhost` domain was not being resolved correctly when a bound
container port was not provided a host port. Providing a "0" host port
to continue using auto assignment resolves the issue.


## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

<img width="1314" alt="Screen Shot 2021-05-11 at 1 06 59 PM" src="https://user-images.githubusercontent.com/475559/117864535-8a2df300-b25a-11eb-8909-5cd15cc58599.png">


#### After

<img width="1323" alt="Screen Shot 2021-05-11 at 1 08 41 PM" src="https://user-images.githubusercontent.com/475559/117864561-8f8b3d80-b25a-11eb-8be5-3358482b1882.png">
