### PR TITLE
Fix pack builder suggest panic

### DIFF
--- a/internal/commands/suggest_builders.go
+++ b/internal/commands/suggest_builders.go
@@ -118,7 +118,7 @@ func WriteSuggestedBuilder(logger logging.Logger, inspector BuilderInspector, bu
 
 func getBuilderDescription(builder SuggestedBuilder, inspector BuilderInspector) string {
 	info, err := inspector.InspectBuilder(builder.Image, false)
-	if err == nil && info.Description != "" {
+	if err == nil && info != nil && info.Description != "" {
 		return info.Description
 	}
 


### PR DESCRIPTION
- check `inspector.InspectBuilder` returned info is not nil

## Summary
<!-- Provide a high-level summary of the change. -->
Fix pack builder suggest panic
## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
```
go test -v --run=Test_getBuilderDescription
=== RUN   Test_getBuilderDescription
--- FAIL: Test_getBuilderDescription (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x171447c]

goroutine 6 [running]:
testing.tRunner.func1.2(0x185ed40, 0x1ecf140)
        /usr/local/Cellar/go/1.16.6/libexec/src/testing/testing.go:1143 +0x332
testing.tRunner.func1(0xc00039a600)
        /usr/local/Cellar/go/1.16.6/libexec/src/testing/testing.go:1146 +0x4b6
panic(0x185ed40, 0x1ecf140)
        /usr/local/Cellar/go/1.16.6/libexec/src/runtime/panic.go:965 +0x1b9
github.com/buildpacks/pack/internal/commands.getBuilderDescription(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1a5d340, 0x1f15870, 0x3b20f68, 0x167da3c04692c)
        /Users/damao/workspace/contribute/pack/internal/commands/suggest_builders.go:121 +0x9c
github.com/buildpacks/pack/internal/commands.Test_getBuilderDescription(0xc00039a600)
        /Users/damao/workspace/contribute/pack/internal/commands/stack_suggest_test.go:77 +0x4b
testing.tRunner(0xc00039a600, 0x19a5658)
        /usr/local/Cellar/go/1.16.6/libexec/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
        /usr/local/Cellar/go/1.16.6/libexec/src/testing/testing.go:1238 +0x2b3
exit status 2
FAIL    github.com/buildpacks/pack/internal/commands    0.569s
```
#### After
```
go test -v --run=Test_getBuilderDescription
=== RUN   Test_getBuilderDescription
--- PASS: Test_getBuilderDescription (0.00s)
PASS
ok      github.com/buildpacks/pack/internal/commands    1.001s
```
## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1250
