### PR TITLE
Fix: error of private registry in lifecycle phase

### DIFF
--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -273,7 +273,7 @@ func (l *LifecycleExecution) Create(ctx context.Context, publish bool, dockerHos
 	}
 
 	if publish {
-		authConfig, err := auth.BuildEnvVar(authn.DefaultKeychain, repoName)
+		authConfig, err := auth.BuildEnvVar(authn.DefaultKeychain, repoName, runImage, l.opts.CacheImage, l.opts.PreviousImage)
 		if err != nil {
 			return err
 		}
@@ -429,7 +429,7 @@ func (l *LifecycleExecution) newAnalyze(repoName, networkMode string, publish bo
 	}
 
 	if publish {
-		authConfig, err := auth.BuildEnvVar(authn.DefaultKeychain, repoName)
+		authConfig, err := auth.BuildEnvVar(authn.DefaultKeychain, repoName, runImage, l.opts.CacheImage, l.opts.PreviousImage)
 		if err != nil {
 			return nil, err
 		}
@@ -566,7 +566,7 @@ func (l *LifecycleExecution) newExport(repoName, runImage string, publish bool, 
 	}
 
 	if publish {
-		authConfig, err := auth.BuildEnvVar(authn.DefaultKeychain, repoName, runImage)
+		authConfig, err := auth.BuildEnvVar(authn.DefaultKeychain, repoName, runImage, l.opts.CacheImage, l.opts.PreviousImage)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR is mainly used to solve the problem of private registry that cannot be verified during `pack build -- publish`.


The error is as follows:

```
[analyzer] ERROR: failed to : ensure registry read access to myprivate.registry.com/org/pack:bullseye-linux-amd64
ERROR: failed to build: executing lifecycle. This may be the result of using an untrusted builder: failed with status code: 1
```

