### PR TITLE
Add flag to export image to OCI layout format - (Experimental)

### DIFF
--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -388,7 +388,7 @@ func (l *LifecycleExecution) newAnalyze(repoName, networkMode string, publish bo
 		l.opts.Image = prevImage
 	}
 
-	if l.opts.UseLayout {
+	if l.opts.OCIPath != "" {
 		flagsOpt = WithFlags("-layout")
 	}
 	_, layoutOpt, layoutEnv := l.configureLayout([]string{})
@@ -570,7 +570,7 @@ func (l *LifecycleExecution) configureLayout(flags []string) ([]string, PhaseCon
 	layoutOpt := NullOp()
 	layoutEnv := NullOp()
 
-	if l.opts.UseLayout {
+	if l.opts.OCIPath != "" {
 		flags = append(flags, "-layout")
 		layoutOpt = WithBinds(fmt.Sprintf("%s:%s:%s", l.opts.OCIPath, l.mountPaths.ociDir(), "rw"))
 		layoutEnv = WithEnv(fmt.Sprintf("%s=%s", builder.EnvLayoutDir, l.mountPaths.ociDir()))

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -50,10 +50,15 @@ func NewLifecycleExecution(logger logging.Logger, docker client.CommonAPIClient,
 		return nil, err
 	}
 
+	layersVolumeName := paths.FilterReservedNames("pack-layers-" + randString(10))
+	if opts.UseLayout {
+		layersVolumeName = paths.FilterReservedNames("pack-layers-" + opts.Image.String())
+	}
+
 	exec := &LifecycleExecution{
 		logger:       logger,
 		docker:       docker,
-		layersVolume: paths.FilterReservedNames("pack-layers-" + randString(10)),
+		layersVolume: layersVolumeName,
 		appVolume:    paths.FilterReservedNames("pack-app-" + randString(10)),
 		platformAPI:  latestSupportedPlatformAPI,
 		opts:         opts,
@@ -130,6 +135,7 @@ func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseF
 		}
 		buildCache = cache.NewImageCache(cacheImage, l.docker)
 	} else {
+		l.logger.Debugf("Creating a new cache volumne for image %s", l.opts.Image.Name())
 		buildCache = cache.NewVolumeCache(l.opts.Image, "build", l.docker)
 	}
 
@@ -171,13 +177,17 @@ func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseF
 		return l.Export(ctx, l.opts.Image.String(), l.opts.RunImage, l.opts.Publish, l.opts.DockerHost, l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, phaseFactory)
 	}
 
-	return l.Create(ctx, l.opts.Publish, l.opts.DockerHost, l.opts.ClearCache, l.opts.RunImage, l.opts.Image.String(), l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, l.opts.Volumes, phaseFactory)
+	return l.Create(ctx, l.opts.Publish, l.opts.DockerHost, l.opts.ClearCache, l.opts.UseLayout, l.opts.RunImage, l.opts.Image.String(), l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, l.opts.Volumes, phaseFactory)
 }
 
 func (l *LifecycleExecution) Cleanup() error {
 	var reterr error
-	if err := l.docker.VolumeRemove(context.Background(), l.layersVolume, true); err != nil {
-		reterr = errors.Wrapf(err, "failed to clean up layers volume %s", l.layersVolume)
+	if !l.opts.UseLayout {
+		if err := l.docker.VolumeRemove(context.Background(), l.layersVolume, true); err != nil {
+			reterr = errors.Wrapf(err, "failed to clean up layers volume %s", l.layersVolume)
+		}
+	} else {
+		l.logger.Debugf("Skipping volume %s clean up because -layer flag is enabled", l.layersVolume)
 	}
 	if err := l.docker.VolumeRemove(context.Background(), l.appVolume, true); err != nil {
 		reterr = errors.Wrapf(err, "failed to clean up app volume %s", l.appVolume)
@@ -185,7 +195,7 @@ func (l *LifecycleExecution) Cleanup() error {
 	return reterr
 }
 
-func (l *LifecycleExecution) Create(ctx context.Context, publish bool, dockerHost string, clearCache bool, runImage, repoName, networkMode string, buildCache, launchCache Cache, additionalTags, volumes []string, phaseFactory PhaseFactory) error {
+func (l *LifecycleExecution) Create(ctx context.Context, publish bool, dockerHost string, clearCache, useLayout bool, runImage, repoName, networkMode string, buildCache, launchCache Cache, additionalTags, volumes []string, phaseFactory PhaseFactory) error {
 	flags := addTags([]string{
 		"-app", l.mountPaths.appDir(),
 		"-cache-dir", l.mountPaths.cacheDir(),
@@ -194,6 +204,10 @@ func (l *LifecycleExecution) Create(ctx context.Context, publish bool, dockerHos
 
 	if clearCache {
 		flags = append(flags, "-skip-restore")
+	}
+
+	if useLayout {
+		flags = append(flags, "-layout")
 	}
 
 	if l.opts.GID >= overrideGID {
@@ -487,7 +501,9 @@ func (l *LifecycleExecution) newExport(repoName, runImage string, publish bool, 
 	if l.opts.GID >= overrideGID {
 		flags = append(flags, "-gid", strconv.Itoa(l.opts.GID))
 	}
-
+	if l.opts.UseLayout {
+		flags = append(flags, "-layout")
+	}
 	cacheOpt := NullOp()
 	switch buildCache.Type() {
 	case cache.Image:

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -50,10 +50,15 @@ func NewLifecycleExecution(logger logging.Logger, docker client.CommonAPIClient,
 		return nil, err
 	}
 
+	layersVolumeName := paths.FilterReservedNames("pack-layers-" + randString(10))
+	if opts.UseLayout {
+		layersVolumeName = paths.FilterReservedNames("pack-layers-" + opts.Image.String())
+	}
+
 	exec := &LifecycleExecution{
 		logger:       logger,
 		docker:       docker,
-		layersVolume: paths.FilterReservedNames("pack-layers-" + randString(10)),
+		layersVolume: layersVolumeName,
 		appVolume:    paths.FilterReservedNames("pack-app-" + randString(10)),
 		platformAPI:  latestSupportedPlatformAPI,
 		opts:         opts,
@@ -130,6 +135,7 @@ func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseF
 		}
 		buildCache = cache.NewImageCache(cacheImage, l.docker)
 	} else {
+		l.logger.Debugf("Creating a new cache volumne for image %s", l.opts.Image.Name())
 		buildCache = cache.NewVolumeCache(l.opts.Image, "build", l.docker)
 	}
 
@@ -171,13 +177,17 @@ func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseF
 		return l.Export(ctx, l.opts.Image.String(), l.opts.RunImage, l.opts.Publish, l.opts.DockerHost, l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, phaseFactory)
 	}
 
-	return l.Create(ctx, l.opts.Publish, l.opts.DockerHost, l.opts.ClearCache, l.opts.RunImage, l.opts.Image.String(), l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, l.opts.Volumes, phaseFactory)
+	return l.Create(ctx, l.opts.Publish, l.opts.DockerHost, l.opts.ClearCache, l.opts.UseLayout, l.opts.RunImage, l.opts.Image.String(), l.opts.Network, buildCache, launchCache, l.opts.AdditionalTags, l.opts.Volumes, phaseFactory)
 }
 
 func (l *LifecycleExecution) Cleanup() error {
 	var reterr error
-	if err := l.docker.VolumeRemove(context.Background(), l.layersVolume, true); err != nil {
-		reterr = errors.Wrapf(err, "failed to clean up layers volume %s", l.layersVolume)
+	if !l.opts.UseLayout {
+		if err := l.docker.VolumeRemove(context.Background(), l.layersVolume, true); err != nil {
+			reterr = errors.Wrapf(err, "failed to clean up layers volume %s", l.layersVolume)
+		}
+	} else {
+		l.logger.Debugf("Skipping volume %s clean up because -layer flag is enabled", l.layersVolume)
 	}
 	if err := l.docker.VolumeRemove(context.Background(), l.appVolume, true); err != nil {
 		reterr = errors.Wrapf(err, "failed to clean up app volume %s", l.appVolume)
@@ -185,7 +195,7 @@ func (l *LifecycleExecution) Cleanup() error {
 	return reterr
 }
 
-func (l *LifecycleExecution) Create(ctx context.Context, publish bool, dockerHost string, clearCache bool, runImage, repoName, networkMode string, buildCache, launchCache Cache, additionalTags, volumes []string, phaseFactory PhaseFactory) error {
+func (l *LifecycleExecution) Create(ctx context.Context, publish bool, dockerHost string, clearCache, useLayout bool, runImage, repoName, networkMode string, buildCache, launchCache Cache, additionalTags, volumes []string, phaseFactory PhaseFactory) error {
 	flags := addTags([]string{
 		"-app", l.mountPaths.appDir(),
 		"-cache-dir", l.mountPaths.cacheDir(),
@@ -194,6 +204,10 @@ func (l *LifecycleExecution) Create(ctx context.Context, publish bool, dockerHos
 
 	if clearCache {
 		flags = append(flags, "-skip-restore")
+	}
+
+	if useLayout {
+		flags = append(flags, "-layout")
 	}
 
 	if l.opts.GID >= overrideGID {
@@ -385,6 +399,10 @@ func (l *LifecycleExecution) newAnalyze(repoName, networkMode string, publish bo
 		l.opts.Image = prevImage
 	}
 
+	if l.opts.UseLayout {
+		flagsOpt = WithFlags("-layout")
+	}
+
 	if publish {
 		authConfig, err := auth.BuildEnvVar(authn.DefaultKeychain, repoName)
 		if err != nil {
@@ -477,7 +495,9 @@ func (l *LifecycleExecution) newExport(repoName, runImage string, publish bool, 
 	if l.opts.GID >= overrideGID {
 		flags = append(flags, "-gid", strconv.Itoa(l.opts.GID))
 	}
-
+	if l.opts.UseLayout {
+		flags = append(flags, "-layout")
+	}
 	cacheOpt := NullOp()
 	switch buildCache.Type() {
 	case cache.Image:

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -932,6 +932,56 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 		})
+
+		when("oci-dir", func() {
+			var (
+				lifecycle        *build.LifecycleExecution
+				fakePhaseFactory *fakes.FakePhaseFactory
+			)
+			fakePhase := &fakes.FakePhase{}
+			fakePhaseFactory = fakes.NewFakePhaseFactory(fakes.WhichReturnsForNew(fakePhase))
+
+			when("OCIPath is provided", func() {
+				it.Before(func() {
+					lifecycle = newTestLifecycleExec(t, true, func(options *build.LifecycleOptions) {
+						options.OCIPath = "/path/to/oci"
+					})
+				})
+
+				it("configures the phase with the expected arguments", func() {
+					err := lifecycle.Create(context.Background(), false, "", true, "test", "test", "test", fakeBuildCache, fakeLaunchCache, []string{}, []string{}, fakePhaseFactory)
+					h.AssertNil(t, err)
+
+					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+					h.AssertNotEq(t, lastCallIndex, -1)
+
+					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+					h.AssertEq(t, configProvider.Name(), "creator")
+					assertValidOCIConfiguration(t, configProvider, "/path/to/oci")
+				})
+			})
+
+			when("OCIPath is not provided", func() {
+				it.Before(func() {
+					lifecycle = newTestLifecycleExec(t, true, func(options *build.LifecycleOptions) {
+						options.OCIPath = ""
+					})
+				})
+
+				it("layout is not added to the expected arguments", func() {
+					err := lifecycle.Create(context.Background(), false, "", true, "test", "test", "test", fakeBuildCache, fakeLaunchCache, []string{}, []string{}, fakePhaseFactory)
+					h.AssertNil(t, err)
+
+					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+					h.AssertNotEq(t, lastCallIndex, -1)
+
+					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+					h.AssertEq(t, configProvider.Name(), "creator")
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-layout")
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Env, "CNB_LAYOUT_DIR=/oci")
+				})
+			})
+		})
 	})
 
 	when("#Detect", func() {
@@ -1496,6 +1546,56 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 						err = lifecycle.Analyze(context.Background(), "test", "test", true, "", false, fakeCache, fakePhaseFactory)
 						h.AssertError(t, err, fmt.Sprintf("%s", err))
 					})
+				})
+			})
+		})
+
+		when("oci-dir", func() {
+			var (
+				lifecycle        *build.LifecycleExecution
+				fakePhaseFactory *fakes.FakePhaseFactory
+			)
+			fakePhase := &fakes.FakePhase{}
+			fakePhaseFactory = fakes.NewFakePhaseFactory(fakes.WhichReturnsForNew(fakePhase))
+
+			when("OCIPath is provided", func() {
+				it.Before(func() {
+					lifecycle = newTestLifecycleExec(t, true, func(options *build.LifecycleOptions) {
+						options.OCIPath = "/path/to/oci"
+					})
+				})
+
+				it("configures the phase with the expected arguments", func() {
+					err := lifecycle.Analyze(context.Background(), "test", "test", false, "", false, fakeCache, fakePhaseFactory)
+					h.AssertNil(t, err)
+
+					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+					h.AssertNotEq(t, lastCallIndex, -1)
+
+					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+					h.AssertEq(t, configProvider.Name(), "analyzer")
+					assertValidOCIConfiguration(t, configProvider, "/path/to/oci")
+				})
+			})
+
+			when("OCIPath is not provided", func() {
+				it.Before(func() {
+					lifecycle = newTestLifecycleExec(t, true, func(options *build.LifecycleOptions) {
+						options.OCIPath = ""
+					})
+				})
+
+				it("layout is not added to the expected arguments", func() {
+					err := lifecycle.Analyze(context.Background(), "test", "test", false, "", false, fakeCache, fakePhaseFactory)
+					h.AssertNil(t, err)
+
+					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+					h.AssertNotEq(t, lastCallIndex, -1)
+
+					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+					h.AssertEq(t, configProvider.Name(), "analyzer")
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-layout")
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Env, "CNB_LAYOUT_DIR=/oci")
 				})
 			})
 		})
@@ -2324,6 +2424,56 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 		})
+
+		when("oci-dir", func() {
+			var (
+				lifecycle        *build.LifecycleExecution
+				fakePhaseFactory *fakes.FakePhaseFactory
+			)
+			fakePhase := &fakes.FakePhase{}
+			fakePhaseFactory = fakes.NewFakePhaseFactory(fakes.WhichReturnsForNew(fakePhase))
+
+			when("OCIPath is provided", func() {
+				it.Before(func() {
+					lifecycle = newTestLifecycleExec(t, true, func(options *build.LifecycleOptions) {
+						options.OCIPath = "/path/to/oci"
+					})
+				})
+
+				it("configures the phase with the expected arguments", func() {
+					err := lifecycle.Export(context.Background(), "test", "test", false, "", "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
+					h.AssertNil(t, err)
+
+					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+					h.AssertNotEq(t, lastCallIndex, -1)
+
+					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+					h.AssertEq(t, configProvider.Name(), "exporter")
+					assertValidOCIConfiguration(t, configProvider, "/path/to/oci")
+				})
+			})
+
+			when("OCIPath is not provided", func() {
+				it.Before(func() {
+					lifecycle = newTestLifecycleExec(t, true, func(options *build.LifecycleOptions) {
+						options.OCIPath = ""
+					})
+				})
+
+				it("layout is not added to the expected arguments", func() {
+					err := lifecycle.Export(context.Background(), "test", "test", false, "", "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
+					h.AssertNil(t, err)
+
+					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+					h.AssertNotEq(t, lastCallIndex, -1)
+
+					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+					h.AssertEq(t, configProvider.Name(), "exporter")
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-layout")
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Env, "CNB_LAYOUT_DIR=/oci")
+				})
+			})
+		})
 	})
 }
 
@@ -2361,4 +2511,15 @@ func newTestLifecycleExec(t *testing.T, logVerbose bool, ops ...func(*build.Life
 	lifecycleExec, err := newTestLifecycleExecErr(t, logVerbose, ops...)
 	h.AssertNil(t, err)
 	return lifecycleExec
+}
+
+func assertValidOCIConfiguration(t *testing.T, configProvider *build.PhaseConfigProvider, path string) {
+	h.AssertIncludeAllExpectedPatterns(t,
+		configProvider.ContainerConfig().Cmd,
+		[]string{"-layout"},
+	)
+	h.AssertIncludeAllExpectedPatterns(t,
+		configProvider.ContainerConfig().Env,
+		[]string{"CNB_LAYOUT_DIR=/layers/oci"},
+	)
 }

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -72,6 +72,7 @@ type LifecycleOptions struct {
 	TrustBuilder       bool
 	UseCreator         bool
 	Interactive        bool
+	UseLayout          bool
 	Termui             Termui
 	DockerHost         string
 	CacheImage         string

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -72,7 +72,6 @@ type LifecycleOptions struct {
 	TrustBuilder       bool
 	UseCreator         bool
 	Interactive        bool
-	UseLayout          bool
 	Termui             Termui
 	DockerHost         string
 	CacheImage         string

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -70,6 +70,7 @@ type LifecycleOptions struct {
 	TrustBuilder       bool
 	UseCreator         bool
 	Interactive        bool
+	UseLayout          bool
 	Termui             Termui
 	DockerHost         string
 	CacheImage         string

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -65,6 +65,8 @@ type LifecycleOptions struct {
 	LifecycleImage     string
 	RunImage           string
 	ProjectMetadata    platform.ProjectMetadata
+	ProjectPath        string
+	OCIPath			   string
 	ClearCache         bool
 	Publish            bool
 	TrustBuilder       bool

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -65,7 +65,6 @@ type LifecycleOptions struct {
 	LifecycleImage     string
 	RunImage           string
 	ProjectMetadata    platform.ProjectMetadata
-	ProjectPath        string
 	OCIPath			   string
 	ClearCache         bool
 	Publish            bool

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -65,7 +65,7 @@ type LifecycleOptions struct {
 	LifecycleImage     string
 	RunImage           string
 	ProjectMetadata    platform.ProjectMetadata
-	OCIPath			   string
+	OCIPath            string
 	ClearCache         bool
 	Publish            bool
 	TrustBuilder       bool

--- a/internal/build/mount_paths.go
+++ b/internal/build/mount_paths.go
@@ -59,5 +59,5 @@ func (m mountPaths) launchCacheDir() string {
 }
 
 func (m mountPaths) ociDir() string {
-	return m.join(m.volume, "oci")
+	return m.join(m.layersDir(), "oci")
 }

--- a/internal/build/mount_paths.go
+++ b/internal/build/mount_paths.go
@@ -57,3 +57,7 @@ func (m mountPaths) cacheDir() string {
 func (m mountPaths) launchCacheDir() string {
 	return m.join(m.volume, "launch-cache")
 }
+
+func (m mountPaths) ociDir() string {
+	return m.join(m.volume, "oci")
+}

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -46,6 +46,7 @@ const (
 
 	EnvUID = "CNB_USER_ID"
 	EnvGID = "CNB_GROUP_ID"
+	EnvLayoutDir = "CNB_LAYOUT_DIR"
 
 	BuildpackOnBuilderMessage = `buildpack %s already exists on builder and will be overwritten
   - existing diffID: %s

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -44,8 +44,8 @@ const (
 	metadataLabel = "io.buildpacks.builder.metadata"
 	stackLabel    = "io.buildpacks.stack.id"
 
-	EnvUID = "CNB_USER_ID"
-	EnvGID = "CNB_GROUP_ID"
+	EnvUID       = "CNB_USER_ID"
+	EnvGID       = "CNB_GROUP_ID"
 	EnvLayoutDir = "CNB_LAYOUT_DIR"
 
 	BuildpackOnBuilderMessage = `buildpack %s already exists on builder and will be overwritten

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -24,6 +24,7 @@ type BuildFlags struct {
 	ClearCache         bool
 	TrustBuilder       bool
 	Interactive        bool
+	UseLayout          bool
 	DockerHost         string
 	CacheImage         string
 	AppPath            string
@@ -157,6 +158,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				GroupID:                  gid,
 				PreviousImage:            flags.PreviousImage,
 				Interactive:              flags.Interactive,
+				UseLayout:                flags.UseLayout,
 			}); err != nil {
 				return errors.Wrap(err, "failed to build")
 			}
@@ -198,6 +200,7 @@ This option may set DOCKER_HOST environment variable for the build container if 
 	cmd.Flags().IntVar(&buildFlags.GID, "gid", 0, `Override GID of user's group in the stack's build and run images. The provided value must be a positive number`)
 	cmd.Flags().StringVar(&buildFlags.PreviousImage, "previous-image", "", "Set previous image to a particular tag reference, digest reference, or (when performing a daemon build) image ID")
 	cmd.Flags().BoolVar(&buildFlags.Interactive, "interactive", false, "Launch a terminal UI to depict the build process")
+	cmd.Flags().BoolVar(&buildFlags.UseLayout, "layout", false, "export to OIC layout")
 	if !cfg.Experimental {
 		cmd.Flags().MarkHidden("interactive")
 	}

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -36,6 +36,7 @@ type BuildFlags struct {
 	DescriptorPath     string
 	DefaultProcessType string
 	LifecycleImage     string
+	OCIPath			   string
 	Env                []string
 	EnvFiles           []string
 	Buildpacks         []string
@@ -159,6 +160,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				PreviousImage:            flags.PreviousImage,
 				Interactive:              flags.Interactive,
 				UseLayout:                flags.UseLayout,
+				OCIPath: 				  flags.OCIPath,
 			}); err != nil {
 				return errors.Wrap(err, "failed to build")
 			}
@@ -204,6 +206,7 @@ This option may set DOCKER_HOST environment variable for the build container if 
 	if !cfg.Experimental {
 		cmd.Flags().MarkHidden("interactive")
 	}
+	cmd.Flags().StringVarP(&buildFlags.OCIPath, "oci-path", "", "", "Path to export the oci layout image (only valid if layout is used).\nIf unset it defaults to 'oci' folder in current working directory.")
 }
 
 func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackClient, logger logging.Logger) error {
@@ -221,6 +224,10 @@ func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackCli
 
 	if flags.Interactive && !cfg.Experimental {
 		return client.NewExperimentError("Interactive mode is currently experimental.")
+	}
+
+	if !flags.UseLayout && flags.OCIPath != "" {
+		return errors.New("oci-path flag requires the layout flag")
 	}
 
 	return nil

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -36,6 +36,7 @@ type BuildFlags struct {
 	DescriptorPath     string
 	DefaultProcessType string
 	LifecycleImage     string
+	OCIPath			   string
 	Env                []string
 	EnvFiles           []string
 	Buildpacks         []string
@@ -205,7 +206,6 @@ This option may set DOCKER_HOST environment variable for the build container if 
 		cmd.Flags().MarkHidden("interactive")
 		cmd.Flags().MarkHidden("oci-dir")
 	}
-
 }
 
 func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackClient, logger logging.Logger) error {

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -225,7 +225,7 @@ func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackCli
 	}
 
 	if flags.OCIPath != "" && !cfg.Experimental {
-		return pack.NewExperimentError("Exporting to OCI layout is currently experimental.")
+		return client.NewExperimentError("Exporting to OCI layout is currently experimental.")
 	}
 	return nil
 }

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -36,7 +36,6 @@ type BuildFlags struct {
 	DescriptorPath     string
 	DefaultProcessType string
 	LifecycleImage     string
-	OCIPath			   string
 	Env                []string
 	EnvFiles           []string
 	Buildpacks         []string

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -126,6 +126,9 @@ type BuildOptions struct {
 	// Launch a terminal UI to depict the build process
 	Interactive bool
 
+	// Export to OIC layout
+	UseLayout bool
+
 	// List of buildpack images or archives to add to a builder.
 	// These buildpacks may overwrite those on the builder if they
 	// share both an ID and Version with a buildpack on the builder.

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -121,6 +121,9 @@ type BuildOptions struct {
 	// Launch a terminal UI to depict the build process
 	Interactive bool
 
+	// Export to OIC layout
+	UseLayout bool
+
 	// List of buildpack images or archives to add to a builder.
 	// These buildpacks may overwrite those on the builder if they
 	// share both an ID and Version with a buildpack on the builder.
@@ -353,6 +356,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		PreviousImage:      opts.PreviousImage,
 		Interactive:        opts.Interactive,
 		Termui:             termui.NewTermui(),
+		UseLayout:          opts.UseLayout,
 	}
 
 	lifecycleVersion := ephemeralBuilder.LifecycleDescriptor().Info.Version

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -126,7 +126,7 @@ type BuildOptions struct {
 	// Launch a terminal UI to depict the build process
 	Interactive bool
 
-	// Export to OIC layout
+	// Export to OCI layout
 	UseLayout bool
 
 	// List of buildpack images or archives to add to a builder.

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -363,7 +363,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		PreviousImage:      opts.PreviousImage,
 		Interactive:        opts.Interactive,
 		Termui:             termui.NewTermui(),
-		OCIPath: 			ociPath,
+		OCIPath:            ociPath,
 	}
 
 	lifecycleVersion := ephemeralBuilder.LifecycleDescriptor().Info.Version

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -126,9 +126,6 @@ type BuildOptions struct {
 	// Launch a terminal UI to depict the build process
 	Interactive bool
 
-	// Export to OCI layout
-	UseLayout bool
-
 	// List of buildpack images or archives to add to a builder.
 	// These buildpacks may overwrite those on the builder if they
 	// share both an ID and Version with a buildpack on the builder.

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -2475,7 +2475,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 		when("oci-dir option", func() {
 			var (
 				ociPath string
-				err error
+				err     error
 			)
 
 			when("flag is not set", func() {
@@ -2490,7 +2490,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 			})
 			when("set to current directory", func() {
 				it.Before(func() {
-					ociPath, err = getPathAtWorkingDir(defaultOCIFolder)
+					ociPath, err = getPathAtWorkingDir("")
 					h.AssertNil(t, err)
 					os.Remove(ociPath)
 				})
@@ -2512,7 +2512,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 				it.Before(func() {
 					ociPath, err = getPathAtWorkingDir("oci-dir")
 					h.AssertNil(t, err)
-					err = os.Mkdir(ociPath, os.ModePerm)
+					err = os.MkdirAll(ociPath, os.ModePerm)
 					h.AssertNil(t, err)
 				})
 
@@ -2520,13 +2520,13 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					os.Remove(ociPath)
 				})
 
-				it("absolute path is passthroughs to lifecycle", func() {
+				it("default folder is appended to the absolute path and pass through to the lifecycle", func() {
 					h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
 						Image:   "some/app",
 						Builder: defaultBuilderName,
 						OCIPath: "oci-dir",
 					}))
-					h.AssertEq(t, fakeLifecycle.Opts.OCIPath, ociPath)
+					h.AssertEq(t, fakeLifecycle.Opts.OCIPath, filepath.Join(ociPath, ""))
 				})
 			})
 			when("set to non existing directory", func() {

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -2537,6 +2537,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 						OCIPath: "does/not/exist",
 					})
 					h.AssertError(t, err, "no such file or directory")
+					h.AssertError(t, err, "invalid oci path")
 				})
 			})
 		})


### PR DESCRIPTION
## Summary

Eric Hripko worked a few months ago on integrating Buildkit with Lifecycle (watch demo [here](https://youtu.be/jFvOV6crtfI)), after that work some ideas on improving lifecycle were designed, one [idea](https://hackmd.io/@jromero/B1HfPTM__#Option-2---Interface-via-OCI-layout-format) was to add a new flag to export the container image into OCI format.

This PR adds the experimental feature in Pack to invoke the lifecycle supporting this new flag for exporting the image.

## Output

A new flag **-oci-dir** was added, this new flag is a string and the argument specifies the path in the local filesystem where the OCI image must be exported

![Screen Shot 2021-10-26 at 2 09 57 PM](https://user-images.githubusercontent.com/1181799/138945862-75232360-6cb6-47de-9d6e-5ceab886d0e6.png)

The following image shows the arguments during the exporting phase

![Screen Shot 2021-10-26 at 2 11 02 PM](https://user-images.githubusercontent.com/1181799/138945899-79ea6736-0ca4-4201-910d-a9d1c165d0b8.png)

We can notice three things here:

1. **layout** flag is sent to the lifecycle
2. **CNB_LAYOUT_DIR** environment variable is also sent to lifecycle
3. We can notice a new volume mounted in the local filesystem and pointing to the directory specified in the environment variable **CNB_LAYOUT_DIR** is also created

Finally, the following image shows the final output. A new folder **/oci** is created and inside this folder, the image in [OCI format](https://github.com/opencontainers/image-spec/blob/main/spec.md) is saved

![Screen Shot 2021-10-26 at 2 12 22 PM](https://user-images.githubusercontent.com/1181799/138945913-53f61bd2-6584-48d3-9889-eb62a80c9dd0.png)

#### Before

The exporting flag didn't exist

#### After

A new flag **--oci-dir** was added

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

**This feature requires a new version of the lifecycle, but is still on experimental mode**
Resolves #___
