### PR TITLE
When pack is run with --verbose, it should not print registry creds

### DIFF
--- a/internal/build/phase_config_provider.go
+++ b/internal/build/phase_config_provider.go
@@ -68,7 +68,7 @@ func NewPhaseConfigProvider(name string, lifecycleExec *LifecycleExecution, ops 
 	lifecycleExec.logger.Debugf("Running the %s on OS %s with:", style.Symbol(provider.Name()), style.Symbol(provider.os))
 	lifecycleExec.logger.Debug("Container Settings:")
 	lifecycleExec.logger.Debugf("  Args: %s", style.Symbol(strings.Join(provider.ctrConf.Cmd, " ")))
-	lifecycleExec.logger.Debugf("  System Envs: %s", style.Symbol(strings.Join(provider.ctrConf.Env, " ")))
+	lifecycleExec.logger.Debugf("  System Envs: %s", style.Symbol(strings.Join(sanitized(provider.ctrConf.Env), " ")))
 	lifecycleExec.logger.Debugf("  Image: %s", style.Symbol(provider.ctrConf.Image))
 	lifecycleExec.logger.Debugf("  User: %s", style.Symbol(provider.ctrConf.User))
 	lifecycleExec.logger.Debugf("  Labels: %s", style.Symbol(fmt.Sprintf("%s", provider.ctrConf.Labels)))
@@ -82,6 +82,18 @@ func NewPhaseConfigProvider(name string, lifecycleExec *LifecycleExecution, ops 
 	}
 
 	return provider
+}
+
+func sanitized(origEnv []string) []string {
+	var sanitizedEnv []string
+	for _, env := range origEnv {
+		if strings.HasPrefix(env, "CNB_REGISTRY_AUTH") {
+			sanitizedEnv = append(sanitizedEnv, "CNB_REGISTRY_AUTH=<redacted>")
+			continue
+		}
+		sanitizedEnv = append(sanitizedEnv, env)
+	}
+	return sanitizedEnv
 }
 
 func (p *PhaseConfigProvider) ContainerConfig() *container.Config {


### PR DESCRIPTION
#### Before

See comment here: https://github.com/buildpacks/lifecycle/issues/651#issuecomment-1111506330

#### After

The output will include something like `System Envs: 'CNB_REGISTRY_AUTH=<redacted>'`
