### PR TITLE
Add milestone requirement to release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,6 +45,9 @@ The [release manager](#release-manager) will:
         - **release notes**
         - **migration guide** (if necessary)
 - Merge the release branch into `main`.
+- Create a new [milestone](https://github.com/buildpacks/pack/milestones) for the next version, and set the delivery time in 6 weeks.
+- Move all PRs/issues in the delivered milestone to the new milestone
+- Close the delivered milestone
 - Send out release notifications, if deemed necessary, on
   - The [cncf-buildpacks mailing list](https://lists.cncf.io/g/cncf-buildpacks)
   - Twitter

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,7 +46,7 @@ The [release manager](#release-manager) will:
         - **migration guide** (if necessary)
 - Merge the release branch into `main`.
 - Create a new [milestone](https://github.com/buildpacks/pack/milestones) for the next version, and set the delivery time in 6 weeks.
-- Move all PRs/issues in the delivered milestone to the new milestone
+- Move all still open PRs/issues in the delivered milestone to the new milestone
 - Close the delivered milestone
 - Send out release notifications, if deemed necessary, on
   - The [cncf-buildpacks mailing list](https://lists.cncf.io/g/cncf-buildpacks)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -938,9 +938,7 @@ func testAcceptance(
 						assertOutput = assertions.NewOutputAssertionManager(t, output)
 						assertOutput.ReportsSuccessfulImageBuild(repoName)
 						assertLifecycleOutput = assertions.NewLifecycleOutputAssertionManager(t, output)
-						if !pack.SupportsFeature(invoke.AnalysisFirst) {
-							assertLifecycleOutput.ReportsSkippingBuildpackLayerAnalysis()
-						}
+						assertLifecycleOutput.ReportsSkippingBuildpackLayerAnalysis()
 						assertLifecycleOutput.ReportsExporterReusingUnchangedLayer(cachedLaunchLayer)
 						assertLifecycleOutput.ReportsCacheCreation(cachedLaunchLayer)
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -938,7 +938,6 @@ func testAcceptance(
 						assertOutput = assertions.NewOutputAssertionManager(t, output)
 						assertOutput.ReportsSuccessfulImageBuild(repoName)
 						assertLifecycleOutput = assertions.NewLifecycleOutputAssertionManager(t, output)
-						assertLifecycleOutput.ReportsSkippingBuildpackLayerAnalysis()
 						assertLifecycleOutput.ReportsExporterReusingUnchangedLayer(cachedLaunchLayer)
 						assertLifecycleOutput.ReportsCacheCreation(cachedLaunchLayer)
 

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -218,15 +218,7 @@ func (i *PackInvoker) Supports(command string) bool {
 
 type Feature int
 
-const (
-	AnalysisFirst = iota
-)
-
-var featureTests = map[Feature]func(i *PackInvoker) bool{
-	AnalysisFirst: func(i *PackInvoker) bool {
-		return i.atLeast("0.23.0")
-	},
-}
+var featureTests = map[Feature]func(i *PackInvoker) bool{}
 
 func (i *PackInvoker) SupportsFeature(f Feature) bool {
 	return featureTests[f](i)


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
This PR adds requirements to the release process, requiring the release manager to create a new milestone, move all PRs and issues there, and close the current one. 

It also removes unnecessary pack version check from acceptance_tests. 

Resolves https://github.com/buildpacks/pack/issues/1352