### PR TITLE
Fix: Failing creation-time tests

### DIFF
--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -222,7 +222,7 @@ const CreationTime = iota
 
 var featureTests = map[Feature]func(i *PackInvoker) bool{
 	CreationTime: func(i *PackInvoker) bool {
-		return i.laterThan("0.24.1")
+		return i.Supports("build --creation-time")
 	},
 }
 


### PR DESCRIPTION
Acceptance tests for compatibility were failing due to an overzealous
declaration on when creation-time feature would be released.

Changed over to checking if feature was available using help command.

Signed-off-by: Javier Romero <root@jromero.codes>