### PR TITLE
Allow debug ports when pack build

### DIFF
--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -88,6 +88,7 @@ type LifecycleOptions struct {
 	Workspace          string
 	GID                int
 	PreviousImage      string
+	Ports              []string
 }
 
 func NewLifecycleExecutor(logger logging.Logger, docker client.CommonAPIClient) *LifecycleExecutor {

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -43,6 +43,7 @@ type BuildFlags struct {
 	Workspace          string
 	GID                int
 	PreviousImage      string
+	Ports              []string
 }
 
 // Build an image from source code
@@ -157,6 +158,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				GroupID:                  gid,
 				PreviousImage:            flags.PreviousImage,
 				Interactive:              flags.Interactive,
+				Ports:                    flags.Ports,
 			}); err != nil {
 				return errors.Wrap(err, "failed to build")
 			}
@@ -198,6 +200,7 @@ This option may set DOCKER_HOST environment variable for the build container if 
 	cmd.Flags().IntVar(&buildFlags.GID, "gid", 0, `Override GID of user's group in the stack's build and run images. The provided value must be a positive number`)
 	cmd.Flags().StringVar(&buildFlags.PreviousImage, "previous-image", "", "Set previous image to a particular tag reference, digest reference, or (when performing a daemon build) image ID")
 	cmd.Flags().BoolVar(&buildFlags.Interactive, "interactive", false, "Launch a terminal UI to depict the build process")
+	cmd.Flags().StringSliceVar(&buildFlags.Ports, "port", []string{}, "Ports to expose from build containers. Ex. --port 40000")
 	if !cfg.Experimental {
 		cmd.Flags().MarkHidden("interactive")
 	}

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -167,6 +167,10 @@ type BuildOptions struct {
 	// This places registry credentials on the builder's build image.
 	// Only trust builders from reputable sources.
 	TrustBuilder IsTrustedBuilder
+
+	// Ports to expose from build containers
+	// e.g. "40000"
+	Ports []string
 }
 
 // ProxyConfig specifies proxy setting to be set as environment variables in a container.
@@ -352,6 +356,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		PreviousImage:      opts.PreviousImage,
 		Interactive:        opts.Interactive,
 		Termui:             termui.NewTermui(imageRef.Name(), bldr, runImageName),
+		Ports:              opts.Ports,
 	}
 
 	lifecycleVersion := ephemeralBuilder.LifecycleDescriptor().Info.Version


### PR DESCRIPTION
## Summary
Expose `--port` to the build containers. It's useful for connecting to advertising debuggers.

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
https://github.com/buildpacks/lifecycle/pull/783
