### PR TITLE
Update registry helper to fallback to insecure registry network range

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -822,7 +822,7 @@ func testAcceptance(
 							assertions.NewOutputAssertionManager(t, output).ReportsSuccessfulImageBuild(repoName)
 
 							assertOutput := assertions.NewLifecycleOutputAssertionManager(t, output)
-							assertOutput.IncludesLifecycleImageTag()
+							assertOutput.IncludesLifecycleImageTag(lifecycle.Image())
 							assertOutput.IncludesSeparatePhases()
 						})
 					})
@@ -844,7 +844,7 @@ func testAcceptance(
 							assertions.NewOutputAssertionManager(t, output).ReportsSuccessfulImageBuild(repoName)
 
 							assertOutput := assertions.NewLifecycleOutputAssertionManager(t, output)
-							assertOutput.IncludesLifecycleImageTag()
+							assertOutput.IncludesLifecycleImageTag(lifecycle.Image())
 							assertOutput.IncludesSeparatePhases()
 						})
 					})

--- a/acceptance/assertions/lifecycle_output.go
+++ b/acceptance/assertions/lifecycle_output.go
@@ -69,8 +69,8 @@ func (l LifecycleOutputAssertionManager) IncludesSeparatePhases() {
 	l.assert.ContainsAll(l.output, "[detector]", "[analyzer]", "[builder]", "[exporter]")
 }
 
-func (l LifecycleOutputAssertionManager) IncludesLifecycleImageTag() {
+func (l LifecycleOutputAssertionManager) IncludesLifecycleImageTag(tag string) {
 	l.testObject.Helper()
 
-	l.assert.Contains(l.output, "buildpacksio/lifecycle")
+	l.assert.Contains(l.output, tag)
 }


### PR DESCRIPTION
This may allow acceptance tests to run on a GitHub hosted runner

Signed-off-by: Natalie Arellano <narellano@vmware.com>

## Summary
imgutil and lifecycle acceptance tests use the registry helpers from imgutil and can run on a GitHub hosted runner. This change attempts to make that possible for pack.

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
