### PR TITLE
Remove outdated acceptance tests constraints

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -48,6 +48,9 @@ The [release manager](#release-manager) will:
 - Send out release notifications, if deemed necessary, on
   - The [cncf-buildpacks mailing list](https://lists.cncf.io/g/cncf-buildpacks)
   - Twitter
+- Post release, you should be able to remove any acceptance test constraints (in [acceptance/invoke/pack.go](acceptance/invoke/pack.go)) in the `featureTests` struct. Create a PR removing them, in order to ensure our acceptance tests are clean.
+
+And with that, you're done!
 
 ## Manual Releasing
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -709,7 +709,6 @@ func testAcceptance(
 				it.Before(func() {
 					// create our nested builder
 					h.SkipIf(t, imageManager.HostOS() == "windows", "These tests are not yet compatible with Windows-based containers")
-					h.SkipIf(t, !createBuilderPack.SupportsFeature(invoke.BuilderNoDuplicateLayers), "bug fixed in 0.18.0")
 
 					// create a task, handled by a 'task manager' which executes our pack commands during tests.
 					// looks like this is used to de-dup tasks
@@ -904,9 +903,7 @@ func testAcceptance(
 						assertImage.HasLabelWithData(repoName, "io.buildpacks.lifecycle.metadata", fmt.Sprintf(`"stack":{"runImage":{"image":"%s","mirrors":["%s"]}}}`, runImage, runImageMirror))
 
 						t.Log("sets the source metadata")
-						if pack.SupportsFeature(invoke.SourceMetadataFromProjectTOML) {
-							assertImage.HasLabelWithData(repoName, "io.buildpacks.project.metadata", (`{"source":{"type":"project","version":{"declared":"1.0.2"},"metadata":{"url":"https://github.com/buildpacks/pack"}}}`))
-						}
+						assertImage.HasLabelWithData(repoName, "io.buildpacks.project.metadata", (`{"source":{"type":"project","version":{"declared":"1.0.2"},"metadata":{"url":"https://github.com/buildpacks/pack"}}}`))
 
 						t.Log("registry is empty")
 						assertImage.NotExistsInRegistry(repo)
@@ -1599,11 +1596,6 @@ func testAcceptance(
 							t.Log("checking that registry has contents")
 							assertImage.ExistsInRegistryCatalog(repo)
 
-							// TODO: remove this if block after pack 0.18.0 is released
-							if !pack.SupportsFeature(invoke.InspectRemoteImage) {
-								imageManager.PullImage(repoName, registryConfig.RegistryAuth())
-							}
-
 							cmdName := "inspect"
 							if !pack.Supports("inspect") {
 								cmdName = "inspect-image"
@@ -1670,11 +1662,6 @@ func testAcceptance(
 								)
 
 								format.compareFunc(output, expectedOutput)
-							}
-
-							// TODO: remove this if block after pack 0.18.0 is released
-							if pack.SupportsFeature(invoke.InspectRemoteImage) {
-								imageManager.PullImage(repoName, registryConfig.RegistryAuth())
 							}
 
 							t.Log("app is runnable")
@@ -1763,7 +1750,7 @@ func testAcceptance(
 							if imageManager.HostOS() == "windows" {
 								// Cache images are automatically Linux container images, and therefore can't be pulled
 								// and inspected correctly on WCOW systems
-								//https://github.com/buildpacks/lifecycle/issues/529
+								// https://github.com/buildpacks/lifecycle/issues/529
 								imageManager.PullImage(cacheImageRef.Name(), registryConfig.RegistryAuth())
 							} else {
 								assertImage.CanBePulledFromRegistry(cacheImageRef.Name())
@@ -1996,7 +1983,6 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 					it.Before(func() {
 						// create our nested builder
 						h.SkipIf(t, imageManager.HostOS() == "windows", "These tests are not yet compatible with Windows-based containers")
-						h.SkipIf(t, !pack.SupportsFeature(invoke.BuilderNoDuplicateLayers), "bug fixed in 0.18.0")
 
 						// create a task, handled by a 'task manager' which executes our pack commands during tests.
 						// looks like this is used to de-dup tasks

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1664,6 +1664,8 @@ func testAcceptance(
 								format.compareFunc(output, expectedOutput)
 							}
 
+							imageManager.PullImage(repoName, registryConfig.RegistryAuth())
+
 							t.Log("app is runnable")
 							assertImage.RunsWithOutput(
 								repoName,

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -185,7 +185,7 @@ func (i *PackInvoker) EnableExperimental() {
 	i.JustRunSuccessfully("config", "experimental", "true")
 }
 
-// supports returns whether or not the executor's pack binary supports a
+// Supports returns whether or not the executor's pack binary supports a
 // given command string. The command string can take one of four forms:
 //   - "<command>" (e.g. "create-builder")
 //   - "<flag>" (e.g. "--verbose")
@@ -219,22 +219,10 @@ func (i *PackInvoker) Supports(command string) bool {
 type Feature int
 
 const (
-	InspectRemoteImage = iota
-	BuilderNoDuplicateLayers
-	SourceMetadataFromProjectTOML
-	AnalysisFirst
+	AnalysisFirst = iota
 )
 
 var featureTests = map[Feature]func(i *PackInvoker) bool{
-	InspectRemoteImage: func(i *PackInvoker) bool {
-		return i.laterThan("0.17.0")
-	},
-	BuilderNoDuplicateLayers: func(i *PackInvoker) bool {
-		return i.laterThan("0.18.0")
-	},
-	SourceMetadataFromProjectTOML: func(i *PackInvoker) bool {
-		return i.laterThan("0.20.0")
-	},
 	AnalysisFirst: func(i *PackInvoker) bool {
 		return i.atLeast("0.23.0")
 	},


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
Pack tests the current state of the code, and pulls the latest tag for the compatibility tests. We sometimes include constraints in our acceptance tests in order to ensure that we can account for changes between versions, but we only need to keep the constraint for `n-1` versions; this PR prunes some old acceptance constraints, to simplify the code paths. 
