### PR TITLE
Set PACK_VERSION on Unix from GITHUB_REF_NAME

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Derive pack version from branch name Unix
         if: runner.os != 'Windows'
         run: |
-          [[ $GITHUB_REF =~ ^refs\/heads\/release/(.*)$ ]] && version=${BASH_REMATCH[1]} || version=0.0.0
+          [[ $GITHUB_REF_NAME =~ ^release/(.*)$ ]] && version=${BASH_REMATCH[1]} || version=0.0.0
           echo "PACK_VERSION=${version}" >> $GITHUB_ENV
         shell: bash
       - name: Derive pack version from branch name Windows


### PR DESCRIPTION
Pull x.y.z out of releases/x.y.z in the GITHUB_REF_NAME variable

Signed-off-by: Aidan Delaney <adelaney21@bloomberg.net>

## Summary

Updates `build.yml` to correctly inject PACK_VERSION

## Output

#### Before

`pack --version` is `0.0.0`

#### After

`pack --version` is `0.0.24`

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [X] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1369 
