### PR TITLE
Expose ExtractBuildpacks function

### DIFF
--- a/buildpackage/buildpackage.go
+++ b/buildpackage/buildpackage.go
@@ -1,0 +1,12 @@
+package buildpackage
+
+import (
+	"github.com/buildpacks/pack/internal/dist"
+)
+
+const MetadataLabel = "io.buildpacks.buildpackage.metadata"
+
+type Metadata struct {
+	dist.BuildpackInfo
+	Stacks []dist.Stack `toml:"stacks" json:"stacks"`
+}

--- a/buildpackage/package.go
+++ b/buildpackage/package.go
@@ -1,0 +1,86 @@
+package buildpackage
+
+import (
+	"io"
+
+	"github.com/pkg/errors"
+
+	"github.com/buildpacks/pack/internal/dist"
+	"github.com/buildpacks/pack/internal/style"
+)
+
+type Package interface {
+	Label(name string) (value string, err error)
+	GetLayer(diffID string) (io.ReadCloser, error)
+}
+
+func ExtractBuildpacks(pkg Package) (mainBP dist.Buildpack, depBPs []dist.Buildpack, err error) {
+	md := &Metadata{}
+	if found, err := dist.GetLabel(pkg, MetadataLabel, md); err != nil {
+		return nil, nil, err
+	} else if !found {
+		return nil, nil, errors.Errorf(
+			"could not find label %s",
+			style.Symbol(MetadataLabel),
+		)
+	}
+
+	bpLayers := dist.BuildpackLayers{}
+	ok, err := dist.GetLabel(pkg, dist.BuildpackLayersLabel, &bpLayers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !ok {
+		return nil, nil, errors.Errorf(
+			"could not find label %s",
+			style.Symbol(dist.BuildpackLayersLabel),
+		)
+	}
+
+	for bpID, v := range bpLayers {
+		for bpVersion, bpInfo := range v {
+			desc := dist.BuildpackDescriptor{
+				API: bpInfo.API,
+				Info: dist.BuildpackInfo{
+					ID:       bpID,
+					Version:  bpVersion,
+					Homepage: bpInfo.Homepage,
+				},
+				Stacks: bpInfo.Stacks,
+				Order:  bpInfo.Order,
+			}
+
+			diffID := bpInfo.LayerDiffID // Allow use in closure
+			b := &openerBlob{
+				opener: func() (io.ReadCloser, error) {
+					rc, err := pkg.GetLayer(diffID)
+					if err != nil {
+						return nil, errors.Wrapf(err,
+							"extracting buildpack %s layer (diffID %s)",
+							style.Symbol(desc.Info.FullName()),
+							style.Symbol(diffID),
+						)
+					}
+					return rc, nil
+				},
+			}
+
+			if desc.Info.Match(md.BuildpackInfo) { // This is the order buildpack of the package
+				mainBP = dist.BuildpackFromBlob(desc, b)
+			} else {
+				depBPs = append(depBPs, dist.BuildpackFromBlob(desc, b))
+			}
+		}
+	}
+
+	return mainBP, depBPs, nil
+}
+
+type openerBlob struct {
+	opener func() (io.ReadCloser, error)
+}
+
+func (b *openerBlob) Open() (io.ReadCloser, error) {
+	return b.opener()
+}


### PR DESCRIPTION
## Summary
In our platform implementation, we'd like to reuse some of the functions that `pack` uses for downloading and extracting buildpacks. Specifically,`ExtractBuildpacks` is something we can use instead of reimplementing. This PR copies (And eventually moves) the logic from `internal/buildpackage` to `buildpackage`

This is related to the broader issue of fully exposing the core methods for downloading and extracting buildpacks, https://github.com/buildpacks/pack/issues/761. The downloading logic in https://github.com/buildpacks/pack/blob/f3d6be6b1981c9800e1aae0edbeba10fe1a2b704/create_builder.go#L205 is a little bit harder to extract out and make reusable; we need to stay away from using Docker in our implementation. The discussion on https://github.com/buildpacks/pack/issues/761 suggests a `DownloadBuildpack` function. My questions there are: 
- Do you think that the existing pack methods for buildpack downloading such as addBuildpacksToBuilder would need to be refactored to use DownloadBuildpack or would DownloadBuildpack be something specifically for platforms to consume? 
- If the latter, should the change live somewhere else? 

TODO: This is just a draft PR, still need to remove the old files and update imports
## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
