### PR TITLE
Add a registry pull proxy

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,13 +2,12 @@ package pack
 
 import (
 	"context"
-	"os"
-	"path/filepath"
-
 	"github.com/buildpacks/imgutil"
 	dockerClient "github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/pkg/errors"
+	"os"
+	"path/filepath"
 
 	pubcfg "github.com/buildpacks/pack/config"
 	"github.com/buildpacks/pack/internal/blob"

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -157,7 +157,7 @@ func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseF
 		return l.Export(ctx, l.opts.Image.String(), l.opts.RunImage, l.opts.Publish, l.opts.DockerHost, l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, phaseFactory)
 	}
 
-	return l.Create(ctx, l.opts.Publish, l.opts.DockerHost, l.opts.ClearCache, l.opts.RunImage, l.opts.Image.String(), l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, l.opts.Volumes, phaseFactory)
+	return l.Create(ctx, l.opts.Publish, l.opts.DockerHost, l.opts.ClearCache, l.opts.RunImage, l.opts.Image.String(), l.opts.PreviousImage.String(), l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, l.opts.Volumes, phaseFactory)
 }
 
 func (l *LifecycleExecution) Cleanup() error {
@@ -171,10 +171,11 @@ func (l *LifecycleExecution) Cleanup() error {
 	return reterr
 }
 
-func (l *LifecycleExecution) Create(ctx context.Context, publish bool, dockerHost string, clearCache bool, runImage, repoName, networkMode string, buildCache, launchCache Cache, additionalTags, volumes []string, phaseFactory PhaseFactory) error {
+func (l *LifecycleExecution) Create(ctx context.Context, publish bool, dockerHost string, clearCache bool, runImage, repoName, prevImage, networkMode string, buildCache, launchCache Cache, additionalTags, volumes []string, phaseFactory PhaseFactory) error {
 	flags := addTags([]string{
 		"-cache-dir", l.mountPaths.cacheDir(),
 		"-run-image", runImage,
+		"-previous-image", prevImage,
 	}, additionalTags)
 
 	if clearCache {

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -48,9 +48,12 @@ func init() {
 	rand.Seed(time.Now().UTC().UnixNano())
 }
 
+// TODO -Dan- Need an option for previousImage here. So that our proxy can pull from a different location
+//   than it pushes to.
 type LifecycleOptions struct {
 	AppPath            string
 	Image              name.Reference
+	PreviousImage       name.Reference
 	Builder            Builder
 	LifecycleImage     string
 	RunImage           string

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -41,6 +41,7 @@ type BuildFlags struct {
 	Volumes            []string
 	AdditionalTags     []string
 	Workspace          string
+	PullProxy          string
 }
 
 // Build an image from source code
@@ -146,6 +147,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				CacheImage:               flags.CacheImage,
 				Workspace:                flags.Workspace,
 				LifecycleImage:           lifecycleImage,
+				PullProxy:                flags.PullProxy,
 			}); err != nil {
 				return errors.Wrap(err, "failed to build")
 			}
@@ -184,6 +186,7 @@ This option may set DOCKER_HOST environment variable for the build container if 
 	cmd.Flags().BoolVar(&buildFlags.TrustBuilder, "trust-builder", false, "Trust the provided builder\nAll lifecycle phases will be run in a single container (if supported by the lifecycle).")
 	cmd.Flags().StringArrayVar(&buildFlags.Volumes, "volume", nil, "Mount host volume into the build container, in the form '<host path>:<target path>[:<options>]'.\n- 'host path': Name of the volume or absolute directory path to mount.\n- 'target path': The path where the file or directory is available in the container.\n- 'options' (default \"ro\"): An optional comma separated list of mount options.\n    - \"ro\", volume contents are read-only.\n    - \"rw\", volume contents are readable and writeable.\n    - \"volume-opt=<key>=<value>\", can be specified more than once, takes a key-value pair consisting of the option name and its value."+multiValueHelp("volume"))
 	cmd.Flags().StringVar(&buildFlags.Workspace, "workspace", "", "Location at which to mount the app dir in the build image")
+	cmd.Flags().StringVar(&buildFlags.PullProxy, "pull-proxy", "", "Proxy Registry to pull all images from")
 }
 
 func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackClient, logger logging.Logger) error {

--- a/internal/image/fetcher.go
+++ b/internal/image/fetcher.go
@@ -44,14 +44,14 @@ func (f *Fetcher) Fetch(ctx context.Context, name string, daemon bool, pullPolic
 		} else if pullPolicy == config.PullIfNotPresent {
 			img, err := f.fetchDaemonImage(name)
 			if err == nil || !errors.Is(err, ErrNotFound) {
-				return img, err
+				return img, errors.Wrap(err, "first daemon case")
 			}
 		}
 	}
 
 	image, err := remote.NewImage(name, authn.DefaultKeychain, remote.FromBaseImage(name))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed making new image")
 	}
 
 	remoteFound := image.Found()
@@ -60,7 +60,7 @@ func (f *Fetcher) Fetch(ctx context.Context, name string, daemon bool, pullPolic
 		if remoteFound {
 			f.logger.Debugf("Pulling image %s", style.Symbol(name))
 			if err := f.pullImage(ctx, name); err != nil {
-				return nil, err
+				return nil, errors.Wrap(err, "pulling image failed")
 			}
 		}
 		return f.fetchDaemonImage(name)

--- a/internal/image/proxied_fetcher.go
+++ b/internal/image/proxied_fetcher.go
@@ -1,0 +1,53 @@
+package image
+
+import (
+	"context"
+	"github.com/buildpacks/imgutil"
+	"github.com/buildpacks/pack/config"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/pkg/errors"
+	"path"
+	"strings"
+)
+
+type ImageFetcher interface {
+	Fetch(ctx context.Context, name string, daemon bool, pullPolicy config.PullPolicy) (imgutil.Image, error)
+}
+
+type ProxiedFetcher struct {
+	proxyHost string
+	fetcher   ImageFetcher
+}
+
+func (pw ProxiedFetcher) Fetch(ctx context.Context, imgName string, daemon bool, pullPolicy config.PullPolicy) (imgutil.Image, error) {
+	proxiedImage, err := ProxyImage(pw.proxyHost, imgName)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create proxy image name")
+	}
+	return pw.fetcher.Fetch(ctx, proxiedImage.Name(), daemon, pullPolicy)
+}
+
+func NewProxiedFetcher(proxyHost string, fetcher ImageFetcher) ImageFetcher {
+	return ProxiedFetcher{
+		proxyHost: strings.TrimRight(proxyHost,"/"),
+		fetcher:   fetcher,
+	}
+}
+
+func ProxyImage(proxyHost, imageName string) (name.Reference, error) {
+	parsedRef, err := name.ParseReference(imageName, name.WeakValidation)
+	if err != nil {
+		return nil, errors.Wrap(err, "image name is invalid")
+	}
+	reg := parsedRef.Context().RegistryStr()
+	if strings.Contains(proxyHost, reg) {
+		return parsedRef, nil
+	}
+	proxiedRef, err := name.ParseReference(path.Join(proxyHost, strings.TrimPrefix(parsedRef.Name(), reg)), name.WeakValidation)
+	if err != nil {
+		return nil, errors.Wrap(err, "proxied image name is invalid")
+	}
+	return proxiedRef, err
+}
+
+

--- a/internal/image/proxied_fetcher_test.go
+++ b/internal/image/proxied_fetcher_test.go
@@ -1,0 +1,78 @@
+package image_test
+
+import (
+	"context"
+	pubcfg "github.com/buildpacks/pack/config"
+	"github.com/buildpacks/pack/internal/image"
+	"github.com/buildpacks/pack/testhelpers"
+	"github.com/buildpacks/pack/testmocks"
+	"github.com/golang/mock/gomock"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"testing"
+)
+
+func TestProxiedFetcher(t *testing.T) {
+	spec.Run(t, "Proxied Fetcher", testProxiedFetcher, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func testProxiedFetcher(t *testing.T,when spec.G, it spec.S) {
+	var (
+		mockController *gomock.Controller
+		mockFetcher *testmocks.MockImageFetcher
+		mockImage *testmocks.MockImage
+		assert = testhelpers.NewAssertionManager(t)
+	)
+	it.Before(func() {
+		mockController = gomock.NewController(t)
+		mockImage = testmocks.NewImage("test-image", "", nil)
+		mockFetcher = testmocks.NewMockImageFetcher(mockController)
+	})
+	when("fetching an image", func () {
+		it.Before(func() {
+			mockFetcher.EXPECT().Fetch(gomock.Any(), "host:8080/proxy_path/org/repo:latest", true, pubcfg.PullIfNotPresent).Return(mockImage, nil)
+		})
+		it("replaces host with proxied hostname", func() {
+			subject := image.NewProxiedFetcher("host:8080/proxy_path/", mockFetcher)
+			fetchedImage, err := subject.Fetch(context.Background(), "index.docker.io/org/repo", true, pubcfg.PullIfNotPresent)
+			assert.Nil(err)
+
+			assert.Equal(fetchedImage.Name(), mockImage.Name())
+		})
+
+		it("replaces default registry name", func() {
+			subject := image.NewProxiedFetcher("host:8080/proxy_path", mockFetcher)
+			fetchedImage, err := subject.Fetch(context.Background(), "org/repo", true, pubcfg.PullIfNotPresent)
+			assert.Nil(err)
+
+			assert.Equal(fetchedImage.Name(), mockImage.Name())
+		})
+
+		it("is idempotent on replaced hostnames", func() {
+			subject := image.NewProxiedFetcher("host:8080/proxy_path", mockFetcher)
+			fetchedImage, err := subject.Fetch(context.Background(), "host:8080/proxy_path/org/repo:latest", true, pubcfg.PullIfNotPresent)
+			assert.Nil(err)
+
+			assert.Equal(fetchedImage.Name(), mockImage.Name())
+		})
+	})
+
+
+	when("error cases", func() {
+		when("passed an invalid image name to fetch", func() {
+			it("errors with a helpful error message", func() {
+				subject := image.NewProxiedFetcher("host:8080/proxy_path", mockFetcher)
+				_, err := subject.Fetch(context.Background(), "::::", true, pubcfg.PullIfNotPresent)
+
+				assert.ErrorContains(err, "image name is invalid")
+			})
+		})
+		when("proxy host is semantically invalid", func() {
+			it("errors with a helpful error message", func() {
+				subject := image.NewProxiedFetcher("%%%", mockFetcher)
+				_, err := subject.Fetch(context.Background(), "index.docker.io/org/repo", true, pubcfg.PullIfNotPresent)
+				assert.ErrorContains(err, "proxied image name is invalid")
+			})
+		})
+	})
+}

--- a/rebase.go
+++ b/rebase.go
@@ -59,6 +59,7 @@ func (c *Client) Rebase(ctx context.Context, opts RebaseOptions) error {
 		opts.RunImage,
 		imageRef.Context().RegistryStr(),
 		"",
+		"", // TODO: -Dan- add pull proxy
 		builder.StackMetadata{
 			RunImage: builder.RunImageMetadata{
 				Image:   md.Stack.RunImage.Image,


### PR DESCRIPTION
Signed-off-by: dwillist <dthornton@vmware.com>

## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
All image pulls would come from the registry specified in their name Eg `index.docker.io/repo/name:latest` would pull from `index.docker.io`

#### After
You can specify a pull proxy that re-directs all image pulls. If passed the `--pull-proxy index.proxy.io/proxy_registry` all image pulls will be routed through this proxy instead of their original. 

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
