### PR TITLE
Update github rest calls to use Octokit v.5

### DIFF
--- a/.github/workflows/delivery-archlinux.yml
+++ b/.github/workflows/delivery-archlinux.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           script: |
             let tag_name = "v${{ env.PACK_VERSION }}";
-            var release = context.payload.release || await github.repos.listReleases(context.repo)
+            var release = context.payload.release || await github.rest.repos.listReleases(context.repo)
                   .then(result => result.data.find(r => r.tag_name === tag_name))
                   .catch(err => {throw "ERROR: " + err.message});
 

--- a/.github/workflows/delivery-homebrew.yml
+++ b/.github/workflows/delivery-homebrew.yml
@@ -35,7 +35,7 @@ jobs:
             }
             let tag_name = tag.replace(/^v/, '');
 
-            var release = payload.release || await github.repos.listReleases(context.repo)
+            var release = payload.release || await github.rest.repos.listReleases(context.repo)
                   .then(result => result.data.find(r => r.tag_name === tag_name))
                   .catch(err => {throw "ERROR: " + err.message});
 

--- a/.github/workflows/privileged-pr-process.yml
+++ b/.github/workflows/privileged-pr-process.yml
@@ -19,7 +19,7 @@ jobs:
         id: assets
         with:
           script: |
-            var milestone = await github.issues.listMilestones({
+            var milestone = await github.rest.issues.listMilestones({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
                       state: 'open',
@@ -30,7 +30,7 @@ jobs:
                   .catch(err => {throw "ERROR: " + err.message});
 
             if (milestone) {
-                await github.issues.update({
+                await github.rest.issues.update({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: context.payload.number,


### PR DESCRIPTION
Signed-off-by: David Freilich <freilich.david@gmail.com>

## Summary
<!-- Provide a high-level summary of the change. -->
https://github.com/buildpacks/pack/pull/1294 upgraded the GH scripts to use the latest version of Octokit. This PR updates our scripts to match that, based on the API [docs](https://octokit.github.io/rest.js/v18)

