### PR TITLE
Add registry mirror support for pack build

### DIFF
--- a/build.go
+++ b/build.go
@@ -29,6 +29,7 @@ import (
 	"github.com/buildpacks/pack/internal/dist"
 	"github.com/buildpacks/pack/internal/image"
 	"github.com/buildpacks/pack/internal/layer"
+	pname "github.com/buildpacks/pack/internal/name"
 	"github.com/buildpacks/pack/internal/paths"
 	"github.com/buildpacks/pack/internal/stack"
 	"github.com/buildpacks/pack/internal/stringset"
@@ -284,6 +285,11 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 	}
 
 	fileFilter, err := getFileFilter(opts.ProjectDescriptor)
+	if err != nil {
+		return err
+	}
+
+	runImageName, err = pname.TranslateRegistry(runImageName, c.registryMirrors)
 	if err != nil {
 		return err
 	}

--- a/build.go
+++ b/build.go
@@ -289,7 +289,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		return err
 	}
 
-	runImageName, err = pname.TranslateRegistry(runImageName, c.registryMirrors)
+	runImageName, err = pname.TranslateRegistry(runImageName, c.registryMirrors, c.logger)
 	if err != nil {
 		return err
 	}

--- a/build_test.go
+++ b/build_test.go
@@ -2206,6 +2206,20 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, fakeLifecycle.Opts.GID, 2)
 			})
 		})
+
+		when("RegistryMirrors option", func() {
+			it("translates run image before passing to lifecycle", func() {
+				subject.registryMirrors = map[string]string{
+					"index.docker.io": "10.0.0.1",
+				}
+
+				h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+					Builder: defaultBuilderName,
+					Image:   "example.com/some/repo:tag",
+				}))
+				h.AssertEq(t, fakeLifecycle.Opts.RunImage, "10.0.0.1/default/run:latest")
+			})
+		})
 	})
 }
 

--- a/client.go
+++ b/client.go
@@ -64,6 +64,7 @@ type Client struct {
 	docker            dockerClient.CommonAPIClient
 	imageFactory      ImageFactory
 	experimental      bool
+	registryMirrors   map[string]string
 }
 
 // ClientOption is a type of function that mutate settings on the client.
@@ -123,6 +124,13 @@ func WithExperimental(experimental bool) ClientOption {
 	}
 }
 
+// WithRegistryMirrors sets mirrors to pull images from.
+func WithRegistryMirrors(registryMirrors map[string]string) ClientOption {
+	return func(c *Client) {
+		c.registryMirrors = registryMirrors
+	}
+}
+
 // NewClient allocates and returns a Client configured with the specified options.
 func NewClient(opts ...ClientOption) (*Client, error) {
 	var client Client
@@ -155,7 +163,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	}
 
 	if client.imageFetcher == nil {
-		client.imageFetcher = image.NewFetcher(client.logger, client.docker)
+		client.imageFetcher = image.NewFetcher(client.logger, client.docker, image.WithRegistryMirrors(client.registryMirrors))
 	}
 
 	if client.imageFactory == nil {

--- a/client_test.go
+++ b/client_test.go
@@ -110,4 +110,16 @@ func testClient(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, cl.experimental, true)
 		})
 	})
+
+	when("#WithRegistryMirror", func() {
+		it("uses registry mirrors provided", func() {
+			registryMirrors := map[string]string{
+				"index.docker.io": "10.0.0.1",
+			}
+
+			cl, err := NewClient(WithRegistryMirrors(registryMirrors))
+			h.AssertNil(t, err)
+			h.AssertEq(t, cl.registryMirrors, registryMirrors)
+		})
+	})
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -133,7 +133,7 @@ func initConfig() (config.Config, string, error) {
 }
 
 func initClient(logger logging.Logger, cfg config.Config) (pack.Client, error) {
-	client, err := pack.NewClient(pack.WithLogger(logger), pack.WithExperimental(cfg.Experimental))
+	client, err := pack.NewClient(pack.WithLogger(logger), pack.WithExperimental(cfg.Experimental), pack.WithRegistryMirrors(cfg.RegistryMirrors))
 	if err != nil {
 		return pack.Client{}, err
 	}

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -23,6 +23,7 @@ func NewConfigCommand(logger logging.Logger, cfg config.Config, cfgPath string, 
 	cmd.AddCommand(ConfigRunImagesMirrors(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigTrustedBuilder(logger, cfg, cfgPath))
 	cmd.AddCommand(ConfigLifecycleImage(logger, cfg, cfgPath))
+	cmd.AddCommand(ConfigRegistryMirrors(logger, cfg, cfgPath))
 
 	AddHelpFlag(cmd, "config")
 	return cmd

--- a/internal/commands/config_registry_mirrors.go
+++ b/internal/commands/config_registry_mirrors.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
+)
+
+var registryMirror string
+
+func ConfigRegistryMirrors(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registry-mirrors",
+		Short: "List, add and remove registry mirrors",
+		Args:  cobra.MaximumNArgs(3),
+		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
+			listRegistryMirrors(args, logger, cfg)
+			return nil
+		}),
+	}
+
+	listCmd := generateListCmd(cmd.Use, logger, cfg, listRegistryMirrors)
+	listCmd.Long = "List all registry mirrors."
+	listCmd.Use = "list"
+	listCmd.Example = "pack config registry-mirrors list"
+	cmd.AddCommand(listCmd)
+
+	addCmd := generateAdd("mirror for a registry", logger, cfg, cfgPath, addRegistryMirror)
+	addCmd.Use = "add <registry> [-m <mirror...]"
+	addCmd.Long = "Set mirror for a given registry."
+	addCmd.Example = "pack config registry-mirrors add index.docker.io --mirror 10.0.0.1"
+	addCmd.Flags().StringVarP(&registryMirror, "mirror", "m", "", "Registry mirror")
+	cmd.AddCommand(addCmd)
+
+	rmCmd := generateRemove("mirror for a registry", logger, cfg, cfgPath, removeRegistryMirror)
+	rmCmd.Use = "remove <registry>"
+	rmCmd.Long = "Remove mirror for a given registry."
+	rmCmd.Example = "pack config registry-mirrors remove index.docker.io"
+	cmd.AddCommand(rmCmd)
+
+	AddHelpFlag(cmd, "run-image-mirrors")
+	return cmd
+}
+
+func addRegistryMirror(args []string, logger logging.Logger, cfg config.Config, cfgPath string) error {
+	registry := args[0]
+	if registryMirror == "" {
+		logger.Infof("A registry mirror was not provided.")
+		return nil
+	}
+
+	if cfg.RegistryMirrors == nil {
+		cfg.RegistryMirrors = map[string]string{}
+	}
+
+	cfg.RegistryMirrors[registry] = registryMirror
+	if err := config.Write(cfg, cfgPath); err != nil {
+		return errors.Wrapf(err, "failed to write to %s", cfgPath)
+	}
+
+	logger.Infof("Registry %s configured with mirror %s", style.Symbol(registry), style.Symbol(registryMirror))
+	return nil
+}
+
+func removeRegistryMirror(args []string, logger logging.Logger, cfg config.Config, cfgPath string) error {
+	registry := args[0]
+	_, ok := cfg.RegistryMirrors[registry]
+	if !ok {
+		logger.Infof("No registry mirror has been set for %s", style.Symbol(registry))
+		return nil
+	}
+
+	delete(cfg.RegistryMirrors, registry)
+	if err := config.Write(cfg, cfgPath); err != nil {
+		return errors.Wrapf(err, "failed to write to %s", cfgPath)
+	}
+
+	logger.Infof("Removed mirror for %s", style.Symbol(registry))
+	return nil
+}
+
+func listRegistryMirrors(args []string, logger logging.Logger, cfg config.Config) {
+	if len(cfg.RegistryMirrors) == 0 {
+		logger.Info("No registry mirrors have been set")
+		return
+	}
+
+	buf := strings.Builder{}
+	buf.WriteString("Registry Mirrors:\n")
+	for registry, mirror := range cfg.RegistryMirrors {
+		buf.WriteString(fmt.Sprintf("  %s: %s\n", registry, style.Symbol(mirror)))
+	}
+
+	logger.Info(buf.String())
+}

--- a/internal/commands/config_registry_mirrors.go
+++ b/internal/commands/config_registry_mirrors.go
@@ -16,9 +16,10 @@ var registryMirror string
 
 func ConfigRegistryMirrors(logger logging.Logger, cfg config.Config, cfgPath string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "registry-mirrors",
-		Short: "List, add and remove registry mirrors",
-		Args:  cobra.MaximumNArgs(3),
+		Use:     "registry-mirrors",
+		Short:   "List, add and remove OCI registry mirrors",
+		Aliases: []string{"registry-mirror"},
+		Args:    cobra.MaximumNArgs(3),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			listRegistryMirrors(args, logger, cfg)
 			return nil
@@ -34,7 +35,7 @@ func ConfigRegistryMirrors(logger logging.Logger, cfg config.Config, cfgPath str
 	addCmd := generateAdd("mirror for a registry", logger, cfg, cfgPath, addRegistryMirror)
 	addCmd.Use = "add <registry> [-m <mirror...]"
 	addCmd.Long = "Set mirror for a given registry."
-	addCmd.Example = "pack config registry-mirrors add index.docker.io --mirror 10.0.0.1"
+	addCmd.Example = "pack config registry-mirrors add index.docker.io --mirror 10.0.0.1\npack config registry-mirrors add '*' --mirror 10.0.0.1"
 	addCmd.Flags().StringVarP(&registryMirror, "mirror", "m", "", "Registry mirror")
 	cmd.AddCommand(addCmd)
 

--- a/internal/commands/config_registry_mirrors_test.go
+++ b/internal/commands/config_registry_mirrors_test.go
@@ -1,0 +1,219 @@
+package commands_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"github.com/spf13/cobra"
+
+	"github.com/buildpacks/pack/internal/commands"
+	"github.com/buildpacks/pack/internal/config"
+	ilogging "github.com/buildpacks/pack/internal/logging"
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestConfigRegistryMirrors(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "ConfigRunImageMirrorsCommand", testConfigRegistryMirrorsCommand, spec.Random(), spec.Report(report.Terminal{}))
+}
+
+func testConfigRegistryMirrorsCommand(t *testing.T, when spec.G, it spec.S) {
+	var (
+		cmd          *cobra.Command
+		logger       logging.Logger
+		outBuf       bytes.Buffer
+		tempPackHome string
+		configPath   string
+		registry1    = "index.docker.io"
+		registry2    = "us.gcr.io"
+		testMirror1  = "10.0.0.1"
+		testMirror2  = "10.0.0.2"
+		testCfg      = config.Config{
+			RegistryMirrors: map[string]string{
+				registry1: testMirror1,
+				registry2: testMirror2,
+			},
+		}
+	)
+
+	it.Before(func() {
+		var err error
+		logger = ilogging.NewLogWithWriters(&outBuf, &outBuf)
+		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		h.AssertNil(t, err)
+		configPath = filepath.Join(tempPackHome, "config.toml")
+
+		cmd = commands.ConfigRegistryMirrors(logger, testCfg, configPath)
+		cmd.SetOut(logging.GetWriterForLevel(logger, logging.InfoLevel))
+	})
+
+	it.After(func() {
+		h.AssertNil(t, os.RemoveAll(tempPackHome))
+	})
+
+	when("-h", func() {
+		it("prints available commands", func() {
+			cmd.SetArgs([]string{"-h"})
+			h.AssertNil(t, cmd.Execute())
+			output := outBuf.String()
+			h.AssertContains(t, output, "Usage:")
+			for _, command := range []string{"add", "remove", "list"} {
+				h.AssertContains(t, output, command)
+			}
+		})
+	})
+
+	when("no arguments", func() {
+		it("lists registry mirrors", func() {
+			cmd.SetArgs([]string{})
+			h.AssertNil(t, cmd.Execute())
+			output := outBuf.String()
+			h.AssertContains(t, strings.TrimSpace(output), `Registry Mirrors:`)
+			h.AssertContains(t, strings.TrimSpace(output), `index.docker.io: '10.0.0.1'`)
+			h.AssertContains(t, strings.TrimSpace(output), `us.gcr.io: '10.0.0.2'`)
+		})
+	})
+
+	when("add", func() {
+		when("no registry is specified", func() {
+			it("fails to run", func() {
+				cmd.SetArgs([]string{"add"})
+				err := cmd.Execute()
+				h.AssertError(t, err, "accepts 1 arg")
+			})
+		})
+
+		when("config path doesn't exist", func() {
+			it("fails to run", func() {
+				fakePath := filepath.Join(tempPackHome, "not-exist.toml")
+				h.AssertNil(t, ioutil.WriteFile(fakePath, []byte("something"), 0001))
+				cmd = commands.ConfigRegistryMirrors(logger, config.Config{}, fakePath)
+				cmd.SetArgs([]string{"add", registry1, "-m", testMirror1})
+
+				err := cmd.Execute()
+				h.AssertError(t, err, "failed to write to")
+			})
+		})
+
+		when("mirrors are provided", func() {
+			it("adds them as mirrors to the config", func() {
+				cmd.SetArgs([]string{"add", "asia.gcr.io", "-m", "10.0.0.3"})
+				h.AssertNil(t, cmd.Execute())
+				cfg, err := config.Read(configPath)
+				h.AssertNil(t, err)
+				h.AssertEq(t, cfg, config.Config{
+					RegistryMirrors: map[string]string{
+						registry1:     testMirror1,
+						registry2:     testMirror2,
+						"asia.gcr.io": "10.0.0.3",
+					},
+				})
+			})
+
+			it("replaces pre-existing mirrors in the config", func() {
+				cmd.SetArgs([]string{"add", registry1, "-m", "10.0.0.3"})
+				h.AssertNil(t, cmd.Execute())
+				cfg, err := config.Read(configPath)
+				h.AssertNil(t, err)
+				h.AssertEq(t, cfg, config.Config{
+					RegistryMirrors: map[string]string{
+						registry1: "10.0.0.3",
+						registry2: testMirror2,
+					},
+				})
+			})
+		})
+
+		when("no mirrors are provided", func() {
+			it("preserves old mirrors, and prints helpful message", func() {
+				cmd.SetArgs([]string{"add", registry1})
+				h.AssertNil(t, cmd.Execute())
+				h.AssertContains(t, outBuf.String(), "A registry mirror was not provided")
+			})
+		})
+	})
+
+	when("remove", func() {
+		when("no registry is specified", func() {
+			it("fails to run", func() {
+				cmd.SetArgs([]string{"remove"})
+				err := cmd.Execute()
+				h.AssertError(t, err, "accepts 1 arg")
+			})
+		})
+
+		when("registry provided isn't present", func() {
+			it("prints a clear message", func() {
+				fakeImage := "not-set-image"
+				cmd.SetArgs([]string{"remove", fakeImage})
+				h.AssertNil(t, cmd.Execute())
+				output := outBuf.String()
+				h.AssertContains(t, output, fmt.Sprintf("No registry mirror has been set for %s", style.Symbol(fakeImage)))
+			})
+		})
+
+		when("config path doesn't exist", func() {
+			it("fails to run", func() {
+				fakePath := filepath.Join(tempPackHome, "not-exist.toml")
+				h.AssertNil(t, ioutil.WriteFile(fakePath, []byte("something"), 0001))
+				cmd = commands.ConfigRegistryMirrors(logger, testCfg, fakePath)
+				cmd.SetArgs([]string{"remove", registry1})
+
+				err := cmd.Execute()
+				h.AssertError(t, err, "failed to write to")
+			})
+		})
+
+		when("registry is provided", func() {
+			it("removes the given registry", func() {
+				cmd.SetArgs([]string{"remove", registry1})
+				h.AssertNil(t, cmd.Execute())
+				cfg, err := config.Read(configPath)
+				h.AssertNil(t, err)
+				h.AssertEq(t, cfg.RegistryMirrors, map[string]string{
+					registry2: testMirror2,
+				})
+			})
+		})
+	})
+
+	when("list", func() {
+		when("mirrors were previously set", func() {
+			it("lists registry mirrors", func() {
+				cmd.SetArgs([]string{"list"})
+				h.AssertNil(t, cmd.Execute())
+				output := outBuf.String()
+				h.AssertContains(t, output, registry1)
+				h.AssertContains(t, output, testMirror1)
+				h.AssertContains(t, output, registry2)
+				h.AssertContains(t, output, testMirror2)
+			})
+		})
+
+		when("no registry mirrors were set", func() {
+			it("prints a clear message", func() {
+				cmd = commands.ConfigRegistryMirrors(logger, config.Config{}, configPath)
+				cmd.SetArgs([]string{"list"})
+				h.AssertNil(t, cmd.Execute())
+				output := outBuf.String()
+				h.AssertNotContains(t, output, registry1)
+				h.AssertNotContains(t, output, testMirror1)
+				h.AssertNotContains(t, output, registry2)
+				h.AssertNotContains(t, output, testMirror2)
+
+				h.AssertContains(t, output, "No registry mirrors have been set")
+			})
+		})
+	})
+}

--- a/internal/commands/config_test.go
+++ b/internal/commands/config_test.go
@@ -62,7 +62,7 @@ func testConfigCommand(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNil(t, command.Execute())
 			output := outBuf.String()
 			h.AssertContains(t, output, "Usage:")
-			for _, command := range []string{"trusted-builders", "run-image-mirrors", "default-builder", "experimental", "registries", "pull-policy"} {
+			for _, command := range []string{"trusted-builders", "run-image-mirrors", "default-builder", "experimental", "registries", "pull-policy", "registry-mirrors"} {
 				h.AssertContains(t, output, command)
 			}
 		})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,15 +12,16 @@ import (
 
 type Config struct {
 	// Deprecated: Use DefaultRegistryName instead. See https://github.com/buildpacks/pack/issues/747.
-	DefaultRegistry     string           `toml:"default-registry-url,omitempty"`
-	DefaultRegistryName string           `toml:"default-registry,omitempty"`
-	DefaultBuilder      string           `toml:"default-builder-image,omitempty"`
-	PullPolicy          string           `toml:"pull-policy,omitempty"`
-	Experimental        bool             `toml:"experimental,omitempty"`
-	RunImages           []RunImage       `toml:"run-images"`
-	TrustedBuilders     []TrustedBuilder `toml:"trusted-builders,omitempty"`
-	Registries          []Registry       `toml:"registries,omitempty"`
-	LifecycleImage      string           `toml:"lifecycle-image,omitempty"`
+	DefaultRegistry     string            `toml:"default-registry-url,omitempty"`
+	DefaultRegistryName string            `toml:"default-registry,omitempty"`
+	DefaultBuilder      string            `toml:"default-builder-image,omitempty"`
+	PullPolicy          string            `toml:"pull-policy,omitempty"`
+	Experimental        bool              `toml:"experimental,omitempty"`
+	RunImages           []RunImage        `toml:"run-images"`
+	TrustedBuilders     []TrustedBuilder  `toml:"trusted-builders,omitempty"`
+	Registries          []Registry        `toml:"registries,omitempty"`
+	LifecycleImage      string            `toml:"lifecycle-image,omitempty"`
+	RegistryMirrors     map[string]string `toml:"registry-mirrors,omitempty"`
 }
 
 type Registry struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,6 +46,7 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, subject.DefaultBuilder, "")
 				h.AssertEq(t, len(subject.RunImages), 0)
 				h.AssertEq(t, subject.Experimental, false)
+				h.AssertEq(t, len(subject.RegistryMirrors), 0)
 			})
 		})
 	})
@@ -68,7 +69,11 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 					TrustedBuilders: []config.TrustedBuilder{
 						{Name: "some-trusted-builder"},
 					},
+					RegistryMirrors: map[string]string{
+						"index.docker.io": "10.0.0.1",
+					},
 				}, configPath))
+
 				b, err := ioutil.ReadFile(configPath)
 				h.AssertNil(t, err)
 				h.AssertContains(t, string(b), `default-builder-image = "some/builder"`)
@@ -82,6 +87,9 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertContains(t, string(b), `[[trusted-builders]]
   name = "some-trusted-builder"`)
+
+				h.AssertContains(t, string(b), `[registry-mirrors]
+  "index.docker.io" = "10.0.0.1"`)
 			})
 		})
 

--- a/internal/image/fetcher.go
+++ b/internal/image/fetcher.go
@@ -63,7 +63,7 @@ func NewFetcher(logger logging.Logger, docker client.CommonAPIClient, opts ...Fe
 var ErrNotFound = errors.New("not found")
 
 func (f *Fetcher) Fetch(ctx context.Context, name string, options FetchOptions) (imgutil.Image, error) {
-	name, err := pname.TranslateRegistry(name, f.registryMirrors)
+	name, err := pname.TranslateRegistry(name, f.registryMirrors, f.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/image/fetcher.go
+++ b/internal/image/fetcher.go
@@ -19,13 +19,26 @@ import (
 
 	"github.com/buildpacks/pack/config"
 	ilogging "github.com/buildpacks/pack/internal/logging"
+	pname "github.com/buildpacks/pack/internal/name"
 	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/logging"
 )
 
+// FetcherOption is a type of function that mutate settings on the client.
+// Values in these functions are set through currying.
+type FetcherOption func(c *Fetcher)
+
+// WithRegistryMirrors supply your own mirrors for registry.
+func WithRegistryMirrors(registryMirrors map[string]string) FetcherOption {
+	return func(c *Fetcher) {
+		c.registryMirrors = registryMirrors
+	}
+}
+
 type Fetcher struct {
-	docker client.CommonAPIClient
-	logger logging.Logger
+	docker          client.CommonAPIClient
+	logger          logging.Logger
+	registryMirrors map[string]string
 }
 
 type FetchOptions struct {
@@ -34,16 +47,27 @@ type FetchOptions struct {
 	PullPolicy config.PullPolicy
 }
 
-func NewFetcher(logger logging.Logger, docker client.CommonAPIClient) *Fetcher {
-	return &Fetcher{
+func NewFetcher(logger logging.Logger, docker client.CommonAPIClient, opts ...FetcherOption) *Fetcher {
+	var fetcher = &Fetcher{
 		logger: logger,
 		docker: docker,
 	}
+
+	for _, opt := range opts {
+		opt(fetcher)
+	}
+
+	return fetcher
 }
 
 var ErrNotFound = errors.New("not found")
 
 func (f *Fetcher) Fetch(ctx context.Context, name string, options FetchOptions) (imgutil.Image, error) {
+	name, err := pname.TranslateRegistry(name, f.registryMirrors)
+	if err != nil {
+		return nil, err
+	}
+
 	if !options.Daemon {
 		return f.fetchRemoteImage(name)
 	}
@@ -60,7 +84,7 @@ func (f *Fetcher) Fetch(ctx context.Context, name string, options FetchOptions) 
 	}
 
 	f.logger.Debugf("Pulling image %s", style.Symbol(name))
-	err := f.pullImage(ctx, name, options.Platform)
+	err = f.pullImage(ctx, name, options.Platform)
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, err
 	}

--- a/internal/name/name.go
+++ b/internal/name/name.go
@@ -1,0 +1,32 @@
+package name
+
+import (
+	"fmt"
+
+	gname "github.com/google/go-containerregistry/pkg/name"
+)
+
+func TranslateRegistry(name string, registryMirrors map[string]string) (string, error) {
+	if registryMirrors == nil {
+		return name, nil
+	}
+
+	srcRef, err := gname.ParseReference(name, gname.WeakValidation)
+	if err != nil {
+		return "", err
+	}
+
+	srcContext := srcRef.Context()
+	registryMirror, ok := registryMirrors[srcContext.RegistryStr()]
+	if !ok {
+		return name, nil
+	}
+
+	refName := fmt.Sprintf("%s/%s:%s", registryMirror, srcContext.RepositoryStr(), srcRef.Identifier())
+	_, err = gname.ParseReference(refName, gname.WeakValidation)
+	if err != nil {
+		return "", err
+	}
+
+	return refName, nil
+}

--- a/internal/name/name.go
+++ b/internal/name/name.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 
 	gname "github.com/google/go-containerregistry/pkg/name"
+
+	"github.com/buildpacks/pack/internal/style"
+	"github.com/buildpacks/pack/logging"
 )
 
-func TranslateRegistry(name string, registryMirrors map[string]string) (string, error) {
+func TranslateRegistry(name string, registryMirrors map[string]string, logger logging.Logger) (string, error) {
 	if registryMirrors == nil {
 		return name, nil
 	}
@@ -28,6 +31,7 @@ func TranslateRegistry(name string, registryMirrors map[string]string) (string, 
 		return "", err
 	}
 
+	logger.Infof("Using mirror %s for %s", style.Symbol(refName), name)
 	return refName, nil
 }
 

--- a/internal/name/name.go
+++ b/internal/name/name.go
@@ -17,7 +17,7 @@ func TranslateRegistry(name string, registryMirrors map[string]string) (string, 
 	}
 
 	srcContext := srcRef.Context()
-	registryMirror, ok := registryMirrors[srcContext.RegistryStr()]
+	registryMirror, ok := getMirror(srcContext, registryMirrors)
 	if !ok {
 		return name, nil
 	}
@@ -29,4 +29,14 @@ func TranslateRegistry(name string, registryMirrors map[string]string) (string, 
 	}
 
 	return refName, nil
+}
+
+func getMirror(repo gname.Repository, registryMirrors map[string]string) (string, bool) {
+	mirror, ok := registryMirrors["*"]
+	if ok {
+		return mirror, ok
+	}
+
+	mirror, ok = registryMirrors[repo.RegistryStr()]
+	return mirror, ok
 }

--- a/internal/name/name_test.go
+++ b/internal/name/name_test.go
@@ -1,0 +1,54 @@
+package name_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpacks/pack/internal/name"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestTranslateRegistry(t *testing.T) {
+	spec.Run(t, "TranslateRegistry", testTranslateRegistry, spec.Report(report.Terminal{}))
+}
+
+func testTranslateRegistry(t *testing.T, when spec.G, it spec.S) {
+	var (
+		assert = h.NewAssertionManager(t)
+	)
+
+	when("#TranslateRegistry", func() {
+		it("doesn't translate when there are no mirrors", func() {
+			input := "index.docker.io/my/buildpack:0.1"
+
+			output, err := name.TranslateRegistry(input, nil)
+			assert.Nil(err)
+			assert.Equal(output, input)
+		})
+
+		it("doesn't translate when there are is no matching mirrors", func() {
+			input := "index.docker.io/my/buildpack:0.1"
+			registryMirrors := map[string]string{
+				"us.gcr.io": "10.0.0.1",
+			}
+
+			output, err := name.TranslateRegistry(input, registryMirrors)
+			assert.Nil(err)
+			assert.Equal(output, input)
+		})
+
+		it("translates when there is a mirror", func() {
+			input := "index.docker.io/my/buildpack:0.1"
+			expected := "10.0.0.1/my/buildpack:0.1"
+			registryMirrors := map[string]string{
+				"index.docker.io": "10.0.0.1",
+			}
+
+			output, err := name.TranslateRegistry(input, registryMirrors)
+			assert.Nil(err)
+			assert.Equal(output, expected)
+		})
+	})
+}

--- a/internal/name/name_test.go
+++ b/internal/name/name_test.go
@@ -1,12 +1,14 @@
 package name_test
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/pack/internal/name"
+	"github.com/buildpacks/pack/logging"
 	h "github.com/buildpacks/pack/testhelpers"
 )
 
@@ -17,13 +19,14 @@ func TestTranslateRegistry(t *testing.T) {
 func testTranslateRegistry(t *testing.T, when spec.G, it spec.S) {
 	var (
 		assert = h.NewAssertionManager(t)
+		logger = logging.New(ioutil.Discard)
 	)
 
 	when("#TranslateRegistry", func() {
 		it("doesn't translate when there are no mirrors", func() {
 			input := "index.docker.io/my/buildpack:0.1"
 
-			output, err := name.TranslateRegistry(input, nil)
+			output, err := name.TranslateRegistry(input, nil, logger)
 			assert.Nil(err)
 			assert.Equal(output, input)
 		})
@@ -34,7 +37,7 @@ func testTranslateRegistry(t *testing.T, when spec.G, it spec.S) {
 				"us.gcr.io": "10.0.0.1",
 			}
 
-			output, err := name.TranslateRegistry(input, registryMirrors)
+			output, err := name.TranslateRegistry(input, registryMirrors, logger)
 			assert.Nil(err)
 			assert.Equal(output, input)
 		})
@@ -46,7 +49,7 @@ func testTranslateRegistry(t *testing.T, when spec.G, it spec.S) {
 				"index.docker.io": "10.0.0.1",
 			}
 
-			output, err := name.TranslateRegistry(input, registryMirrors)
+			output, err := name.TranslateRegistry(input, registryMirrors, logger)
 			assert.Nil(err)
 			assert.Equal(output, expected)
 		})
@@ -59,7 +62,7 @@ func testTranslateRegistry(t *testing.T, when spec.G, it spec.S) {
 				"*":               "10.0.0.2",
 			}
 
-			output, err := name.TranslateRegistry(input, registryMirrors)
+			output, err := name.TranslateRegistry(input, registryMirrors, logger)
 			assert.Nil(err)
 			assert.Equal(output, expected)
 		})

--- a/internal/name/name_test.go
+++ b/internal/name/name_test.go
@@ -50,5 +50,18 @@ func testTranslateRegistry(t *testing.T, when spec.G, it spec.S) {
 			assert.Nil(err)
 			assert.Equal(output, expected)
 		})
+
+		it("prefers the wildcard mirror translation", func() {
+			input := "index.docker.io/my/buildpack:0.1"
+			expected := "10.0.0.2/my/buildpack:0.1"
+			registryMirrors := map[string]string{
+				"index.docker.io": "10.0.0.1",
+				"*":               "10.0.0.2",
+			}
+
+			output, err := name.TranslateRegistry(input, registryMirrors)
+			assert.Nil(err)
+			assert.Equal(output, expected)
+		})
 	})
 }


### PR DESCRIPTION
## Summary
Add support for a registry mirroring  during **pack build** command. The use-case being enterprise environments where public registry access is denied.

If pack's `config.toml` is configured like:
```toml
[registry-mirrors]
  "index.docker.io" = "nexus.mycompany.local/mirror"
```

Then requests from registries`paketobuildpacks/builder` will be turned into `nexus.mycompany.local/mirror/paketobuildpacks/builder`

This PR also adds the config subcommands to manipulate these entries to config.toml.

## Output
#### Before
```bash
$ pack build aemengo/hello
full: Pulling from paketobuildpacks/builder
Digest: sha256:2917564c2de52debd1df70d11c014b2708c8974e6e853804958825be84cfb859
Status: Image is up to date for paketobuildpacks/builder:full
...
```
#### After

```bash
$ pack build aemengo/hello
full: Pulling from mirror/paketobuildpacks/builder
Digest: sha256:2917564c2de52debd1df70d11c014b2708c8974e6e853804958825be84cfb859
Status: Image is up to date for nexus.mycompany.local/mirror/dockerhub-mirror/paketobuildpacks/builder:full
...
```

## Caveats
* The user entered `image-tag` is not modified. Not sure if this is desired behavior or not. 🤷🏾‍♂️

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves https://github.com/buildpacks/pack/issues/821
