### PR TITLE
Use lifecycle image that matches builder platform

### DIFF
--- a/build.go
+++ b/build.go
@@ -333,10 +333,16 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 			if lifecycleImageName == "" {
 				lifecycleImageName = fmt.Sprintf("%s:%s", internalConfig.DefaultLifecycleImageRepo, lifecycleVersion.String())
 			}
+
+			imgArch, err := rawBuilderImage.Architecture()
+			if err != nil {
+				return errors.Wrapf(err, "getting builder architecture")
+			}
+
 			lifecycleImage, err := c.imageFetcher.Fetch(
 				ctx,
 				lifecycleImageName,
-				image.FetchOptions{Daemon: true, PullPolicy: opts.PullPolicy},
+				image.FetchOptions{Daemon: true, PullPolicy: opts.PullPolicy, Platform: fmt.Sprintf("%s/%s", imgOS, imgArch)},
 			)
 			if err != nil {
 				return errors.Wrap(err, "fetching lifecycle image")

--- a/build.go
+++ b/build.go
@@ -27,6 +27,7 @@ import (
 	"github.com/buildpacks/pack/internal/buildpackage"
 	internalConfig "github.com/buildpacks/pack/internal/config"
 	"github.com/buildpacks/pack/internal/dist"
+	"github.com/buildpacks/pack/internal/image"
 	"github.com/buildpacks/pack/internal/layer"
 	"github.com/buildpacks/pack/internal/paths"
 	"github.com/buildpacks/pack/internal/stack"
@@ -212,7 +213,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		return errors.Wrapf(err, "invalid builder '%s'", opts.Builder)
 	}
 
-	rawBuilderImage, err := c.imageFetcher.Fetch(ctx, builderRef.Name(), true, opts.PullPolicy)
+	rawBuilderImage, err := c.imageFetcher.Fetch(ctx, builderRef.Name(), image.FetchOptions{Daemon: true, PullPolicy: opts.PullPolicy})
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch builder image '%s'", builderRef.Name())
 	}
@@ -335,8 +336,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 			lifecycleImage, err := c.imageFetcher.Fetch(
 				ctx,
 				lifecycleImageName,
-				true,
-				opts.PullPolicy,
+				image.FetchOptions{Daemon: true, PullPolicy: opts.PullPolicy},
 			)
 			if err != nil {
 				return errors.Wrap(err, "fetching lifecycle image")
@@ -423,7 +423,7 @@ func (c *Client) validateRunImage(context context.Context, name string, pullPoli
 	if name == "" {
 		return nil, errors.New("run image must be specified")
 	}
-	img, err := c.imageFetcher.Fetch(context, name, !publish, pullPolicy)
+	img, err := c.imageFetcher.Fetch(context, name, image.FetchOptions{Daemon: !publish, PullPolicy: pullPolicy})
 	if err != nil {
 		return nil, err
 	}
@@ -862,7 +862,7 @@ func (c *Client) logImageNameAndSha(ctx context.Context, publish bool, imageRef 
 		return nil
 	}
 
-	img, err := c.imageFetcher.Fetch(ctx, imageRef.Name(), !publish, config.PullNever)
+	img, err := c.imageFetcher.Fetch(ctx, imageRef.Name(), image.FetchOptions{Daemon: !publish, PullPolicy: config.PullNever})
 	if err != nil {
 		return errors.Wrap(err, "fetching built image")
 	}

--- a/build_test.go
+++ b/build_test.go
@@ -1439,6 +1439,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 							args := fakeImageFetcher.FetchCalls[fakeLifecycleImage.Name()]
 							h.AssertEq(t, args.Daemon, true)
 							h.AssertEq(t, args.PullPolicy, config.PullAlways)
+							h.AssertEq(t, args.Platform, "linux/amd64")
 						})
 					})
 
@@ -1522,6 +1523,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 							args := fakeImageFetcher.FetchCalls[fakeLifecycleImage.Name()]
 							h.AssertEq(t, args.Daemon, true)
 							h.AssertEq(t, args.PullPolicy, config.PullAlways)
+							h.AssertEq(t, args.Platform, "linux/amd64")
 						})
 
 						it("suggests that being untrusted may be the root of a failure", func() {
@@ -1605,6 +1607,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					args = fakeImageFetcher.FetchCalls["buildpacksio/lifecycle:0.11.3"]
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.PullPolicy, config.PullNever)
+					h.AssertEq(t, args.Platform, "linux/amd64")
 				})
 			})
 

--- a/client.go
+++ b/client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/pkg/errors"
 
-	pubcfg "github.com/buildpacks/pack/config"
 	"github.com/buildpacks/pack/internal/blob"
 	"github.com/buildpacks/pack/internal/build"
 	"github.com/buildpacks/pack/internal/config"
@@ -33,7 +32,7 @@ type ImageFetcher interface {
 	// These PullPolicies that these interact with the daemon argument.
 	// PullIfNotPresent and daemon = false, gives us the same behavior as PullAlways.
 	// There is a single invalid configuration, PullNever and daemon = false, this will always fail.
-	Fetch(ctx context.Context, name string, daemon bool, pullPolicy pubcfg.PullPolicy) (imgutil.Image, error)
+	Fetch(ctx context.Context, name string, options image.FetchOptions) (imgutil.Image, error)
 }
 
 //go:generate mockgen -package testmocks -destination testmocks/mock_downloader.go github.com/buildpacks/pack Downloader

--- a/create_builder.go
+++ b/create_builder.go
@@ -80,7 +80,7 @@ func (c *Client) validateRunImageConfig(ctx context.Context, opts CreateBuilderO
 	var runImages []imgutil.Image
 	for _, i := range append([]string{opts.Config.Stack.RunImage}, opts.Config.Stack.RunImageMirrors...) {
 		if !opts.Publish {
-			img, err := c.imageFetcher.Fetch(ctx, i, true, opts.PullPolicy)
+			img, err := c.imageFetcher.Fetch(ctx, i, image.FetchOptions{Daemon: true, PullPolicy: opts.PullPolicy})
 			if err != nil {
 				if errors.Cause(err) != image.ErrNotFound {
 					return errors.Wrap(err, "failed to fetch image")
@@ -91,7 +91,7 @@ func (c *Client) validateRunImageConfig(ctx context.Context, opts CreateBuilderO
 			}
 		}
 
-		img, err := c.imageFetcher.Fetch(ctx, i, false, opts.PullPolicy)
+		img, err := c.imageFetcher.Fetch(ctx, i, image.FetchOptions{Daemon: false, PullPolicy: opts.PullPolicy})
 		if err != nil {
 			if errors.Cause(err) != image.ErrNotFound {
 				return errors.Wrap(err, "failed to fetch image")
@@ -122,7 +122,7 @@ func (c *Client) validateRunImageConfig(ctx context.Context, opts CreateBuilderO
 }
 
 func (c *Client) createBaseBuilder(ctx context.Context, opts CreateBuilderOptions) (*builder.Builder, error) {
-	baseImage, err := c.imageFetcher.Fetch(ctx, opts.Config.Stack.BuildImage, !opts.Publish, opts.PullPolicy)
+	baseImage, err := c.imageFetcher.Fetch(ctx, opts.Config.Stack.BuildImage, image.FetchOptions{Daemon: !opts.Publish, PullPolicy: opts.PullPolicy})
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch build image")
 	}

--- a/inspect_builder_test.go
+++ b/inspect_builder_test.go
@@ -71,9 +71,9 @@ func testInspectBuilder(t *testing.T, when spec.G, it spec.S) {
 			when(fmt.Sprintf("daemon is %t", useDaemon), func() {
 				it.Before(func() {
 					if useDaemon {
-						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", true, config.PullNever).Return(builderImage, nil)
+						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", image.FetchOptions{Daemon: true, PullPolicy: config.PullNever}).Return(builderImage, nil)
 					} else {
-						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", false, config.PullNever).Return(builderImage, nil)
+						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", image.FetchOptions{Daemon: false, PullPolicy: config.PullNever}).Return(builderImage, nil)
 					}
 				})
 
@@ -406,7 +406,7 @@ func testInspectBuilder(t *testing.T, when spec.G, it spec.S) {
 		it.Before(func() {
 			notFoundImage := fakes.NewImage("", "", nil)
 			notFoundImage.Delete()
-			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", true, config.PullNever).Return(nil, errors.Wrap(image.ErrNotFound, "some-error"))
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/builder", image.FetchOptions{Daemon: true, PullPolicy: config.PullNever}).Return(nil, errors.Wrap(image.ErrNotFound, "some-error"))
 		})
 
 		it("return nil metadata", func() {

--- a/inspect_buildpack.go
+++ b/inspect_buildpack.go
@@ -7,12 +7,12 @@ import (
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/buildpacks/pack/internal/style"
-
 	"github.com/buildpacks/pack/config"
 	"github.com/buildpacks/pack/internal/buildpack"
 	"github.com/buildpacks/pack/internal/buildpackage"
 	"github.com/buildpacks/pack/internal/dist"
+	"github.com/buildpacks/pack/internal/image"
+	"github.com/buildpacks/pack/internal/style"
 )
 
 type BuildpackInfo struct {
@@ -109,7 +109,7 @@ func metadataFromArchive(downloader Downloader, path string) (buildpackMd buildp
 
 func metadataFromImage(client *Client, name string, daemon bool) (buildpackMd buildpackage.Metadata, layersMd dist.BuildpackLayers, err error) {
 	imageName := buildpack.ParsePackageLocator(name)
-	img, err := client.imageFetcher.Fetch(context.Background(), imageName, daemon, config.PullNever)
+	img, err := client.imageFetcher.Fetch(context.Background(), imageName, image.FetchOptions{Daemon: daemon, PullPolicy: config.PullNever})
 	if err != nil {
 		return buildpackage.Metadata{}, dist.BuildpackLayers{}, err
 	}

--- a/inspect_buildpack_test.go
+++ b/inspect_buildpack_test.go
@@ -382,8 +382,7 @@ func testInspectBuildpack(t *testing.T, when spec.G, it spec.S) {
 				mockImageFetcher.EXPECT().Fetch(
 					gomock.Any(),
 					"example.com/some/package@sha256:8c27fe111c11b722081701dfed3bd55e039b9ce92865473cf4cdfa918071c566",
-					false,
-					config.PullNever).Return(buildpackImage, nil)
+					image.FetchOptions{Daemon: false, PullPolicy: config.PullNever}).Return(buildpackImage, nil)
 			})
 
 			it.After(func() {
@@ -430,9 +429,9 @@ func testInspectBuildpack(t *testing.T, when spec.G, it spec.S) {
 					it.Before(func() {
 						expectedInfo.Location = buildpack.PackageLocator
 						if useDaemon {
-							mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/buildpack", true, config.PullNever).Return(buildpackImage, nil)
+							mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/buildpack", image.FetchOptions{Daemon: true, PullPolicy: config.PullNever}).Return(buildpackImage, nil)
 						} else {
-							mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/buildpack", false, config.PullNever).Return(buildpackImage, nil)
+							mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/buildpack", image.FetchOptions{Daemon: false, PullPolicy: config.PullNever}).Return(buildpackImage, nil)
 						}
 					})
 
@@ -466,7 +465,7 @@ func testInspectBuildpack(t *testing.T, when spec.G, it spec.S) {
 		when("buildpack image", func() {
 			when("unable to fetch buildpack image", func() {
 				it.Before(func() {
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "missing/buildpack", true, config.PullNever).Return(nil, errors.Wrapf(image.ErrNotFound, "big bad error"))
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "missing/buildpack", image.FetchOptions{Daemon: true, PullPolicy: config.PullNever}).Return(nil, errors.Wrapf(image.ErrNotFound, "big bad error"))
 				})
 				it("returns an ErrNotFound error", func() {
 					inspectOptions := pack.InspectBuildpackOptions{
@@ -482,7 +481,7 @@ func testInspectBuildpack(t *testing.T, when spec.G, it spec.S) {
 				it.Before(func() {
 					fakeImage := fakes.NewImage("empty", "", nil)
 					h.AssertNil(t, fakeImage.SetLabel(dist.BuildpackLayersLabel, ":::"))
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "missing-metadata/buildpack", true, config.PullNever).Return(fakeImage, nil)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "missing-metadata/buildpack", image.FetchOptions{Daemon: true, PullPolicy: config.PullNever}).Return(fakeImage, nil)
 				})
 				it("returns an error", func() {
 					inspectOptions := pack.InspectBuildpackOptions{
@@ -604,8 +603,7 @@ func testInspectBuildpack(t *testing.T, when spec.G, it spec.S) {
 					mockImageFetcher.EXPECT().Fetch(
 						gomock.Any(),
 						"example.com/some/package@sha256:2560f05307e8de9d830f144d09556e19dd1eb7d928aee900ed02208ae9727e7a",
-						false,
-						config.PullNever).Return(nil, image.ErrNotFound)
+						image.FetchOptions{Daemon: false, PullPolicy: config.PullNever}).Return(nil, image.ErrNotFound)
 				})
 				it("returns an untyped error", func() {
 					registryBuildpack := "urn:cnb:registry:example/foo"

--- a/inspect_image.go
+++ b/inspect_image.go
@@ -86,7 +86,7 @@ const (
 // If daemon is true, first the local registry will be searched for the image.
 // Otherwise it assumes the image is remote.
 func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
-	img, err := c.imageFetcher.Fetch(context.Background(), name, daemon, config.PullNever)
+	img, err := c.imageFetcher.Fetch(context.Background(), name, image.FetchOptions{Daemon: daemon, PullPolicy: config.PullNever})
 	if err != nil {
 		if errors.Cause(err) == image.ErrNotFound {
 			return nil, nil

--- a/inspect_image_test.go
+++ b/inspect_image_test.go
@@ -116,9 +116,9 @@ func testInspectImage(t *testing.T, when spec.G, it spec.S) {
 			when(fmt.Sprintf("daemon is %t", useDaemon), func() {
 				it.Before(func() {
 					if useDaemon {
-						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/image", true, config.PullNever).Return(mockImage, nil)
+						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/image", image.FetchOptions{Daemon: true, PullPolicy: config.PullNever}).Return(mockImage, nil)
 					} else {
-						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/image", false, config.PullNever).Return(mockImage, nil)
+						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/image", image.FetchOptions{Daemon: false, PullPolicy: config.PullNever}).Return(mockImage, nil)
 					}
 				})
 
@@ -538,7 +538,7 @@ func testInspectImage(t *testing.T, when spec.G, it spec.S) {
 
 	when("the image doesn't exist", func() {
 		it("returns nil", func() {
-			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "not/some-image", true, config.PullNever).Return(nil, image.ErrNotFound)
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "not/some-image", image.FetchOptions{Daemon: true, PullPolicy: config.PullNever}).Return(nil, image.ErrNotFound)
 
 			info, err := subject.InspectImage("not/some-image", true)
 			h.AssertNil(t, err)
@@ -548,7 +548,7 @@ func testInspectImage(t *testing.T, when spec.G, it spec.S) {
 
 	when("there is an error fetching the image", func() {
 		it("returns the error", func() {
-			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "not/some-image", true, config.PullNever).Return(nil, errors.New("some-error"))
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "not/some-image", image.FetchOptions{Daemon: true, PullPolicy: config.PullNever}).Return(nil, errors.New("some-error"))
 
 			_, err := subject.InspectImage("not/some-image", true)
 			h.AssertError(t, err, "some-error")
@@ -558,7 +558,7 @@ func testInspectImage(t *testing.T, when spec.G, it spec.S) {
 	when("the image is missing labels", func() {
 		it("returns empty data", func() {
 			mockImageFetcher.EXPECT().
-				Fetch(gomock.Any(), "missing/labels", true, config.PullNever).
+				Fetch(gomock.Any(), "missing/labels", image.FetchOptions{Daemon: true, PullPolicy: config.PullNever}).
 				Return(fakes.NewImage("missing/labels", "", nil), nil)
 			info, err := subject.InspectImage("missing/labels", true)
 			h.AssertNil(t, err)
@@ -572,7 +572,7 @@ func testInspectImage(t *testing.T, when spec.G, it spec.S) {
 		it.Before(func() {
 			badImage = fakes.NewImage("bad/image", "", nil)
 			mockImageFetcher.EXPECT().
-				Fetch(gomock.Any(), "bad/image", true, config.PullNever).
+				Fetch(gomock.Any(), "bad/image", image.FetchOptions{Daemon: true, PullPolicy: config.PullNever}).
 				Return(badImage, nil)
 		})
 
@@ -592,7 +592,7 @@ func testInspectImage(t *testing.T, when spec.G, it spec.S) {
 	when("lifecycle version is 0.4.x or earlier", func() {
 		it("includes an empty base image reference", func() {
 			oldImage := fakes.NewImage("old/image", "", nil)
-			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "old/image", true, config.PullNever).Return(oldImage, nil)
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "old/image", image.FetchOptions{Daemon: true, PullPolicy: config.PullNever}).Return(oldImage, nil)
 
 			h.AssertNil(t, oldImage.SetLabel(
 				"io.buildpacks.lifecycle.metadata",

--- a/internal/builder/fakes/fake_inspectable_fetcher.go
+++ b/internal/builder/fakes/fake_inspectable_fetcher.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/buildpacks/pack/config"
 	"github.com/buildpacks/pack/internal/builder"
+	"github.com/buildpacks/pack/internal/image"
 )
 
 type FakeInspectableFetcher struct {
@@ -18,12 +19,12 @@ type FakeInspectableFetcher struct {
 	ReceivedPullPolicy config.PullPolicy
 }
 
-func (f *FakeInspectableFetcher) Fetch(ctx context.Context, name string, daemon bool, pullPolicy config.PullPolicy) (builder.Inspectable, error) {
+func (f *FakeInspectableFetcher) Fetch(ctx context.Context, name string, options image.FetchOptions) (builder.Inspectable, error) {
 	f.CallCount++
 
 	f.ReceivedName = name
-	f.ReceivedDaemon = daemon
-	f.ReceivedPullPolicy = pullPolicy
+	f.ReceivedDaemon = options.Daemon
+	f.ReceivedPullPolicy = options.PullPolicy
 
 	return f.InspectableToReturn, f.ErrorToReturn
 }

--- a/internal/builder/image_fetcher_wrapper.go
+++ b/internal/builder/image_fetcher_wrapper.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/buildpacks/imgutil"
 
-	pubcfg "github.com/buildpacks/pack/config"
+	"github.com/buildpacks/pack/internal/image"
 )
 
 type ImageFetcher interface {
 	// Fetch fetches an image by resolving it both remotely and locally depending on provided parameters.
 	// If daemon is true, it will look return a `local.Image`. Pull, applicable only when daemon is true, will
 	// attempt to pull a remote image first.
-	Fetch(ctx context.Context, name string, daemon bool, pullPolicy pubcfg.PullPolicy) (imgutil.Image, error)
+	Fetch(ctx context.Context, name string, options image.FetchOptions) (imgutil.Image, error)
 }
 
 type ImageFetcherWrapper struct {
@@ -28,8 +28,7 @@ func NewImageFetcherWrapper(fetcher ImageFetcher) *ImageFetcherWrapper {
 func (w *ImageFetcherWrapper) Fetch(
 	ctx context.Context,
 	name string,
-	daemon bool,
-	pullPolicy pubcfg.PullPolicy,
+	options image.FetchOptions,
 ) (Inspectable, error) {
-	return w.fetcher.Fetch(ctx, name, daemon, pullPolicy)
+	return w.fetcher.Fetch(ctx, name, options)
 }

--- a/internal/builder/inspect.go
+++ b/internal/builder/inspect.go
@@ -7,10 +7,9 @@ import (
 	"strings"
 
 	pubbldr "github.com/buildpacks/pack/builder"
-
-	"github.com/buildpacks/pack/internal/dist"
-
 	"github.com/buildpacks/pack/config"
+	"github.com/buildpacks/pack/internal/dist"
+	"github.com/buildpacks/pack/internal/image"
 )
 
 type Info struct {
@@ -31,7 +30,7 @@ type Inspectable interface {
 }
 
 type InspectableFetcher interface {
-	Fetch(ctx context.Context, name string, daemon bool, pullPolicy config.PullPolicy) (Inspectable, error)
+	Fetch(ctx context.Context, name string, options image.FetchOptions) (Inspectable, error)
 }
 
 type LabelManagerFactory interface {
@@ -65,7 +64,7 @@ func NewInspector(fetcher InspectableFetcher, factory LabelManagerFactory, calcu
 }
 
 func (i *Inspector) Inspect(name string, daemon bool, orderDetectionDepth int) (Info, error) {
-	inspectable, err := i.imageFetcher.Fetch(context.Background(), name, daemon, config.PullNever)
+	inspectable, err := i.imageFetcher.Fetch(context.Background(), name, image.FetchOptions{Daemon: daemon, PullPolicy: config.PullNever})
 	if err != nil {
 		return Info{}, fmt.Errorf("fetching builder image: %w", err)
 	}

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -389,6 +389,7 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 		})
+
 		when("an invalid lifecycle-image is provided", func() {
 			when("the repo name is invalid", func() {
 				it("returns a parse error", func() {

--- a/internal/fakes/fake_image_fetcher.go
+++ b/internal/fakes/fake_image_fetcher.go
@@ -14,6 +14,7 @@ import (
 type FetchArgs struct {
 	Daemon     bool
 	PullPolicy config.PullPolicy
+	Platform   string
 }
 
 type FakeImageFetcher struct {
@@ -31,7 +32,7 @@ func NewFakeImageFetcher() *FakeImageFetcher {
 }
 
 func (f *FakeImageFetcher) Fetch(ctx context.Context, name string, options image.FetchOptions) (imgutil.Image, error) {
-	f.FetchCalls[name] = &FetchArgs{Daemon: options.Daemon, PullPolicy: options.PullPolicy}
+	f.FetchCalls[name] = &FetchArgs{Daemon: options.Daemon, PullPolicy: options.PullPolicy, Platform: options.Platform}
 
 	ri, remoteFound := f.RemoteImages[name]
 

--- a/internal/fakes/fake_image_fetcher.go
+++ b/internal/fakes/fake_image_fetcher.go
@@ -30,15 +30,15 @@ func NewFakeImageFetcher() *FakeImageFetcher {
 	}
 }
 
-func (f *FakeImageFetcher) Fetch(ctx context.Context, name string, daemon bool, policy config.PullPolicy) (imgutil.Image, error) {
-	f.FetchCalls[name] = &FetchArgs{Daemon: daemon, PullPolicy: policy}
+func (f *FakeImageFetcher) Fetch(ctx context.Context, name string, options image.FetchOptions) (imgutil.Image, error) {
+	f.FetchCalls[name] = &FetchArgs{Daemon: options.Daemon, PullPolicy: options.PullPolicy}
 
 	ri, remoteFound := f.RemoteImages[name]
 
-	if daemon {
+	if options.Daemon {
 		li, localFound := f.LocalImages[name]
 
-		if shouldPull(localFound, remoteFound, policy) {
+		if shouldPull(localFound, remoteFound, options.PullPolicy) {
 			f.LocalImages[name] = ri
 			li = ri
 		}

--- a/internal/image/fetcher.go
+++ b/internal/image/fetcher.go
@@ -28,6 +28,14 @@ type Fetcher struct {
 	logger logging.Logger
 }
 
+type FetchOptions struct {
+	//TODO: would love to reverse (Daemon bool) to (Remote bool)
+	//      so that "false" becomes the default, when omitted
+	Daemon     bool
+	Platform   string
+	PullPolicy config.PullPolicy
+}
+
 func NewFetcher(logger logging.Logger, docker client.CommonAPIClient) *Fetcher {
 	return &Fetcher{
 		logger: logger,
@@ -37,12 +45,12 @@ func NewFetcher(logger logging.Logger, docker client.CommonAPIClient) *Fetcher {
 
 var ErrNotFound = errors.New("not found")
 
-func (f *Fetcher) Fetch(ctx context.Context, name string, daemon bool, pullPolicy config.PullPolicy) (imgutil.Image, error) {
-	if !daemon {
+func (f *Fetcher) Fetch(ctx context.Context, name string, options FetchOptions) (imgutil.Image, error) {
+	if !options.Daemon {
 		return f.fetchRemoteImage(name)
 	}
 
-	switch pullPolicy {
+	switch options.PullPolicy {
 	case config.PullNever:
 		img, err := f.fetchDaemonImage(name)
 		return img, err

--- a/internal/image/fetcher.go
+++ b/internal/image/fetcher.go
@@ -29,8 +29,6 @@ type Fetcher struct {
 }
 
 type FetchOptions struct {
-	//TODO: would love to reverse (Daemon bool) to (Remote bool)
-	//      so that "false" becomes the default, when omitted
 	Daemon     bool
 	Platform   string
 	PullPolicy config.PullPolicy

--- a/internal/image/fetcher.go
+++ b/internal/image/fetcher.go
@@ -62,7 +62,7 @@ func (f *Fetcher) Fetch(ctx context.Context, name string, options FetchOptions) 
 	}
 
 	f.logger.Debugf("Pulling image %s", style.Symbol(name))
-	err := f.pullImage(ctx, name)
+	err := f.pullImage(ctx, name, options.Platform)
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, err
 	}
@@ -96,13 +96,13 @@ func (f *Fetcher) fetchRemoteImage(name string) (imgutil.Image, error) {
 	return image, nil
 }
 
-func (f *Fetcher) pullImage(ctx context.Context, imageID string) error {
+func (f *Fetcher) pullImage(ctx context.Context, imageID string, platform string) error {
 	regAuth, err := registryAuth(imageID)
 	if err != nil {
 		return err
 	}
 
-	rc, err := f.docker.ImagePull(ctx, imageID, types.ImagePullOptions{RegistryAuth: regAuth})
+	rc, err := f.docker.ImagePull(ctx, imageID, types.ImagePullOptions{RegistryAuth: regAuth, Platform: platform})
 	if err != nil {
 		if client.IsErrNotFound(err) {
 			return errors.Wrapf(ErrNotFound, "image %s does not exist on the daemon", style.Symbol(imageID))

--- a/internal/image/fetcher_test.go
+++ b/internal/image/fetcher_test.go
@@ -211,6 +211,13 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 						})
 					})
 				})
+
+				when("image platform is specified", func() {
+					it("passes the platform argument to the daemon", func() {
+						_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullAlways, Platform: "some-unsupported-platform"})
+						h.AssertError(t, err, "unknown operating system or architecture")
+					})
+				})
 			})
 
 			when("PullIfNotPresent", func() {
@@ -308,6 +315,13 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 							_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullIfNotPresent})
 							h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist on the daemon", repoName))
 						})
+					})
+				})
+
+				when("image platform is specified", func() {
+					it("passes the platform argument to the daemon", func() {
+						_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullIfNotPresent, Platform: "some-unsupported-platform"})
+						h.AssertError(t, err, "unknown operating system or architecture")
 					})
 				})
 			})

--- a/internal/image/fetcher_test.go
+++ b/internal/image/fetcher_test.go
@@ -72,14 +72,14 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it("returns the remote image", func() {
-						_, err := fetcher.Fetch(context.TODO(), repoName, false, pubcfg.PullAlways)
+						_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: false, PullPolicy: pubcfg.PullAlways})
 						h.AssertNil(t, err)
 					})
 				})
 
 				when("there is no remote image", func() {
 					it("returns an error", func() {
-						_, err := fetcher.Fetch(context.TODO(), repoName, false, pubcfg.PullAlways)
+						_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: false, PullPolicy: pubcfg.PullAlways})
 						h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist in registry", repoName))
 					})
 				})
@@ -95,14 +95,14 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it("returns the remote image", func() {
-						_, err := fetcher.Fetch(context.TODO(), repoName, false, pubcfg.PullIfNotPresent)
+						_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: false, PullPolicy: pubcfg.PullIfNotPresent})
 						h.AssertNil(t, err)
 					})
 				})
 
 				when("there is no remote image", func() {
 					it("returns an error", func() {
-						_, err := fetcher.Fetch(context.TODO(), repoName, false, pubcfg.PullIfNotPresent)
+						_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: false, PullPolicy: pubcfg.PullIfNotPresent})
 						h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist in registry", repoName))
 					})
 				})
@@ -129,14 +129,14 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it("returns the local image", func() {
-						_, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullNever)
+						_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullNever})
 						h.AssertNil(t, err)
 					})
 				})
 
 				when("there is no local image", func() {
 					it("returns an error", func() {
-						_, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullNever)
+						_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullNever})
 						h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist on the daemon", repoName))
 					})
 				})
@@ -172,14 +172,14 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it("pull the image and return the local copy", func() {
-						_, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullAlways)
+						_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullAlways})
 						h.AssertNil(t, err)
 						h.AssertNotEq(t, output(), "")
 					})
 
 					it("doesn't log anything in quiet mode", func() {
 						logger.WantQuiet(true)
-						_, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullAlways)
+						_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullAlways})
 						h.AssertNil(t, err)
 						h.AssertEq(t, output(), "")
 					})
@@ -199,14 +199,14 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 						})
 
 						it("returns the local image", func() {
-							_, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullAlways)
+							_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullAlways})
 							h.AssertNil(t, err)
 						})
 					})
 
 					when("there is no local image", func() {
 						it("returns an error", func() {
-							_, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullAlways)
+							_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullAlways})
 							h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist on the daemon", repoName))
 						})
 					})
@@ -260,7 +260,7 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 						})
 
 						it("returns the local image", func() {
-							fetchedImg, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullIfNotPresent)
+							fetchedImg, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullIfNotPresent})
 							h.AssertNil(t, err)
 							h.AssertNotContains(t, outBuf.String(), "Pulling image")
 
@@ -274,7 +274,7 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 
 					when("there is no local image", func() {
 						it("returns the remote image", func() {
-							fetchedImg, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullIfNotPresent)
+							fetchedImg, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullIfNotPresent})
 							h.AssertNil(t, err)
 
 							fetchedImgLabel, err := fetchedImg.Label(label)
@@ -298,14 +298,14 @@ func testFetcher(t *testing.T, when spec.G, it spec.S) {
 						})
 
 						it("returns the local image", func() {
-							_, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullIfNotPresent)
+							_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullIfNotPresent})
 							h.AssertNil(t, err)
 						})
 					})
 
 					when("there is no local image", func() {
 						it("returns an error", func() {
-							_, err := fetcher.Fetch(context.TODO(), repoName, true, pubcfg.PullIfNotPresent)
+							_, err := fetcher.Fetch(context.TODO(), repoName, image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullIfNotPresent})
 							h.AssertError(t, err, fmt.Sprintf("image '%s' does not exist on the daemon", repoName))
 						})
 					})

--- a/pack.go
+++ b/pack.go
@@ -3,12 +3,12 @@ package pack
 import (
 	"context"
 
-	"github.com/buildpacks/pack/config"
-
 	"github.com/pkg/errors"
 
+	"github.com/buildpacks/pack/config"
 	"github.com/buildpacks/pack/internal/buildpackage"
 	"github.com/buildpacks/pack/internal/dist"
+	"github.com/buildpacks/pack/internal/image"
 	"github.com/buildpacks/pack/internal/style"
 )
 
@@ -18,7 +18,7 @@ var (
 )
 
 func extractPackagedBuildpacks(ctx context.Context, pkgImageRef string, fetcher ImageFetcher, publish bool, pullPolicy config.PullPolicy) (mainBP dist.Buildpack, depBPs []dist.Buildpack, err error) {
-	pkgImage, err := fetcher.Fetch(ctx, pkgImageRef, !publish, pullPolicy)
+	pkgImage, err := fetcher.Fetch(ctx, pkgImageRef, image.FetchOptions{Daemon: !publish, PullPolicy: pullPolicy})
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "fetching image")
 	}

--- a/package_buildpack_test.go
+++ b/package_buildpack_test.go
@@ -270,11 +270,11 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			shouldFetchNestedPackage := func(demon bool, pull pubcfg.PullPolicy) {
-				mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), demon, pull).Return(nestedPackage, nil)
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), image.FetchOptions{Daemon: demon, PullPolicy: pull}).Return(nestedPackage, nil)
 			}
 
 			shouldNotFindNestedPackageWhenCallingImageFetcherWith := func(demon bool, pull pubcfg.PullPolicy) {
-				mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), demon, pull).Return(nil, image.ErrNotFound)
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), image.FetchOptions{Daemon: demon, PullPolicy: pull}).Return(nil, image.ErrNotFound)
 			}
 
 			shouldCreateLocalPackage := func() imgutil.Image {
@@ -395,7 +395,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 		when("nested package is not a valid package", func() {
 			it("should error", func() {
 				notPackageImage := fakes.NewImage("not/package", "", nil)
-				mockImageFetcher.EXPECT().Fetch(gomock.Any(), notPackageImage.Name(), true, pubcfg.PullAlways).Return(notPackageImage, nil)
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), notPackageImage.Name(), image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullAlways}).Return(notPackageImage, nil)
 
 				mockDockerClient.EXPECT().Info(context.TODO()).Return(types.Info{OSType: "linux"}, nil).AnyTimes()
 
@@ -508,7 +508,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 						PullPolicy: pubcfg.PullAlways,
 					}))
 
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), true, pubcfg.PullAlways).Return(nestedPackage, nil)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullAlways}).Return(nestedPackage, nil)
 				})
 
 				it("should pull and use local nested package image", func() {
@@ -623,7 +623,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 						PullPolicy: pubcfg.PullAlways,
 					}))
 
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), true, pubcfg.PullAlways).Return(nestedPackage, nil)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), nestedPackage.Name(), image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullAlways}).Return(nestedPackage, nil)
 				})
 
 				it("should include both of them", func() {
@@ -731,7 +731,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, err)
 					err = packageImage.SetLabel("io.buildpacks.buildpack.layers", `{"example/foo":{"1.1.0":{"api": "0.2", "layerDiffID":"sha256:xxx", "stacks":[{"id":"some.stack.id"}]}}}`)
 					h.AssertNil(t, err)
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), true, pubcfg.PullAlways).Return(packageImage, nil)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), image.FetchOptions{Daemon: true, PullPolicy: pubcfg.PullAlways}).Return(packageImage, nil)
 
 					packHome := filepath.Join(tmpDir, "packHome")
 					h.AssertNil(t, os.Setenv("PACK_HOME", packHome))

--- a/pull_buildpack.go
+++ b/pull_buildpack.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildpacks/pack/config"
 	"github.com/buildpacks/pack/internal/buildpack"
 	"github.com/buildpacks/pack/internal/dist"
+	"github.com/buildpacks/pack/internal/image"
 	"github.com/buildpacks/pack/internal/style"
 )
 
@@ -34,7 +35,7 @@ func (c *Client) PullBuildpack(ctx context.Context, opts PullBuildpackOptions) e
 		imageName := buildpack.ParsePackageLocator(opts.URI)
 		c.logger.Debugf("Pulling buildpack from image: %s", imageName)
 
-		_, err = c.imageFetcher.Fetch(ctx, imageName, true, config.PullAlways)
+		_, err = c.imageFetcher.Fetch(ctx, imageName, image.FetchOptions{Daemon: true, PullPolicy: config.PullAlways})
 		if err != nil {
 			return errors.Wrapf(err, "fetching image %s", style.Symbol(opts.URI))
 		}
@@ -51,7 +52,7 @@ func (c *Client) PullBuildpack(ctx context.Context, opts PullBuildpackOptions) e
 			return errors.Wrapf(err, "locating in registry %s", style.Symbol(opts.URI))
 		}
 
-		_, err = c.imageFetcher.Fetch(ctx, registryBp.Address, true, config.PullAlways)
+		_, err = c.imageFetcher.Fetch(ctx, registryBp.Address, image.FetchOptions{Daemon: true, PullPolicy: config.PullAlways})
 		if err != nil {
 			return errors.Wrapf(err, "fetching image %s", style.Symbol(opts.URI))
 		}

--- a/pull_buildpack_test.go
+++ b/pull_buildpack_test.go
@@ -9,16 +9,15 @@ import (
 	"testing"
 
 	"github.com/buildpacks/imgutil/fakes"
-
+	"github.com/golang/mock/gomock"
 	"github.com/heroku/color"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/buildpacks/pack"
 	"github.com/buildpacks/pack/config"
 	cfg "github.com/buildpacks/pack/internal/config"
+	"github.com/buildpacks/pack/internal/image"
 	"github.com/buildpacks/pack/internal/logging"
 	"github.com/buildpacks/pack/internal/registry"
 	h "github.com/buildpacks/pack/testhelpers"
@@ -93,7 +92,7 @@ func testPullBuildpack(t *testing.T, when spec.G, it spec.S) {
 			packageImage := fakes.NewImage("example.com/some/package:1.0.0", "", nil)
 			h.AssertNil(t, packageImage.SetLabel("io.buildpacks.buildpackage.metadata", `{}`))
 			h.AssertNil(t, packageImage.SetLabel("io.buildpacks.buildpack.layers", `{}`))
-			mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), true, config.PullAlways).Return(packageImage, nil)
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), image.FetchOptions{Daemon: true, PullPolicy: config.PullAlways}).Return(packageImage, nil)
 
 			h.AssertNil(t, subject.PullBuildpack(context.TODO(), pack.PullBuildpackOptions{
 				URI: "example.com/some/package:1.0.0",
@@ -123,7 +122,7 @@ func testPullBuildpack(t *testing.T, when spec.G, it spec.S) {
 			packageImage := fakes.NewImage("example.com/some/package@sha256:74eb48882e835d8767f62940d453eb96ed2737de3a16573881dcea7dea769df7", "", nil)
 			packageImage.SetLabel("io.buildpacks.buildpackage.metadata", `{}`)
 			packageImage.SetLabel("io.buildpacks.buildpack.layers", `{}`)
-			mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), true, config.PullAlways).Return(packageImage, nil)
+			mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), image.FetchOptions{Daemon: true, PullPolicy: config.PullAlways}).Return(packageImage, nil)
 
 			packHome := filepath.Join(tmpDir, "packHome")
 			h.AssertNil(t, os.Setenv("PACK_HOME", packHome))

--- a/rebase.go
+++ b/rebase.go
@@ -11,6 +11,7 @@ import (
 	"github.com/buildpacks/pack/internal/build"
 	"github.com/buildpacks/pack/internal/builder"
 	"github.com/buildpacks/pack/internal/dist"
+	"github.com/buildpacks/pack/internal/image"
 	"github.com/buildpacks/pack/internal/style"
 )
 
@@ -44,7 +45,7 @@ func (c *Client) Rebase(ctx context.Context, opts RebaseOptions) error {
 		return errors.Wrapf(err, "invalid image name '%s'", opts.RepoName)
 	}
 
-	appImage, err := c.imageFetcher.Fetch(ctx, opts.RepoName, !opts.Publish, opts.PullPolicy)
+	appImage, err := c.imageFetcher.Fetch(ctx, opts.RepoName, image.FetchOptions{Daemon: !opts.Publish, PullPolicy: opts.PullPolicy})
 	if err != nil {
 		return err
 	}
@@ -73,7 +74,7 @@ func (c *Client) Rebase(ctx context.Context, opts RebaseOptions) error {
 		return errors.New("run image must be specified")
 	}
 
-	baseImage, err := c.imageFetcher.Fetch(ctx, runImageName, !opts.Publish, opts.PullPolicy)
+	baseImage, err := c.imageFetcher.Fetch(ctx, runImageName, image.FetchOptions{Daemon: !opts.Publish, PullPolicy: opts.PullPolicy})
 	if err != nil {
 		return err
 	}

--- a/register_buildpack.go
+++ b/register_buildpack.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/buildpacks/pack/config"
-
 	"github.com/buildpacks/pack/internal/buildpackage"
 	"github.com/buildpacks/pack/internal/dist"
+	"github.com/buildpacks/pack/internal/image"
 	"github.com/buildpacks/pack/internal/registry"
 )
 
@@ -26,7 +26,7 @@ type RegisterBuildpackOptions struct {
 // RegisterBuildpack updates the Buildpack Registry with to include a new buildpack specified in
 // the opts argument
 func (c *Client) RegisterBuildpack(ctx context.Context, opts RegisterBuildpackOptions) error {
-	appImage, err := c.imageFetcher.Fetch(ctx, opts.ImageName, false, config.PullAlways)
+	appImage, err := c.imageFetcher.Fetch(ctx, opts.ImageName, image.FetchOptions{Daemon: false, PullPolicy: config.PullAlways})
 	if err != nil {
 		return err
 	}

--- a/testmocks/mock_image_fetcher.go
+++ b/testmocks/mock_image_fetcher.go
@@ -11,7 +11,7 @@ import (
 	imgutil "github.com/buildpacks/imgutil"
 	gomock "github.com/golang/mock/gomock"
 
-	config "github.com/buildpacks/pack/config"
+	image "github.com/buildpacks/pack/internal/image"
 )
 
 // MockImageFetcher is a mock of ImageFetcher interface.
@@ -38,16 +38,16 @@ func (m *MockImageFetcher) EXPECT() *MockImageFetcherMockRecorder {
 }
 
 // Fetch mocks base method.
-func (m *MockImageFetcher) Fetch(arg0 context.Context, arg1 string, arg2 bool, arg3 config.PullPolicy) (imgutil.Image, error) {
+func (m *MockImageFetcher) Fetch(arg0 context.Context, arg1 string, arg2 image.FetchOptions) (imgutil.Image, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Fetch", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Fetch", arg0, arg1, arg2)
 	ret0, _ := ret[0].(imgutil.Image)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Fetch indicates an expected call of Fetch.
-func (mr *MockImageFetcherMockRecorder) Fetch(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockImageFetcherMockRecorder) Fetch(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockImageFetcher)(nil).Fetch), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockImageFetcher)(nil).Fetch), arg0, arg1, arg2)
 }


### PR DESCRIPTION
## Summary
This PR fetches a lifecycle image that is the same **platform** as the requested builder image, when this builder is untrusted.

This PR also includes a refactor the `image.Fetch()` method signature. This was done so that future modifications may not involve changes in so many files.

## Documentation
- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Caveats
_Full disclosure:_ I don't have an arm machine, so I've never seen this work 😬 

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves https://github.com/buildpacks/pack/issues/1197
