### PR TITLE
Complete pack-interact workflow

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -190,6 +190,11 @@ func (b *Builder) Order() dist.Order {
 	return b.order
 }
 
+// BaseImageName returns the name of the builder base image
+func (b *Builder) BaseImageName() string {
+	return b.baseImageName
+}
+
 // Name returns the name of the builder
 func (b *Builder) Name() string {
 	return b.image.Name()

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -1326,6 +1326,12 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 					h.AssertEq(t, bldr.GID(), 4321)
 				})
 			})
+
+			when("#BaseImageName", func() {
+				it("return name of base image", func() {
+					h.AssertEq(t, bldr.BaseImageName(), "base/image")
+				})
+			})
 		})
 	})
 }

--- a/internal/termui/dashboard.go
+++ b/internal/termui/dashboard.go
@@ -1,0 +1,143 @@
+package termui
+
+import (
+	"fmt"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/buildpacks/pack/pkg/dist"
+)
+
+type Dashboard struct {
+	app         app
+	appTree     *tview.TreeView
+	builderTree *tview.TreeView
+	planList    *tview.List
+	logsView    *tview.TextView
+	logs        string
+}
+
+func NewDashboard(app app, appName string, bldr buildr, runImageName string, buildpackInfo []dist.BuildpackInfo) *Dashboard {
+	appTree, builderTree := initTrees(appName, bldr, runImageName)
+
+	planList, logsView := initDashboard(buildpackInfo)
+
+	d := &Dashboard{
+		app:         app,
+		appTree:     appTree,
+		builderTree: builderTree,
+		planList:    planList,
+		logsView:    logsView,
+	}
+
+	imagesView := tview.NewFlex().
+		SetDirection(tview.FlexRow).
+		AddItem(appTree, 0, 1, false).
+		AddItem(builderTree, 0, 1, true)
+
+	imagesView.
+		SetBorder(true).
+		SetTitleAlign(tview.AlignLeft).
+		SetTitle("| [::b]images[::-] |").
+		SetBackgroundColor(backgroundColor)
+
+	leftPane := tview.NewFlex().
+		SetDirection(tview.FlexRow).
+		AddItem(imagesView, 11, 0, false).
+		AddItem(planList, 0, 1, true)
+
+	screen := tview.NewFlex().
+		SetDirection(tview.FlexColumn).
+		AddItem(leftPane, 0, 1, true).
+		AddItem(logsView, 0, 1, false)
+
+	d.app.SetRoot(screen, true)
+	return d
+}
+
+func (d *Dashboard) Handle(txt string) {
+	d.app.QueueUpdateDraw(func() {
+		d.logs = d.logs + txt + "\n"
+		d.logsView.SetText(tview.TranslateANSI(d.logs))
+	})
+}
+
+func (d *Dashboard) Stop() {
+	// no-op
+}
+
+func initDashboard(buildpackInfos []dist.BuildpackInfo) (*tview.List, *tview.TextView) {
+	planList := tview.NewList()
+	planList.SetMainTextColor(tcell.ColorMediumTurquoise).
+		SetSelectedTextColor(tcell.ColorMediumTurquoise).
+		SetSelectedBackgroundColor(tcell.ColorDarkSlateGray).
+		SetSecondaryTextColor(tcell.ColorDimGray).
+		SetBorder(true).
+		SetBorderPadding(1, 1, 1, 1).
+		SetTitle("| [::b]plan[::-] |").
+		SetTitleAlign(tview.AlignLeft).
+		SetBackgroundColor(backgroundColor)
+
+	for _, buildpackInfo := range buildpackInfos {
+		planList.AddItem(
+			buildpackInfo.FullName(),
+			info(buildpackInfo),
+			'✔',
+			func() {},
+		)
+	}
+
+	logsView := tview.NewTextView()
+	logsView.SetDynamicColors(true).
+		SetTextAlign(tview.AlignLeft).
+		SetBorderPadding(1, 1, 3, 1).
+		SetTitleAlign(tview.AlignLeft).
+		SetBackgroundColor(backgroundColor)
+
+	return planList, logsView
+}
+
+func initTrees(appName string, bldr buildr, runImageName string) (*tview.TreeView, *tview.TreeView) {
+	var (
+		appImage     = tview.NewTreeNode(fmt.Sprintf("app: [white::b]%s", appName)).SetColor(tcell.ColorDimGray)
+		appRunImage  = tview.NewTreeNode(fmt.Sprintf(" run: [white::b]%s", runImageName)).SetColor(tcell.ColorDimGray)
+		builderImage = tview.NewTreeNode(fmt.Sprintf("builder: [white::b]%s", bldr.BaseImageName())).SetColor(tcell.ColorDimGray)
+		lifecycle    = tview.NewTreeNode(fmt.Sprintf(" lifecycle: [white::b]%s", bldr.LifecycleDescriptor().Info.Version.String())).SetColor(tcell.ColorDimGray)
+		runImage     = tview.NewTreeNode(fmt.Sprintf(" run: [white::b]%s", bldr.Stack().RunImage.Image)).SetColor(tcell.ColorDimGray)
+		buildpacks   = tview.NewTreeNode(" [mediumturquoise::b]buildpacks")
+	)
+
+	appImage.AddChild(appRunImage)
+	builderImage.AddChild(lifecycle)
+	builderImage.AddChild(runImage)
+	builderImage.AddChild(buildpacks)
+
+	appTree := tview.NewTreeView()
+	appTree.
+		SetRoot(appImage).
+		SetGraphics(true).
+		SetGraphicsColor(tcell.ColorMediumTurquoise).
+		SetTitleAlign(tview.AlignLeft).
+		SetBorderPadding(1, 0, 4, 0).
+		SetBackgroundColor(backgroundColor)
+
+	builderTree := tview.NewTreeView()
+	builderTree.
+		SetRoot(builderImage).
+		SetGraphics(true).
+		SetGraphicsColor(tcell.ColorMediumTurquoise).
+		SetTitleAlign(tview.AlignLeft).
+		SetBorderPadding(0, 0, 4, 0).
+		SetBackgroundColor(backgroundColor)
+
+	return appTree, builderTree
+}
+
+func info(buildpackInfo dist.BuildpackInfo) string {
+	if buildpackInfo.Description != "" {
+		return buildpackInfo.Description
+	}
+
+	return buildpackInfo.Homepage
+}

--- a/internal/termui/fakes/app.go
+++ b/internal/termui/fakes/app.go
@@ -27,6 +27,12 @@ func (a *App) Draw() *tview.Application {
 	return nil
 }
 
+func (a *App) QueueUpdateDraw(f func()) *tview.Application {
+	f()
+	a.DrawCallCount++
+	return nil
+}
+
 func (a *App) Run() error {
 	<-a.doneChan
 	return nil
@@ -34,4 +40,8 @@ func (a *App) Run() error {
 
 func (a *App) StopRunning() {
 	a.doneChan <- true
+}
+
+func (a *App) ResetDrawCount() {
+	a.DrawCallCount = 0
 }

--- a/internal/termui/fakes/builder.go
+++ b/internal/termui/fakes/builder.go
@@ -1,0 +1,38 @@
+package fakes
+
+import (
+	"github.com/buildpacks/pack/internal/builder"
+	"github.com/buildpacks/pack/pkg/dist"
+)
+
+type Builder struct {
+	baseImageName       string
+	buildpacks          []dist.BuildpackInfo
+	lifecycleDescriptor builder.LifecycleDescriptor
+	stack               builder.StackMetadata
+}
+
+func NewBuilder(baseImageName string, buildpacks []dist.BuildpackInfo, lifecycleDescriptor builder.LifecycleDescriptor, stack builder.StackMetadata) *Builder {
+	return &Builder{
+		baseImageName:       baseImageName,
+		buildpacks:          buildpacks,
+		lifecycleDescriptor: lifecycleDescriptor,
+		stack:               stack,
+	}
+}
+
+func (b *Builder) BaseImageName() string {
+	return b.baseImageName
+}
+
+func (b *Builder) Buildpacks() []dist.BuildpackInfo {
+	return b.buildpacks
+}
+
+func (b *Builder) LifecycleDescriptor() builder.LifecycleDescriptor {
+	return b.lifecycleDescriptor
+}
+
+func (b *Builder) Stack() builder.StackMetadata {
+	return b.stack
+}

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -352,7 +352,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		GID:                opts.GroupID,
 		PreviousImage:      opts.PreviousImage,
 		Interactive:        opts.Interactive,
-		Termui:             termui.NewTermui(),
+		Termui:             termui.NewTermui(imageRef.Name(), bldr, runImageName),
 	}
 
 	lifecycleVersion := ephemeralBuilder.LifecycleDescriptor().Info.Version


### PR DESCRIPTION
## Summary
Add remaining functionality for pack-interact workflow

This PR kicks continues the following **user workflow**:

When a user runs a pack build like so: `pack build <image-name> --interactive`
Then the user will view the build process through a terminal UI screen
First the `Detecting...` page will show
Then the build "dashboard" page will show

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves:
https://github.com/buildpacks/pack/issues/1203
https://github.com/buildpacks/pack/issues/1204
https://github.com/buildpacks/pack/issues/1205
https://github.com/buildpacks/pack/issues/1206