### PR TITLE
Fix default buildpack API version.

### DIFF
--- a/internal/commands/buildpack_new.go
+++ b/internal/commands/buildpack_new.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/buildpacks/pack/internal/build"
 	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/pkg/client"
 	"github.com/buildpacks/pack/pkg/dist"
@@ -82,7 +81,7 @@ func BuildpackNew(logger logging.Logger, creator BuildpackCreator) *cobra.Comman
 		}),
 	}
 
-	cmd.Flags().StringVarP(&flags.API, "api", "a", build.SupportedPlatformAPIVersions.Latest().String(), "Buildpack API compatibility of the generated buildpack")
+	cmd.Flags().StringVarP(&flags.API, "api", "a", "0.5", "Buildpack API compatibility of the generated buildpack")
 	cmd.Flags().StringVarP(&flags.Path, "path", "p", "", "Path to generate the buildpack")
 	cmd.Flags().StringVarP(&flags.Version, "version", "V", "1.0.0", "Version of the generated buildpack")
 	cmd.Flags().StringSliceVarP(&flags.Stacks, "stacks", "s", []string{"io.buildpacks.stacks.bionic"}, "Stack(s) this buildpack will be compatible with"+multiValueHelp("stack"))

--- a/internal/commands/buildpack_new_test.go
+++ b/internal/commands/buildpack_new_test.go
@@ -57,7 +57,7 @@ func testBuildpackNewCommand(t *testing.T, when spec.G, it spec.S) {
 	when("BuildpackNew#Execute", func() {
 		it("uses the args to generate artifacts", func() {
 			mockClient.EXPECT().NewBuildpack(gomock.Any(), client.NewBuildpackOptions{
-				API:     "0.6",
+				API:     "0.5",
 				ID:      "example/some-cnb",
 				Path:    filepath.Join(tmpDir, "some-cnb"),
 				Version: "1.0.0",


### PR DESCRIPTION
## Summary

<!-- Provide a high-level summary of the change. -->

Fix default buildpack API version in `pack buildpack new`

It was incorrectly pulling the latest supported platform API version.
Explicitly declare the default version instead of dynamically pulling,
as updates may require changes to the buildpack tempalte.

I chose version 0.5 since that is what is declared in the [main branch of the spec](https://github.com/buildpacks/spec/blob/main/buildpack.md#buildpack-api-version). There is also a [buildpack spec 0.6 tag (which still declares it's version 0.5)](https://github.com/buildpacks/spec/blob/buildpack/0.6/buildpack.md?plain=1#L87) and even a [reference to buildpack API 0.7 in lifecycle](https://github.com/buildpacks/lifecycle/blob/9ba9bb88a9eaf667ba294da611df0a1ab57d780a/api/apis.go#L12); happy to use a different version based on feedback.

## Output

When generating a buildpack with `pack buildpack new` without specifying a buildpack API version:

<!-- If applicable, please provide examples of the output changes. -->

#### Before

In buildpack.toml:

```toml
api = "<latest-supported-platform-api-version>"
```


#### After

In buildpack.toml:

```toml
api = "0.5"
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related

[Slack discussion of this.](https://buildpacks.slack.com/archives/CD61YAG69/p1637212159047300)

I don't know if the generated buildpack is currently compatible with all supported buildpack API versions, but if we need slight differences based on the specified buildpack API version, that could be a follow-on to this.