### PR TITLE
Fix using variable reference when running multiple combo tests

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -91,6 +91,9 @@ func TestAcceptance(t *testing.T) {
 	}
 
 	for _, combo := range inputConfigManager.Combinations() {
+		// see https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable
+		combo := combo
+
 		t.Logf(`setting up run combination %s: %s`,
 			style.Symbol(combo.String()),
 			combo.Describe(assetsConfig),


### PR DESCRIPTION
This addresses a common problem when iterating slices of pointers. Previously only the last entry in the set was being tested when running `make acceptance-all`.

Found as part as diagnosing #1253 