### PR TITLE
Cleanup registry cache in tests

### DIFF
--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -29,9 +29,10 @@ const defaultRegistryDir = "registry"
 
 // Cache is a RegistryCache
 type Cache struct {
-	logger logging.Logger
-	url    *url.URL
-	Root   string
+	logger      logging.Logger
+	url         *url.URL
+	Root        string
+	RegistryDir string
 }
 
 const GithubIssueTitleTemplate = "{{ if .Yanked }}YANK{{ else }}ADD{{ end }} {{.Namespace}}/{{.Name}}@{{.Version}}"
@@ -170,12 +171,14 @@ func (r *Cache) Initialize() error {
 func (r *Cache) CreateCache() error {
 	r.logger.Debugf("Creating registry cache for %s/%s", r.url.Host, r.url.Path)
 
-	root, err := ioutil.TempDir(filepath.Dir(r.Root), "registry")
+	registryDir, err := ioutil.TempDir(filepath.Dir(r.Root), "registry")
 	if err != nil {
 		return err
 	}
 
-	repository, err := git.PlainClone(root, false, &git.CloneOptions{
+	r.RegistryDir = registryDir
+
+	repository, err := git.PlainClone(r.RegistryDir, false, &git.CloneOptions{
 		URL: r.url.String(),
 	})
 	if err != nil {

--- a/internal/registry/registry_cache_test.go
+++ b/internal/registry/registry_cache_test.go
@@ -217,7 +217,7 @@ func testRegistryCache(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it.After(func() {
-				h.AssertNil(t, os.RemoveAll(filepath.Join(registryCache.Root, registryCache.RegistryDir)))
+				h.AssertNil(t, os.RemoveAll(registryCache.RegistryDir))
 			})
 
 			when("url is empty string", func() {

--- a/internal/registry/registry_cache_test.go
+++ b/internal/registry/registry_cache_test.go
@@ -191,7 +191,7 @@ func testRegistryCache(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it.After(func() {
-				h.AssertNil(t, os.RemoveAll(filepath.Join(registryCache.Root, registryCache.RegistryDir)))
+				h.AssertNil(t, os.RemoveAll(registryCache.RegistryDir))
 			})
 		})
 	})

--- a/internal/registry/registry_cache_test.go
+++ b/internal/registry/registry_cache_test.go
@@ -189,6 +189,10 @@ func testRegistryCache(t *testing.T, when spec.G, it spec.S) {
 				err = registryCache.Refresh()
 				h.AssertError(t, err, "initializing")
 			})
+
+			it.After(func() {
+				h.AssertNil(t, os.RemoveAll(filepath.Join(registryCache.Root, registryCache.RegistryDir)))
+			})
 		})
 	})
 
@@ -210,6 +214,10 @@ func testRegistryCache(t *testing.T, when spec.G, it spec.S) {
 			it("fails to create registry cache", func() {
 				err = registryCache.Initialize()
 				h.AssertError(t, err, "creating registry cache")
+			})
+
+			it.After(func() {
+				h.AssertNil(t, os.RemoveAll(filepath.Join(registryCache.Root, registryCache.RegistryDir)))
 			})
 
 			when("url is empty string", func() {


### PR DESCRIPTION
Keep a reference to the registry cache dir, which can be used to cleanup in test. Fixes #1228

This only happens when we're testing with a an empty string (`""`) for the root of the registry cache, and the temp dir is actually created from within the production code (not the test code). Therefore, we need to keep a reference to the temp dir so it can be destroyed in `it.After`

## Summary

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

```
$ go test -run TestRegistryCache ./...
$ git status
...
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        internal/registry/registry087316852/
```

#### After

```
$ go test -run TestRegistryCache ./...
$ git status
...
nothing to commit, working tree clean
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1228
