### PR TITLE
Set SOURCE_DATE_EPOCH

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1977,7 +1977,7 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 
 					when("--creation-time", func() {
 						it.Before(func() {
-							h.SkipIf(t, !pack.Supports("--creation-time"), "")
+							h.SkipIf(t, !pack.SupportsFeature(invoke.CreationTime), "")
 						})
 
 						when("provided as 'now'", func() {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1976,6 +1976,10 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 					})
 
 					when("--date-time", func() {
+						it.Before(func() {
+							h.SkipIf(t, !pack.Supports("--date-time"), "")
+						})
+
 						when("provided as 'now'", func() {
 							it("image has create time of the current time", func() {
 								expectedTime := time.Now()

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1975,9 +1975,9 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 						})
 					})
 
-					when("--date-time", func() {
+					when("--creation-time", func() {
 						it.Before(func() {
-							h.SkipIf(t, !pack.Supports("--date-time"), "")
+							h.SkipIf(t, !pack.Supports("--creation-time"), "")
 						})
 
 						when("provided as 'now'", func() {
@@ -1986,7 +1986,7 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 								pack.RunSuccessfully(
 									"build", repoName,
 									"-p", filepath.Join("testdata", "mock_app"),
-									"--date-time", "now",
+									"--creation-time", "now",
 								)
 								assertImage.HasCreateTime(repoName, expectedTime)
 							})
@@ -1997,7 +1997,7 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 								pack.RunSuccessfully(
 									"build", repoName,
 									"-p", filepath.Join("testdata", "mock_app"),
-									"--date-time", "1566172801",
+									"--creation-time", "1566172801",
 								)
 								expectedTime, err := time.Parse("2006-01-02T03:04:05Z", "2019-08-19T00:00:01Z")
 								h.AssertNil(t, err)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1974,6 +1974,45 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 							})
 						})
 					})
+
+					when("--date-time", func() {
+						when("provided as 'now'", func() {
+							it("image has create time of the current time", func() {
+								expectedTime := time.Now()
+								pack.RunSuccessfully(
+									"build", repoName,
+									"-p", filepath.Join("testdata", "mock_app"),
+									"--date-time", "now",
+								)
+								assertImage.HasCreateTime(repoName, expectedTime)
+							})
+						})
+
+						when("provided as unix timestamp", func() {
+							it("image has create time of the time that was provided", func() {
+								pack.RunSuccessfully(
+									"build", repoName,
+									"-p", filepath.Join("testdata", "mock_app"),
+									"--date-time", "1566172801",
+								)
+								expectedTime, err := time.Parse("2006-01-02T03:04:05Z", "2019-08-19T00:00:01Z")
+								h.AssertNil(t, err)
+								assertImage.HasCreateTime(repoName, expectedTime)
+							})
+						})
+
+						when("not provided", func() {
+							it("image has create time of Jan 1, 1980", func() {
+								pack.RunSuccessfully(
+									"build", repoName,
+									"-p", filepath.Join("testdata", "mock_app"),
+								)
+								expectedTime, err := time.Parse("2006-01-02T03:04:05Z", "1980-01-01T00:00:01Z")
+								h.AssertNil(t, err)
+								assertImage.HasCreateTime(repoName, expectedTime)
+							})
+						})
+					})
 				})
 			})
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1978,6 +1978,7 @@ include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 					when("--creation-time", func() {
 						it.Before(func() {
 							h.SkipIf(t, !pack.SupportsFeature(invoke.CreationTime), "")
+							h.SkipIf(t, !lifecycle.SupportsFeature(config.CreationTime), "")
 						})
 
 						when("provided as 'now'", func() {

--- a/acceptance/assertions/image.go
+++ b/acceptance/assertions/image.go
@@ -57,7 +57,7 @@ func (a ImageAssertionManager) HasCreateTime(image string, expectedTime time.Tim
 	a.assert.Nil(err)
 	actualTime, err := time.Parse("2006-01-02T15:04:05Z", inspect.Created)
 	a.assert.Nil(err)
-	a.assert.TrueWithMessage(actualTime.Sub(expectedTime) < 5*time.Second, fmt.Sprintf("expected image create time %s to match expected time %s", actualTime, expectedTime))
+	a.assert.TrueWithMessage(actualTime.Sub(expectedTime) < 5*time.Second && expectedTime.Sub(actualTime) < 5*time.Second, fmt.Sprintf("expected image create time %s to match expected time %s", actualTime, expectedTime))
 }
 
 func (a ImageAssertionManager) HasLabelWithData(image, label, data string) {

--- a/acceptance/assertions/image.go
+++ b/acceptance/assertions/image.go
@@ -6,6 +6,7 @@ package assertions
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/buildpacks/pack/acceptance/managers"
 	h "github.com/buildpacks/pack/testhelpers"
@@ -48,6 +49,15 @@ func (a ImageAssertionManager) HasBaseImage(image, base string) {
 	for i, layer := range baseInspect.RootFS.Layers {
 		a.assert.Equal(imageInspect.RootFS.Layers[i], layer)
 	}
+}
+
+func (a ImageAssertionManager) HasCreateTime(image string, expectedTime time.Time) {
+	a.testObject.Helper()
+	inspect, err := a.imageManager.InspectLocal(image)
+	a.assert.Nil(err)
+	actualTime, err := time.Parse("2006-01-02T15:04:05Z", inspect.Created)
+	a.assert.Nil(err)
+	a.assert.TrueWithMessage(actualTime.Sub(expectedTime) < 5*time.Second, fmt.Sprintf("expected image create time %s to match expected time %s", actualTime, expectedTime))
 }
 
 func (a ImageAssertionManager) HasLabelWithData(image, label, data string) {

--- a/acceptance/config/lifecycle_asset.go
+++ b/acceptance/config/lifecycle_asset.go
@@ -181,7 +181,23 @@ func (l *LifecycleAsset) JSONOutputForAPIs(baseIndentationWidth int) (
 
 type LifecycleFeature int
 
-var lifecycleFeatureTests = map[LifecycleFeature]func(l *LifecycleAsset) bool{}
+const CreationTime = iota
+
+var lifecycleFeatureTests = map[LifecycleFeature]func(l *LifecycleAsset) bool{
+	CreationTime: func(i *LifecycleAsset) bool {
+		for _, platformAPI := range i.descriptor.APIs.Platform.Supported {
+			if platformAPI.AtLeast("0.9") {
+				return true
+			}
+		}
+		for _, platformAPI := range i.descriptor.APIs.Platform.Deprecated {
+			if platformAPI.AtLeast("0.9") {
+				return true
+			}
+		}
+		return false
+	},
+}
 
 func (l *LifecycleAsset) SupportsFeature(f LifecycleFeature) bool {
 	return lifecycleFeatureTests[f](l)

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -218,7 +218,13 @@ func (i *PackInvoker) Supports(command string) bool {
 
 type Feature int
 
-var featureTests = map[Feature]func(i *PackInvoker) bool{}
+const CreationTime = iota
+
+var featureTests = map[Feature]func(i *PackInvoker) bool{
+	CreationTime: func(i *PackInvoker) bool {
+		return i.laterThan("0.24.1")
+	},
+}
 
 func (i *PackInvoker) SupportsFeature(f Feature) bool {
 	return featureTests[f](i)

--- a/acceptance/testdata/pack_fixtures/report_output.txt
+++ b/acceptance/testdata/pack_fixtures/report_output.txt
@@ -4,7 +4,7 @@ Pack:
 
 Default Lifecycle Version:  0.14.0
 
-Supported Platform APIs:  0.3, 0.4, 0.5, 0.6, 0.7, 0.8
+Supported Platform APIs:  0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9
 
 Config:
   default-builder-image = "{{ .DefaultBuilder }}"

--- a/acceptance/testdata/pack_fixtures/report_output.txt
+++ b/acceptance/testdata/pack_fixtures/report_output.txt
@@ -2,7 +2,7 @@ Pack:
   Version:  {{ .Version }}
   OS/Arch:  {{ .OS }}/{{ .Arch }}
 
-Default Lifecycle Version:  0.13.3
+Default Lifecycle Version:  0.14.0
 
 Supported Platform APIs:  0.3, 0.4, 0.5, 0.6, 0.7, 0.8
 

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -252,8 +252,8 @@ func (l *LifecycleExecution) Create(ctx context.Context, publish bool, dockerHos
 	}
 
 	withEnv := NullOp()
-	if l.opts.DateTime != nil {
-		withEnv = WithEnv(fmt.Sprintf("%s=%s", sourceDateEpochEnv, strconv.Itoa(int(l.opts.DateTime.Unix()))))
+	if l.opts.CreationTime != nil {
+		withEnv = WithEnv(fmt.Sprintf("%s=%s", sourceDateEpochEnv, strconv.Itoa(int(l.opts.CreationTime.Unix()))))
 	}
 
 	opts := []PhaseConfigProviderOperation{
@@ -536,8 +536,8 @@ func (l *LifecycleExecution) newExport(repoName, runImage string, publish bool, 
 	}
 
 	withEnv := NullOp()
-	if l.opts.DateTime != nil {
-		withEnv = WithEnv(fmt.Sprintf("%s=%s", sourceDateEpochEnv, strconv.Itoa(int(l.opts.DateTime.Unix()))))
+	if l.opts.CreationTime != nil {
+		withEnv = WithEnv(fmt.Sprintf("%s=%s", sourceDateEpochEnv, strconv.Itoa(int(l.opts.CreationTime.Unix()))))
 	}
 
 	opts := []PhaseConfigProviderOperation{

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -252,7 +252,7 @@ func (l *LifecycleExecution) Create(ctx context.Context, publish bool, dockerHos
 	}
 
 	withEnv := NullOp()
-	if l.opts.CreationTime != nil {
+	if l.opts.CreationTime != nil && l.platformAPI.AtLeast("0.9") {
 		withEnv = WithEnv(fmt.Sprintf("%s=%s", sourceDateEpochEnv, strconv.Itoa(int(l.opts.CreationTime.Unix()))))
 	}
 
@@ -536,7 +536,7 @@ func (l *LifecycleExecution) newExport(repoName, runImage string, publish bool, 
 	}
 
 	withEnv := NullOp()
-	if l.opts.CreationTime != nil {
+	if l.opts.CreationTime != nil && l.platformAPI.AtLeast("0.9") {
 		withEnv = WithEnv(fmt.Sprintf("%s=%s", sourceDateEpochEnv, strconv.Itoa(int(l.opts.CreationTime.Unix()))))
 	}
 

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -1063,7 +1063,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					providedTime := time.Unix(intTime, 0).UTC()
 
 					lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
-						baseOpts.DateTime = &providedTime
+						baseOpts.CreationTime = &providedTime
 					})
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
@@ -1081,7 +1081,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			when("not provided", func() {
 				it("does not panic", func() {
 					lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
-						baseOpts.DateTime = nil
+						baseOpts.CreationTime = nil
 					})
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
@@ -2664,7 +2664,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					providedTime := time.Unix(intTime, 0).UTC()
 
 					lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
-						baseOpts.DateTime = &providedTime
+						baseOpts.CreationTime = &providedTime
 					})
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
@@ -2682,7 +2682,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			when("not provided", func() {
 				it("does not panic", func() {
 					lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
-						baseOpts.DateTime = nil
+						baseOpts.CreationTime = nil
 					})
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -1055,7 +1055,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("--date-time", func() {
+		when("--creation-time", func() {
 			when("provided", func() {
 				it("configures the phase with env SOURCE_DATE_EPOCH", func() {
 					intTime, err := strconv.ParseInt("1234567890", 10, 64)
@@ -2656,7 +2656,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("--date-time", func() {
+		when("--creation-time", func() {
 			when("provided", func() {
 				it("configures the phase with env SOURCE_DATE_EPOCH", func() {
 					intTime, err := strconv.ParseInt("1234567890", 10, 64)

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -1051,6 +1052,42 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, len(provider.PostContainerRunOps()), 2)
 				h.AssertFunctionName(t, provider.PostContainerRunOps()[0], "EnsureVolumeAccess")
 				h.AssertFunctionName(t, provider.PostContainerRunOps()[1], "CopyOut")
+			})
+		})
+
+		when("--date-time", func() {
+			when("provided", func() {
+				it("configures the phase with env SOURCE_DATE_EPOCH", func() {
+					intTime, err := strconv.ParseInt("1234567890", 10, 64)
+					h.AssertNil(t, err)
+					providedTime := time.Unix(intTime, 0).UTC()
+
+					lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
+						baseOpts.DateTime = &providedTime
+					})
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+					err = lifecycle.Create(context.Background(), false, "", false, "some-run-image", "some-repo-name", "test", fakeBuildCache, fakeLaunchCache, []string{}, []string{}, fakePhaseFactory)
+					h.AssertNil(t, err)
+
+					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+					h.AssertNotEq(t, lastCallIndex, -1)
+
+					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+					h.AssertSliceContains(t, configProvider.ContainerConfig().Env, "SOURCE_DATE_EPOCH=1234567890")
+				})
+			})
+
+			when("not provided", func() {
+				it("does not panic", func() {
+					lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
+						baseOpts.DateTime = nil
+					})
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+					err := lifecycle.Create(context.Background(), false, "", false, "some-run-image", "some-repo-name", "test", fakeBuildCache, fakeLaunchCache, []string{}, []string{}, fakePhaseFactory)
+					h.AssertNil(t, err)
+				})
 			})
 		})
 	})
@@ -2616,6 +2653,42 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, len(provider.PostContainerRunOps()), 2)
 				h.AssertFunctionName(t, provider.PostContainerRunOps()[0], "EnsureVolumeAccess")
 				h.AssertFunctionName(t, provider.PostContainerRunOps()[1], "CopyOut")
+			})
+		})
+
+		when("--date-time", func() {
+			when("provided", func() {
+				it("configures the phase with env SOURCE_DATE_EPOCH", func() {
+					intTime, err := strconv.ParseInt("1234567890", 10, 64)
+					h.AssertNil(t, err)
+					providedTime := time.Unix(intTime, 0).UTC()
+
+					lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
+						baseOpts.DateTime = &providedTime
+					})
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+					err = lifecycle.Export(context.Background(), "test", "test", false, "", "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
+					h.AssertNil(t, err)
+
+					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+					h.AssertNotEq(t, lastCallIndex, -1)
+
+					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+					h.AssertSliceContains(t, configProvider.ContainerConfig().Env, "SOURCE_DATE_EPOCH=1234567890")
+				})
+			})
+
+			when("not provided", func() {
+				it("does not panic", func() {
+					lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
+						baseOpts.DateTime = nil
+					})
+					fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+					err := lifecycle.Export(context.Background(), "test", "test", false, "", "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
+					h.AssertNil(t, err)
+				})
 			})
 		})
 	})

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -1056,15 +1056,23 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("--creation-time", func() {
-			when("provided", func() {
-				it("configures the phase with env SOURCE_DATE_EPOCH", func() {
+			var fakeBuilder *fakes.FakeBuilder
+
+			when("platform < 0.9", func() {
+				it.Before(func() {
+					var err error
+					fakeBuilder, err = fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.8")}))
+					h.AssertNil(t, err)
+				})
+
+				it("is ignored", func() {
 					intTime, err := strconv.ParseInt("1234567890", 10, 64)
 					h.AssertNil(t, err)
 					providedTime := time.Unix(intTime, 0).UTC()
 
 					lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
 						baseOpts.CreationTime = &providedTime
-					})
+					}, fakes.WithBuilder(fakeBuilder))
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
 					err = lifecycle.Create(context.Background(), false, "", false, "some-run-image", "some-repo-name", "test", fakeBuildCache, fakeLaunchCache, []string{}, []string{}, fakePhaseFactory)
@@ -1074,19 +1082,49 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNotEq(t, lastCallIndex, -1)
 
 					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
-					h.AssertSliceContains(t, configProvider.ContainerConfig().Env, "SOURCE_DATE_EPOCH=1234567890")
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Env, "SOURCE_DATE_EPOCH=1234567890")
 				})
 			})
 
-			when("not provided", func() {
-				it("does not panic", func() {
-					lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
-						baseOpts.CreationTime = nil
-					})
-					fakePhaseFactory := fakes.NewFakePhaseFactory()
-
-					err := lifecycle.Create(context.Background(), false, "", false, "some-run-image", "some-repo-name", "test", fakeBuildCache, fakeLaunchCache, []string{}, []string{}, fakePhaseFactory)
+			when("platform >= 0.9", func() {
+				it.Before(func() {
+					var err error
+					fakeBuilder, err = fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.9")}))
 					h.AssertNil(t, err)
+				})
+
+				when("provided", func() {
+					it("configures the phase with env SOURCE_DATE_EPOCH", func() {
+						intTime, err := strconv.ParseInt("1234567890", 10, 64)
+						h.AssertNil(t, err)
+						providedTime := time.Unix(intTime, 0).UTC()
+
+						lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
+							baseOpts.CreationTime = &providedTime
+						}, fakes.WithBuilder(fakeBuilder))
+						fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+						err = lifecycle.Create(context.Background(), false, "", false, "some-run-image", "some-repo-name", "test", fakeBuildCache, fakeLaunchCache, []string{}, []string{}, fakePhaseFactory)
+						h.AssertNil(t, err)
+
+						lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+						h.AssertNotEq(t, lastCallIndex, -1)
+
+						configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+						h.AssertSliceContains(t, configProvider.ContainerConfig().Env, "SOURCE_DATE_EPOCH=1234567890")
+					})
+				})
+
+				when("not provided", func() {
+					it("does not panic", func() {
+						lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
+							baseOpts.CreationTime = nil
+						}, fakes.WithBuilder(fakeBuilder))
+						fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+						err := lifecycle.Create(context.Background(), false, "", false, "some-run-image", "some-repo-name", "test", fakeBuildCache, fakeLaunchCache, []string{}, []string{}, fakePhaseFactory)
+						h.AssertNil(t, err)
+					})
 				})
 			})
 		})
@@ -2657,15 +2695,23 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("--creation-time", func() {
-			when("provided", func() {
-				it("configures the phase with env SOURCE_DATE_EPOCH", func() {
+			var fakeBuilder *fakes.FakeBuilder
+
+			when("platform < 0.9", func() {
+				it.Before(func() {
+					var err error
+					fakeBuilder, err = fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.8")}))
+					h.AssertNil(t, err)
+				})
+
+				it("is ignored", func() {
 					intTime, err := strconv.ParseInt("1234567890", 10, 64)
 					h.AssertNil(t, err)
 					providedTime := time.Unix(intTime, 0).UTC()
 
 					lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
 						baseOpts.CreationTime = &providedTime
-					})
+					}, fakes.WithBuilder(fakeBuilder))
 					fakePhaseFactory := fakes.NewFakePhaseFactory()
 
 					err = lifecycle.Export(context.Background(), "test", "test", false, "", "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
@@ -2675,19 +2721,49 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNotEq(t, lastCallIndex, -1)
 
 					configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
-					h.AssertSliceContains(t, configProvider.ContainerConfig().Env, "SOURCE_DATE_EPOCH=1234567890")
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Env, "SOURCE_DATE_EPOCH=1234567890")
 				})
 			})
 
-			when("not provided", func() {
-				it("does not panic", func() {
-					lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
-						baseOpts.CreationTime = nil
-					})
-					fakePhaseFactory := fakes.NewFakePhaseFactory()
-
-					err := lifecycle.Export(context.Background(), "test", "test", false, "", "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
+			when("platform >= 0.9", func() {
+				it.Before(func() {
+					var err error
+					fakeBuilder, err = fakes.NewFakeBuilder(fakes.WithSupportedPlatformAPIs([]*api.Version{api.MustParse("0.9")}))
 					h.AssertNil(t, err)
+				})
+
+				when("provided", func() {
+					it("configures the phase with env SOURCE_DATE_EPOCH", func() {
+						intTime, err := strconv.ParseInt("1234567890", 10, 64)
+						h.AssertNil(t, err)
+						providedTime := time.Unix(intTime, 0).UTC()
+
+						lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
+							baseOpts.CreationTime = &providedTime
+						}, fakes.WithBuilder(fakeBuilder))
+						fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+						err = lifecycle.Export(context.Background(), "test", "test", false, "", "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
+						h.AssertNil(t, err)
+
+						lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
+						h.AssertNotEq(t, lastCallIndex, -1)
+
+						configProvider := fakePhaseFactory.NewCalledWithProvider[lastCallIndex]
+						h.AssertSliceContains(t, configProvider.ContainerConfig().Env, "SOURCE_DATE_EPOCH=1234567890")
+					})
+				})
+
+				when("not provided", func() {
+					it("does not panic", func() {
+						lifecycle := newTestLifecycleExec(t, false, func(baseOpts *build.LifecycleOptions) {
+							baseOpts.CreationTime = nil
+						}, fakes.WithBuilder(fakeBuilder))
+						fakePhaseFactory := fakes.NewFakePhaseFactory()
+
+						err := lifecycle.Export(context.Background(), "test", "test", false, "", "test", fakeBuildCache, fakeLaunchCache, []string{}, fakePhaseFactory)
+						h.AssertNil(t, err)
+					})
 				})
 			})
 		})

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -27,6 +27,7 @@ var (
 		api.MustParse("0.6"),
 		api.MustParse("0.7"),
 		api.MustParse("0.8"),
+		api.MustParse("0.9"),
 	}
 )
 

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -89,6 +89,7 @@ type LifecycleOptions struct {
 	GID                int
 	PreviousImage      string
 	SBOMDestinationDir string
+	DateTime           *time.Time
 }
 
 func NewLifecycleExecutor(logger logging.Logger, docker client.CommonAPIClient) *LifecycleExecutor {

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -89,7 +89,7 @@ type LifecycleOptions struct {
 	GID                int
 	PreviousImage      string
 	SBOMDestinationDir string
-	DateTime           *time.Time
+	CreationTime       *time.Time
 }
 
 func NewLifecycleExecutor(logger logging.Logger, docker client.CommonAPIClient) *LifecycleExecutor {

--- a/internal/builder/lifecycle.go
+++ b/internal/builder/lifecycle.go
@@ -14,7 +14,7 @@ import (
 
 // A snapshot of the latest tested lifecycle version values
 const (
-	DefaultLifecycleVersion    = "0.13.3"
+	DefaultLifecycleVersion    = "0.14.0"
 	DefaultBuildpackAPIVersion = "0.2"
 )
 

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -202,7 +202,7 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringVarP(&buildFlags.Builder, "builder", "B", cfg.DefaultBuilder, "Builder image")
 	cmd.Flags().StringVar(&buildFlags.CacheImage, "cache-image", "", `Cache build layers in remote registry. Requires --publish`)
 	cmd.Flags().BoolVar(&buildFlags.ClearCache, "clear-cache", false, "Clear image's associated cache before building")
-	cmd.Flags().StringVar(&buildFlags.DateTime, "creation-time", "", "Desired create time in the output image config. Accepted values are Unix timestamps (e.g., '1641013200'), or 'now'.")
+	cmd.Flags().StringVar(&buildFlags.DateTime, "creation-time", "", "Desired create time in the output image config. Accepted values are Unix timestamps (e.g., '1641013200'), or 'now'. Platform API version must be at least 0.9 to use this feature.")
 	cmd.Flags().StringVarP(&buildFlags.DescriptorPath, "descriptor", "d", "", "Path to the project descriptor file")
 	cmd.Flags().StringVarP(&buildFlags.DefaultProcessType, "default-process", "D", "", `Set the default process type. (default "web")`)
 	cmd.Flags().StringArrayVarP(&buildFlags.Env, "env", "e", []string{}, "Build-time environment variable, in the form 'VAR=VALUE' or 'VAR'.\nWhen using latter value-less form, value will be taken from current\n  environment at the time this command is executed.\nThis flag may be specified multiple times and will override\n  individual values defined by --env-file."+stringArrayHelp("env")+"\nNOTE: These are NOT available at image runtime.")

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -166,7 +166,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				PreviousImage:            flags.PreviousImage,
 				Interactive:              flags.Interactive,
 				SBOMDestinationDir:       flags.SBOMDestinationDir,
-				DateTime:                 dateTime,
+				CreationTime:             dateTime,
 			}); err != nil {
 				return errors.Wrap(err, "failed to build")
 			}
@@ -202,7 +202,7 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringVarP(&buildFlags.Builder, "builder", "B", cfg.DefaultBuilder, "Builder image")
 	cmd.Flags().StringVar(&buildFlags.CacheImage, "cache-image", "", `Cache build layers in remote registry. Requires --publish`)
 	cmd.Flags().BoolVar(&buildFlags.ClearCache, "clear-cache", false, "Clear image's associated cache before building")
-	cmd.Flags().StringVar(&buildFlags.DateTime, "creation-time", "", "Desired create time in the output image config")
+	cmd.Flags().StringVar(&buildFlags.DateTime, "creation-time", "", "Desired create time in the output image config. Accepted values are Unix timestamps (e.g., '1641013200'), or 'now'.")
 	cmd.Flags().StringVarP(&buildFlags.DescriptorPath, "descriptor", "d", "", "Path to the project descriptor file")
 	cmd.Flags().StringVarP(&buildFlags.DefaultProcessType, "default-process", "D", "", `Set the default process type. (default "web")`)
 	cmd.Flags().StringArrayVarP(&buildFlags.Env, "env", "e", []string{}, "Build-time environment variable, in the form 'VAR=VALUE' or 'VAR'.\nWhen using latter value-less form, value will be taken from current\n  environment at the time this command is executed.\nThis flag may be specified multiple times and will override\n  individual values defined by --env-file."+stringArrayHelp("env")+"\nNOTE: These are NOT available at image runtime.")

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -133,7 +133,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 			}
 			dateTime, err := parseTime(flags.DateTime)
 			if err != nil {
-				return errors.Wrapf(err, "parsing date-time %s", flags.DateTime)
+				return errors.Wrapf(err, "parsing creation time %s", flags.DateTime)
 			}
 			if err := packClient.Build(cmd.Context(), client.BuildOptions{
 				AppPath:           flags.AppPath,
@@ -202,7 +202,7 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringVarP(&buildFlags.Builder, "builder", "B", cfg.DefaultBuilder, "Builder image")
 	cmd.Flags().StringVar(&buildFlags.CacheImage, "cache-image", "", `Cache build layers in remote registry. Requires --publish`)
 	cmd.Flags().BoolVar(&buildFlags.ClearCache, "clear-cache", false, "Clear image's associated cache before building")
-	cmd.Flags().StringVar(&buildFlags.DateTime, "date-time", "", "Desired create time in the output image config")
+	cmd.Flags().StringVar(&buildFlags.DateTime, "creation-time", "", "Desired create time in the output image config")
 	cmd.Flags().StringVarP(&buildFlags.DescriptorPath, "descriptor", "d", "", "Path to the project descriptor file")
 	cmd.Flags().StringVarP(&buildFlags.DefaultProcessType, "default-process", "D", "", `Set the default process type. (default "web")`)
 	cmd.Flags().StringArrayVarP(&buildFlags.Env, "env", "e", []string{}, "Build-time environment variable, in the form 'VAR=VALUE' or 'VAR'.\nWhen using latter value-less form, value will be taken from current\n  environment at the time this command is executed.\nThis flag may be specified multiple times and will override\n  individual values defined by --env-file."+stringArrayHelp("env")+"\nNOTE: These are NOT available at image runtime.")

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -976,7 +976,7 @@ func EqBuildOptionsWithDateTime(t *time.Time) interface{} {
 			if t == nil {
 				return o.CreationTime == nil
 			}
-			return o.CreationTime.Sub(*t) < 5*time.Second
+			return o.CreationTime.Sub(*t) < 5*time.Second && t.Sub(*o.CreationTime) < 5*time.Second
 		},
 	}
 }

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -784,7 +784,7 @@ builder = "my-builder"
 			})
 		})
 
-		when("--date-time", func() {
+		when("--creation-time", func() {
 			when("provided as 'now'", func() {
 				it("passes it to the builder", func() {
 					expectedTime := time.Now().UTC()
@@ -792,7 +792,7 @@ builder = "my-builder"
 						Build(gomock.Any(), EqBuildOptionsWithDateTime(&expectedTime)).
 						Return(nil)
 
-					command.SetArgs([]string{"image", "--builder", "my-builder", "--date-time", "now"})
+					command.SetArgs([]string{"image", "--builder", "my-builder", "--creation-time", "now"})
 					h.AssertNil(t, command.Execute())
 				})
 			})
@@ -805,7 +805,7 @@ builder = "my-builder"
 						Build(gomock.Any(), EqBuildOptionsWithDateTime(&expectedTime)).
 						Return(nil)
 
-					command.SetArgs([]string{"image", "--builder", "my-builder", "--date-time", "1566172801"})
+					command.SetArgs([]string{"image", "--builder", "my-builder", "--creation-time", "1566172801"})
 					h.AssertNil(t, command.Execute())
 				})
 			})
@@ -976,7 +976,7 @@ func EqBuildOptionsWithDateTime(t *time.Time) interface{} {
 			if t == nil {
 				return o.DateTime == nil
 			}
-			return (*o.DateTime).Sub(*t) < 5*time.Second
+			return o.DateTime.Sub(*t) < 5*time.Second
 		},
 	}
 }

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -971,12 +971,12 @@ func EqBuildOptionsWithSBOMOutputDir(s string) interface{} {
 
 func EqBuildOptionsWithDateTime(t *time.Time) interface{} {
 	return buildOptionsMatcher{
-		description: fmt.Sprintf("DateTime=%s", t),
+		description: fmt.Sprintf("CreationTime=%s", t),
 		equals: func(o client.BuildOptions) bool {
 			if t == nil {
-				return o.DateTime == nil
+				return o.CreationTime == nil
 			}
-			return o.DateTime.Sub(*t) < 5*time.Second
+			return o.CreationTime.Sub(*t) < 5*time.Second
 		},
 	}
 }

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/buildpacks/imgutil"
@@ -170,6 +171,9 @@ type BuildOptions struct {
 
 	// Directory to output any SBOM artifacts
 	SBOMDestinationDir string
+
+	// Desired create time in the output image config
+	DateTime *time.Time
 }
 
 // ProxyConfig specifies proxy setting to be set as environment variables in a container.
@@ -356,6 +360,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		Interactive:        opts.Interactive,
 		Termui:             termui.NewTermui(imageRef.Name(), ephemeralBuilder, runImageName),
 		SBOMDestinationDir: opts.SBOMDestinationDir,
+		DateTime:           opts.DateTime,
 	}
 
 	lifecycleVersion := ephemeralBuilder.LifecycleDescriptor().Info.Version

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -173,7 +173,7 @@ type BuildOptions struct {
 	SBOMDestinationDir string
 
 	// Desired create time in the output image config
-	DateTime *time.Time
+	CreationTime *time.Time
 }
 
 // ProxyConfig specifies proxy setting to be set as environment variables in a container.
@@ -360,7 +360,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		Interactive:        opts.Interactive,
 		Termui:             termui.NewTermui(imageRef.Name(), ephemeralBuilder, runImageName),
 		SBOMDestinationDir: opts.SBOMDestinationDir,
-		DateTime:           opts.DateTime,
+		CreationTime:       opts.CreationTime,
 	}
 
 	lifecycleVersion := ephemeralBuilder.LifecycleDescriptor().Info.Version

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -1857,7 +1857,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.PullPolicy, image.PullNever)
 
-					args = fakeImageFetcher.FetchCalls["buildpacksio/lifecycle:0.13.3"]
+					args = fakeImageFetcher.FetchCalls["buildpacksio/lifecycle:0.14.0"]
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.PullPolicy, image.PullNever)
 					h.AssertEq(t, args.Platform, "linux/amd64")


### PR DESCRIPTION
pack should set SOURCE_DATE_EPOCH in exporter's env if --creation-time flag is provided

Also bumps default lifecycle version

#### Before

Image create time is always Jan 1, 1980

#### After

Image create time is configurable

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1281 
