### PR TITLE
Allow wildcard "any" stack

### DIFF
--- a/internal/dist/buildpack_descriptor.go
+++ b/internal/dist/buildpack_descriptor.go
@@ -52,7 +52,7 @@ func (b *BuildpackDescriptor) EnsureStackSupport(stackID string, providedMixins 
 
 func (b *BuildpackDescriptor) findMixinsForStack(stackID string) ([]string, error) {
 	for _, s := range b.Stacks {
-		if s.ID == stackID {
+		if s.ID == stackID || s.ID == "*" {
 			return s.Mixins, nil
 		}
 	}

--- a/internal/dist/buildpack_descriptor_test.go
+++ b/internal/dist/buildpack_descriptor_test.go
@@ -36,6 +36,22 @@ func testBuildpackDescriptor(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, bp.EnsureStackSupport("some.stack.id", providedMixins, false))
 			})
 
+			it("works with wildcard stack", func() {
+				bp := dist.BuildpackDescriptor{
+					Info: dist.BuildpackInfo{
+						ID:      "some.buildpack.id",
+						Version: "some.buildpack.version",
+					},
+					Stacks: []dist.Stack{{
+						ID:     "*",
+						Mixins: []string{"mixinA", "build:mixinB", "run:mixinD"},
+					}},
+				}
+
+				providedMixins := []string{"mixinA", "build:mixinB", "mixinC"}
+				h.AssertNil(t, bp.EnsureStackSupport("some.stack.id", providedMixins, false))
+			})
+
 			it("returns an error with any missing (and non-ignored) mixins", func() {
 				bp := dist.BuildpackDescriptor{
 					Info: dist.BuildpackInfo{


### PR DESCRIPTION
## Summary

Fixes a bug that prevents `*` stacks from working.

## Output

#### Before

```
$ pack build ...
...
ERROR: failed to build: validating stack mixins: buildpack heroku/procfile@0.7.0 does not support stack my_stack
make: *** [test] Error 1
```

#### After

```
$ pack build ...
...
Successfully built image python-cnb-test
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

