### PR TITLE
Fix: Select the right asset to download for linux

### DIFF
--- a/acceptance/os/variables_linux.go
+++ b/acceptance/os/variables_linux.go
@@ -5,4 +5,4 @@ package os
 
 import "regexp"
 
-var PackBinaryExp = regexp.MustCompile(`pack-v\d+.\d+.\d+-linux`)
+var PackBinaryExp = regexp.MustCompile(`pack-v\d+.\d+.\d+-linux\.`)


### PR DESCRIPTION
This minor addition to the regex is necessary to properly determine
the right asset to download in CI now that we have a linux arm64
asset.