### PR TITLE
Check out master for pack-git, and force push

### DIFF
--- a/.github/workflows/delivery/archlinux/publish-package.sh
+++ b/.github/workflows/delivery/archlinux/publish-package.sh
@@ -40,7 +40,9 @@ echo '> Cloning aur...'
 git clone "ssh://aur@aur.archlinux.org/${PACKAGE_NAME}.git" "${PACKAGE_AUR_DIR}"
 chown -R archie "${PACKAGE_AUR_DIR}"
 pushd "${PACKAGE_AUR_DIR}" > /dev/null
-  
+  echo '> Checking out master...'
+  git checkout master
+
   echo '> Applying changes...'
   rm -rf ./*
   cp -R "${PACKAGE_DIR}"/* ./
@@ -53,6 +55,6 @@ pushd "${PACKAGE_AUR_DIR}" > /dev/null
   git diff --color | cat
   git add .
   git commit -m "Version ${PACK_VERSION}"
-  git push
+  git push -f
 
 popd > /dev/null


### PR DESCRIPTION
Signed-off-by: David Freilich <david.freilich@appsflyer.com>

## Summary
<!-- Provide a high-level summary of the change. -->
The [delivery-archlinux-git](https://github.com/buildpacks/pack/actions/workflows/delivery-archlinux-git.yml) workflow has been broken for a fair amount of time ([example](https://github.com/buildpacks/pack/actions/runs/1548498746)), with the error message being:
```
fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD)
state now, use

    git push origin HEAD:<name-of-remote-branch>
```

This PR looks to fix the workflow