### PR TITLE
Default to standard library when validating zip file

### DIFF
--- a/build.go
+++ b/build.go
@@ -559,13 +559,7 @@ func (c *Client) processAppPath(appPath string) (string, error) {
 	}
 
 	if !fi.IsDir() {
-		fh, err := os.Open(filepath.Clean(resolvedAppPath))
-		if err != nil {
-			return "", errors.Wrap(err, "read file")
-		}
-		defer fh.Close()
-
-		isZip, err := archive.IsZip(fh)
+		isZip, err := archive.IsZip(filepath.Clean(resolvedAppPath))
 		if err != nil {
 			return "", errors.Wrap(err, "check zip")
 		}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -4,7 +4,6 @@ package archive // import "github.com/buildpacks/pack/pkg/archive"
 import (
 	"archive/tar"
 	"archive/zip"
-	"bytes"
 	"io"
 	"io/ioutil"
 	"os"
@@ -368,14 +367,16 @@ func NormalizeHeader(header *tar.Header, normalizeModTime bool) {
 }
 
 // IsZip detects whether or not a File is a zip directory
-func IsZip(file io.Reader) (bool, error) {
-	b := make([]byte, 4)
-	_, err := file.Read(b)
-	if err != nil && err != io.EOF {
-		return false, err
-	} else if err == io.EOF {
-		return false, nil
-	}
+func IsZip(path string) (bool, error) {
+	r, err := zip.OpenReader(path)
 
-	return bytes.Equal(b, []byte("\x50\x4B\x03\x04")), nil
+	switch {
+	case err == nil:
+		r.Close()
+		return true, nil
+	case err == zip.ErrFormat:
+		return false, nil
+	default:
+		return false, err
+	}
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -574,12 +574,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 		when("file is a zip file", func() {
 			it("returns true", func() {
 				path := filepath.Join("testdata", "zip-to-tar.zip")
-
-				file, err := os.Open(path)
-				h.AssertNil(t, err)
-				defer file.Close()
-
-				isZip, err := archive.IsZip(file)
+				isZip, err := archive.IsZip(path)
 				h.AssertNil(t, err)
 				h.AssertTrue(t, isZip)
 			})
@@ -588,12 +583,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 		when("file is a jar file", func() {
 			it("returns true", func() {
 				path := filepath.Join("testdata", "jar-file.jar")
-
-				file, err := os.Open(path)
-				h.AssertNil(t, err)
-				defer file.Close()
-
-				isZip, err := archive.IsZip(file)
+				isZip, err := archive.IsZip(path)
 				h.AssertNil(t, err)
 				h.AssertTrue(t, isZip)
 			})
@@ -609,7 +599,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 					err = ioutil.WriteFile(file.Name(), []byte("content"), os.ModePerm)
 					h.AssertNil(t, err)
 
-					isZip, err := archive.IsZip(file)
+					isZip, err := archive.IsZip(file.Name())
 					h.AssertNil(t, err)
 					h.AssertFalse(t, isZip)
 				})
@@ -621,23 +611,10 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, err)
 					defer file.Close()
 
-					isZip, err := archive.IsZip(file)
+					isZip, err := archive.IsZip(file.Name())
 					h.AssertNil(t, err)
 					h.AssertFalse(t, isZip)
 				})
-			})
-		})
-
-		when("reader is closed", func() {
-			it("returns error", func() {
-				file, err := ioutil.TempFile(tmpDir, "file.txt")
-				h.AssertNil(t, err)
-				err = file.Close()
-				h.AssertNil(t, err)
-
-				isZip, err := archive.IsZip(file)
-				h.AssertError(t, err, os.ErrClosed.Error())
-				h.AssertFalse(t, isZip)
 			})
 		})
 	})


### PR DESCRIPTION
## Summary
Go stdlib zip format validation looks _non-trivial_. Might be worth delegating..

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
```shell
$ pack build sample-app --path target/sample-0.0.1-SNAPSHOT.jar --builder cnbs/sample-builder:bionic
ERROR: failed to build: invalid app path 'target/sample-0.0.1-SNAPSHOT.jar': app path must be a directory or zip
```

#### After
```shell
$ pack build sample-app --path target/sample-0.0.1-SNAPSHOT.jar --builder cnbs/sample-builder:bionic
...
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves https://github.com/buildpacks/pack/issues/1236
