### PR TITLE
Clean Filepaths to ensure no XSS (Polish PR for 1164 and 1155)

### DIFF
--- a/acceptance/testdata/mock_stack/windows/run/server.go
+++ b/acceptance/testdata/mock_stack/windows/run/server.go
@@ -28,7 +28,7 @@ func main() {
 		}
 
 		for _, path := range paths {
-			contents, err := ioutil.ReadFile(path)
+			contents, err := ioutil.ReadFile(filepath.Clean(path))
 			if err != nil {
 				panic(err.Error())
 			}

--- a/build.go
+++ b/build.go
@@ -542,7 +542,7 @@ func (c *Client) processAppPath(appPath string) (string, error) {
 	}
 
 	if !fi.IsDir() {
-		fh, err := os.Open(resolvedAppPath)
+		fh, err := os.Open(filepath.Clean(resolvedAppPath))
 		if err != nil {
 			return "", errors.Wrap(err, "read file")
 		}

--- a/builder/config_reader.go
+++ b/builder/config_reader.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
@@ -55,7 +56,7 @@ type LifecycleConfig struct {
 // ReadConfig reads a builder configuration from the file path provided and returns the
 // configuration along with any warnings encountered while parsing
 func ReadConfig(path string) (config Config, warnings []string, err error) {
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return Config{}, nil, errors.Wrap(err, "opening config file")
 	}

--- a/internal/blob/downloader.go
+++ b/internal/blob/downloader.go
@@ -90,7 +90,7 @@ func (d *downloader) handleHTTP(ctx context.Context, uri string) (string, error)
 
 	etag := ""
 	if etagExists {
-		bytes, err := ioutil.ReadFile(etagFile)
+		bytes, err := ioutil.ReadFile(filepath.Clean(etagFile))
 		if err != nil {
 			return "", err
 		}

--- a/internal/build/testdata/fake-lifecycle/phase.go
+++ b/internal/build/testdata/fake-lifecycle/phase.go
@@ -102,7 +102,7 @@ func testRegistryAccess(repoName string) {
 
 func testRead(filename string) {
 	fmt.Println("read test")
-	contents, err := ioutil.ReadFile(filename)
+	contents, err := ioutil.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		fmt.Printf("failed to read file '%s'\n", filename)
 		os.Exit(1)

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -219,7 +219,7 @@ func parseEnv(envFiles []string, envVars []string) (map[string]string, error) {
 
 func parseEnvFile(filename string) (map[string]string, error) {
 	out := make(map[string]string)
-	f, err := ioutil.ReadFile(filename)
+	f, err := ioutil.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, errors.Wrapf(err, "open %s", filename)
 	}

--- a/internal/commands/report.go
+++ b/internal/commands/report.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -56,7 +57,7 @@ Config:
 {{ .Config -}}`))
 
 	configData := ""
-	if data, err := ioutil.ReadFile(cfgPath); err != nil {
+	if data, err := ioutil.ReadFile(filepath.Clean(cfgPath)); err != nil {
 		configData = fmt.Sprintf("(no config file found at %s)", cfgPath)
 	} else {
 		var padded strings.Builder

--- a/internal/dist/layers.go
+++ b/internal/dist/layers.go
@@ -34,7 +34,7 @@ func BuildpackToLayerTar(dest string, bp Buildpack) (string, error) {
 }
 
 func LayerDiffID(layerTarPath string) (v1.Hash, error) {
-	fh, err := os.Open(layerTarPath)
+	fh, err := os.Open(filepath.Clean(layerTarPath))
 	if err != nil {
 		return v1.Hash{}, errors.Wrap(err, "opening tar file")
 	}

--- a/internal/fakes/fake_package.go
+++ b/internal/fakes/fake_package.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 
@@ -76,5 +77,5 @@ func (f *fakePackage) GetLayer(diffID string) (io.ReadCloser, error) {
 		return nil, errors.New("no layer found")
 	}
 
-	return os.Open(tarFile)
+	return os.Open(filepath.Clean(tarFile))
 }

--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -286,7 +286,7 @@ func (r *Cache) writeEntry(b Buildpack) (string, error) {
 		}
 	}
 
-	f, err := os.OpenFile(index, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
+	f, err := os.OpenFile(filepath.Clean(index), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return "", errors.Wrapf(err, "creating buildpack file: %s/%s", ns, name)
 	}
@@ -320,7 +320,7 @@ func (r *Cache) readEntry(ns, name string) (Entry, error) {
 		return Entry{}, errors.Wrapf(err, "finding buildpack: %s/%s", ns, name)
 	}
 
-	file, err := os.Open(index)
+	file, err := os.Open(filepath.Clean(index))
 	if err != nil {
 		return Entry{}, errors.Wrapf(err, "opening index for buildpack: %s/%s", ns, name)
 	}

--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -286,7 +286,7 @@ func (r *Cache) writeEntry(b Buildpack) (string, error) {
 		}
 	}
 
-	f, err := os.OpenFile(index, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
+	f, err := os.OpenFile(index, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return "", errors.Wrapf(err, "creating buildpack file: %s/%s", ns, name)
 	}

--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -286,7 +286,7 @@ func (r *Cache) writeEntry(b Buildpack) (string, error) {
 		}
 	}
 
-	f, err := os.OpenFile(index, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)
+	f, err := os.OpenFile(index, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return "", errors.Wrapf(err, "creating buildpack file: %s/%s", ns, name)
 	}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -222,7 +222,7 @@ func WriteDirToTar(tw TarWriter, srcDir, basePath string, uid, gid int, mode int
 		}
 
 		if fi.Mode().IsRegular() {
-			f, err := os.Open(file)
+			f, err := os.Open(filepath.Clean(file))
 			if err != nil {
 				return err
 			}

--- a/project/project.go
+++ b/project/project.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"io/ioutil"
+	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
@@ -40,7 +41,7 @@ type Descriptor struct {
 }
 
 func ReadProjectDescriptor(pathToFile string) (Descriptor, error) {
-	projectTomlContents, err := ioutil.ReadFile(pathToFile)
+	projectTomlContents, err := ioutil.ReadFile(filepath.Clean(pathToFile))
 	if err != nil {
 		return Descriptor{}, err
 	}

--- a/testhelpers/registry.go
+++ b/testhelpers/registry.go
@@ -43,6 +43,7 @@ func RegistryHost(host, port string) string {
 }
 
 func CreateRegistryFixture(t *testing.T, tmpDir, fixturePath string) string {
+	t.Helper()
 	// copy fixture to temp dir
 	registryFixtureCopy := filepath.Join(tmpDir, "registryCopy")
 

--- a/testhelpers/tar_assertions.go
+++ b/testhelpers/tar_assertions.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ type TarEntryAssertion func(t *testing.T, header *tar.Header, data []byte)
 func AssertOnTarEntry(t *testing.T, tarPath, entryPath string, assertFns ...TarEntryAssertion) {
 	t.Helper()
 
-	tarFile, err := os.Open(tarPath)
+	tarFile, err := os.Open(filepath.Clean(tarPath))
 	AssertNil(t, err)
 	defer tarFile.Close()
 

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -597,7 +597,7 @@ func RecursiveCopyE(src, dst string) error {
 		return err
 	}
 
-	return os.Chmod(dst, 0600)
+	return os.Chmod(dst, 0775)
 }
 
 func RequireDocker(t *testing.T) {
@@ -706,7 +706,7 @@ func RecursiveCopyNow(t *testing.T, src, dst string) {
 			modifiedTime := time.Now().Local()
 			err = os.Chtimes(filepath.Join(dst, fi.Name()), modifiedTime, modifiedTime)
 			AssertNil(t, err)
-			err = os.Chmod(filepath.Join(dst, fi.Name()), 0600)
+			err = os.Chmod(filepath.Join(dst, fi.Name()), 0664)
 			AssertNil(t, err)
 		}
 		if fi.IsDir() {
@@ -718,7 +718,7 @@ func RecursiveCopyNow(t *testing.T, src, dst string) {
 	modifiedTime := time.Now().Local()
 	err = os.Chtimes(dst, modifiedTime, modifiedTime)
 	AssertNil(t, err)
-	err = os.Chmod(dst, 0600)
+	err = os.Chmod(dst, 0775)
 	AssertNil(t, err)
 }
 

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -597,7 +597,7 @@ func RecursiveCopyE(src, dst string) error {
 		return err
 	}
 
-	return os.Chmod(dst, 0775)
+	return os.Chmod(dst, 0600)
 }
 
 func RequireDocker(t *testing.T) {
@@ -706,7 +706,7 @@ func RecursiveCopyNow(t *testing.T, src, dst string) {
 			modifiedTime := time.Now().Local()
 			err = os.Chtimes(filepath.Join(dst, fi.Name()), modifiedTime, modifiedTime)
 			AssertNil(t, err)
-			err = os.Chmod(filepath.Join(dst, fi.Name()), 0664)
+			err = os.Chmod(filepath.Join(dst, fi.Name()), 0600)
 			AssertNil(t, err)
 		}
 		if fi.IsDir() {
@@ -718,7 +718,7 @@ func RecursiveCopyNow(t *testing.T, src, dst string) {
 	modifiedTime := time.Now().Local()
 	err = os.Chtimes(dst, modifiedTime, modifiedTime)
 	AssertNil(t, err)
-	err = os.Chmod(dst, 0775)
+	err = os.Chmod(dst, 0600)
 	AssertNil(t, err)
 }
 

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -284,7 +284,7 @@ func AssertNotNil(t *testing.T, actual interface{}) {
 
 func AssertTarball(t *testing.T, path string) {
 	t.Helper()
-	f, err := os.Open(path)
+	f, err := os.Open(filepath.Clean(path))
 	AssertNil(t, err)
 	defer f.Close()
 
@@ -538,13 +538,13 @@ func CopyFileE(src, dst string) error {
 		return err
 	}
 
-	srcFile, err := os.Open(src)
+	srcFile, err := os.Open(filepath.Clean(src))
 	if err != nil {
 		return err
 	}
 	defer srcFile.Close()
 
-	dstFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fi.Mode())
+	dstFile, err := os.OpenFile(filepath.Clean(dst), os.O_RDWR|os.O_CREATE|os.O_TRUNC, fi.Mode())
 	if err != nil {
 		return err
 	}
@@ -697,7 +697,7 @@ func RecursiveCopyNow(t *testing.T, src, dst string) {
 	AssertNil(t, err)
 	for _, fi := range fis {
 		if fi.Mode().IsRegular() {
-			srcFile, err := os.Open(filepath.Join(src, fi.Name()))
+			srcFile, err := os.Open(filepath.Join(filepath.Clean(src), fi.Name()))
 			AssertNil(t, err)
 			dstFile, err := os.Create(filepath.Join(dst, fi.Name()))
 			AssertNil(t, err)
@@ -733,7 +733,7 @@ func AssertTarFileContents(t *testing.T, tarfile, path, expected string) {
 
 func tarFileContents(t *testing.T, tarfile, path string) (exist bool, contents string) {
 	t.Helper()
-	r, err := os.Open(tarfile)
+	r, err := os.Open(filepath.Clean(tarfile))
 	AssertNil(t, err)
 	defer r.Close()
 
@@ -766,7 +766,7 @@ func AssertTarHasFile(t *testing.T, tarFile, path string) {
 func tarHasFile(t *testing.T, tarFile, path string) (exist bool) {
 	t.Helper()
 
-	r, err := os.Open(tarFile)
+	r, err := os.Open(filepath.Clean(tarFile))
 	AssertNil(t, err)
 	defer r.Close()
 

--- a/tools/pedantic_imports/main.go
+++ b/tools/pedantic_imports/main.go
@@ -66,7 +66,7 @@ func isIgnoredDir(name string) bool {
 }
 
 func checkImports(path, basePackage string) ([]string, error) {
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
This is a polish PR to incorporate the changes made in #1164 and #1155. One particular change in these PRs (for bugsbash) is that it reverts the changes made to the directory permissions – those cases were created and used in a testing context, so a) it broke the code, given that later parts of the program expected to write to those directories from a non-root user, and b) it is in a test, so it isn't quite as exposed as it would be otherwise. 

Resolves #1164
Resolves #1155

Many thanks to @soniasingla and @rahulgrover99 for the work with this!