### PR TITLE
Set the Pack Homebrew formula version explicitly

### DIFF
--- a/.github/workflows/delivery-homebrew.yml
+++ b/.github/workflows/delivery-homebrew.yml
@@ -29,11 +29,12 @@ jobs:
         with:
           script: |
             let payload = context.payload;
-            let tag = (payload.release && payload.release.tag_name) || (payload.inputs && payload.inputs.tag_name);
-            if (!tag) {
+            let tag_name = (payload.release && payload.release.tag_name) || (payload.inputs && payload.inputs.tag_name);
+            if (!tag_name) {
               throw "ERROR: unable to determine tag"
             }
-            let tag_name = tag.replace(/^v/, '');
+
+            core.setOutput("pack_version", tag_name.replace(/^v/, ''));
 
             var release = payload.release || await github.rest.repos.listReleases(context.repo)
                   .then(result => result.data.find(r => r.tag_name === tag_name))
@@ -86,6 +87,7 @@ jobs:
           MACOS_SHA: ${{ steps.checksums.outputs.macos_sha256 }}
           MACOS_ARM64_URL: ${{ steps.assets.outputs.macos_arm64_url }}
           MACOS_ARM64_SHA:  ${{ steps.checksums.outputs.macos_arm64_sha256 }}
+          PACK_VERSION: ${{ pack_version }}
       - run: cat homebrew-tap/Formula/pack.rb
       - name: Commit changes
         run: |

--- a/.github/workflows/delivery/homebrew/pack.rb
+++ b/.github/workflows/delivery/homebrew/pack.rb
@@ -5,6 +5,9 @@
 class Pack < Formula
   desc "A CLI for building apps using Cloud Native Buildpacks"
   homepage "https://github.com/buildpacks/pack"
+  version "{{PACK_VERSION}}"
+  version_scheme 1
+
   if OS.mac? && Hardware::CPU.arm?
     url "{{MACOS_ARM64_URL}}"
     sha256 "{{MACOS_ARM64_SHA}}"


### PR DESCRIPTION
Previously the Pack Homebrew formula did not set an explicit version, meaning that Homebrew attempts to detect it from the package URL. 

Unfortunately on ARM64, this results in the Pack version being detected as `64`, due to the additional `arm64` suffix in the package URL. This results in `pack upgrade` not detecting new pack CLI versions, so pack is never upgraded.

Now, the pack version is set explicitly, avoiding the issues with auto-detection. 

In addition, `version_scheme` has to be set, since otherwise Homebrew will not update the existing installations, as `64` would be treated as a newer version. See:
https://docs.brew.sh/Formula-Cookbook#version-scheme-changes

Lastly, whilst fixing this, I noticed a bug in the GitHub Actions workflow, whereby `tag_name` incorrectly had the `v` prefix removed before being passed to the GitHub releases API. This codepath is presumably unused most of the time (since it's only used when the workflow is manually triggered), which is why this had gone unnoticed.

Fixes buildpacks/homebrew-tap#20.