### PR TITLE
Make lifecycle image expectation configurable

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -822,7 +822,7 @@ func testAcceptance(
 							assertions.NewOutputAssertionManager(t, output).ReportsSuccessfulImageBuild(repoName)
 
 							assertOutput := assertions.NewLifecycleOutputAssertionManager(t, output)
-							assertOutput.IncludesLifecycleImageTag()
+							assertOutput.IncludesLifecycleImageTag(lifecycle.Image())
 							assertOutput.IncludesSeparatePhases()
 						})
 					})
@@ -844,7 +844,7 @@ func testAcceptance(
 							assertions.NewOutputAssertionManager(t, output).ReportsSuccessfulImageBuild(repoName)
 
 							assertOutput := assertions.NewLifecycleOutputAssertionManager(t, output)
-							assertOutput.IncludesLifecycleImageTag()
+							assertOutput.IncludesLifecycleImageTag(lifecycle.Image())
 							assertOutput.IncludesSeparatePhases()
 						})
 					})

--- a/acceptance/assertions/lifecycle_output.go
+++ b/acceptance/assertions/lifecycle_output.go
@@ -69,8 +69,8 @@ func (l LifecycleOutputAssertionManager) IncludesSeparatePhases() {
 	l.assert.ContainsAll(l.output, "[detector]", "[analyzer]", "[builder]", "[exporter]")
 }
 
-func (l LifecycleOutputAssertionManager) IncludesLifecycleImageTag() {
+func (l LifecycleOutputAssertionManager) IncludesLifecycleImageTag(tag string) {
 	l.testObject.Helper()
 
-	l.assert.Contains(l.output, "buildpacksio/lifecycle")
+	l.assert.Contains(l.output, tag)
 }


### PR DESCRIPTION
Signed-off-by: Natalie Arellano <narellano@vmware.com>

## Summary
This change ensures that the repo name for the "lifecycle image" in acceptance test expectations matches the repo name in `LIFECYCLE_IMAGE` (to avoid spurious failures when testing across forks). 
