### PR TITLE
Apply version to inline buildpacks

### DIFF
--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -688,7 +688,7 @@ func (c *Client) processBuildpacks(ctx context.Context, builderImage imgutil.Ima
 
 		for _, bp := range opts.ProjectDescriptor.Build.Buildpacks {
 			switch {
-			case bp.ID != "" && bp.Script.Inline != "" && bp.Version == "" && bp.URI == "":
+			case bp.ID != "" && bp.Script.Inline != "" && bp.URI == "":
 				if bp.Script.API == "" {
 					return nil, nil, errors.New("Missing API version for inline buildpack")
 				}
@@ -891,7 +891,11 @@ func createInlineBuildpack(bp projectTypes.Buildpack, stackID string) (string, e
 		return pathToInlineBuilpack, err
 	}
 
-	if err = createBuildpackTOML(pathToInlineBuilpack, bp.ID, "0.0.0", bp.Script.API, []dist.Stack{{ID: stackID}}, nil); err != nil {
+	if bp.Version == "" {
+		bp.Version = "0.0.0"
+	}
+
+	if err = createBuildpackTOML(pathToInlineBuilpack, bp.ID, bp.Version, bp.Script.API, []dist.Stack{{ID: stackID}}, nil); err != nil {
 		return pathToInlineBuilpack, err
 	}
 


### PR DESCRIPTION
Signed-off-by: David Freilich <david.freilich@appsflyer.com>

## Summary
<!-- Provide a high-level summary of the change. -->
This change allows users to set a specific version for inline buildpacks (buildpacks defined in project descriptors, as documented [here](https://buildpacks.io/docs/app-developer-guide/using-project-descriptor/) and [here](https://buildpacks.io/docs/reference/config/project-descriptor/)). 

Previously, the code didn't allow users to set a version for inline buildpacks. 

The motivation for this is to allow users to stub/swap out specific buildpacks at a specific version. For instance, if you don't want to run a specific buildpack, you can define an inline buildpack in your `project.toml` with the same `id` and `version`, and have the inline script be used in place of the offending buildpack. 

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] No – Although the usage, in that it allows users to stub out buildpacks, should be documented as a useful workflow

