### PR TITLE
Update dispatch workflow

### DIFF
--- a/.github/workflows/delivery-release-dispatch.yml
+++ b/.github/workflows/delivery-release-dispatch.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        repo: ['buildpacks/docs', 'buildpacks/samples']
+        repo: ['buildpacks/docs', 'buildpacks/samples', 'buildpacks/pack-orb', 'buildpacks/github-actions']
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
This commit adds the pack-orb and github-actions repositories to the list of repositories to which a release dispatch is sent.

- Should this change be documented?
    - [ ] Yes    
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

See #1244
[PR for pack-orb repo](https://github.com/buildpacks/pack-orb/pull/34) 
