### PR TITLE
Add linux-arm64 to the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,9 +134,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - goarch: arm64
-          goos: darwin
-          name: macos-arm64
+          - name: linux-arm64
+            goarch: arm64
+            goos: linux
+          - name: macos-arm64
+            goarch: arm64
+            goos: darwin
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -187,6 +190,12 @@ jobs:
           chmod +x pack-macos/pack
           filename=pack-v${{ env.PACK_VERSION }}-macos.tgz
           tar -C pack-macos -vzcf $filename pack
+          shasum -a 256 $filename > $filename.sha256
+      - name: Package artifacts - linux-arm64
+        run: |
+          chmod +x pack-linux-arm64/pack
+          filename=pack-v${{ env.PACK_VERSION }}-linux-arm64.tgz
+          tar -C pack-linux-arm64 -vzcf $filename pack
           shasum -a 256 $filename > $filename.sha256
       - name: Package artifacts - macos-arm64
         run: |


### PR DESCRIPTION
## Summary
As suggested by @josegonzalez, ARM64 artifacts seemed to be able to built, just missing the entries in the build pipeline.

## Output
If successful, `pack-v${{ env.PACK_VERSION }}-linux-arm64.tgz` should appear in the list of generated assets.

Resolves #907 
