### PR TITLE
Add support for using authn keychain in image fetcher

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -215,7 +215,7 @@ func NewClient(opts ...Option) (*Client, error) {
 	}
 
 	if client.imageFetcher == nil {
-		client.imageFetcher = image.NewFetcher(client.logger, client.docker, image.WithRegistryMirrors(client.registryMirrors))
+		client.imageFetcher = image.NewFetcher(client.logger, client.docker, image.WithRegistryMirrors(client.registryMirrors), image.WithKeychain(client.keychain))
 	}
 
 	if client.imageFactory == nil {


### PR DESCRIPTION
## Summary
Add support for using authn keychain in image fetcher. This is handy when using `pack` as a library inside of a container that needs to fetch images. 

## Output
N/A

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No
