### PR TITLE
remove deprecated setting - `bottle :unneeded`

### DIFF
--- a/.github/workflows/delivery/homebrew/pack.rb
+++ b/.github/workflows/delivery/homebrew/pack.rb
@@ -16,8 +16,6 @@ class Pack < Formula
     sha256 "{{LINUX_SHA}}"
   end
 
-  bottle :unneeded
-
   def install
     bin.install "pack"
   end


### PR DESCRIPTION
Signed-off-by: Yuuki Ebihara <yuuki.ebihara813@gmail.com>

## Summary
Remove deprecated setting for Homebrew

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
There is a `bottle :unneeded` setting  in workflow template.

#### After
`bottle :unneeded` setting  is removed.

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
