### PR TITLE
Concurrency Support for Registry Caching

### DIFF
--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -187,7 +188,15 @@ func (r *Cache) CreateCache() error {
 		return err
 	}
 
-	return os.Rename(w.Filesystem.Root(), r.Root)
+	err = os.Rename(w.Filesystem.Root(), r.Root)
+	if err != nil {
+		// If pack is run concurrently, this action might have already occured
+		if strings.Contains(err.Error(), "file exists") {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (r *Cache) validateCache() error {

--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -190,8 +189,8 @@ func (r *Cache) CreateCache() error {
 
 	err = os.Rename(w.Filesystem.Root(), r.Root)
 	if err != nil {
-		// If pack is run concurrently, this action might have already occured
-		if strings.Contains(err.Error(), "file exists") {
+		if err == os.ErrExist {
+			// If pack is run concurrently, this action might have already occured
 			return nil
 		}
 		return err


### PR DESCRIPTION
### Summary
If the pack command is run concurrently and registry caches are constructured, there is a racecase which occurs where both invocations will attempt to update the fs

## Output

#### Before

file exists ERROR: failed to build: locating in registry heroku/nodejs-yarn@0.1.3: refreshing cache: initializing (<$HOME>/.pack/registry-a932275bd19c2d9e1b88fa06698fd2f5427a363d25bf87fa500691c373089381): creating registry cache: rename /tmp/registry373937049 <$HOME>/.pack/registry-a932275bd19c2d9e1b88fa06698fd2f5427a363d25bf87fa500691c373089381: file exists

This change captures and passes on that error

#### After

<no error>

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
