### PR TITLE
Update error when bp order group is malformed for meta-buildpacks

### DIFF
--- a/pkg/buildpack/builder.go
+++ b/pkg/buildpack/builder.go
@@ -269,15 +269,24 @@ func validateBuildpacks(mainBP Buildpack, depBPs []Buildpack) error {
 		bpd := bp.Descriptor()
 		for _, orderEntry := range bpd.Order {
 			for _, groupEntry := range orderEntry.Group {
-				if _, ok := depsWithRefs[groupEntry.BuildpackInfo.FullName()]; !ok {
+				bpFullName, err := groupEntry.BuildpackInfo.FullNameWithVersion()
+				if err != nil {
+					return errors.Wrapf(
+						err,
+						"buildpack %s must specify a version when referencing buildpack %s",
+						style.Symbol(bpd.Info.FullName()),
+						style.Symbol(bpFullName),
+					)
+				}
+				if _, ok := depsWithRefs[bpFullName]; !ok {
 					return errors.Errorf(
 						"buildpack %s references buildpack %s which is not present",
 						style.Symbol(bpd.Info.FullName()),
-						style.Symbol(groupEntry.FullName()),
+						style.Symbol(bpFullName),
 					)
 				}
 
-				depsWithRefs[groupEntry.BuildpackInfo.FullName()] = append(depsWithRefs[groupEntry.BuildpackInfo.FullName()], bpd.Info)
+				depsWithRefs[bpFullName] = append(depsWithRefs[bpFullName], bpd.Info)
 			}
 		}
 	}

--- a/pkg/dist/buildpack.go
+++ b/pkg/dist/buildpack.go
@@ -1,5 +1,11 @@
 package dist
 
+import (
+	"github.com/pkg/errors"
+
+	"github.com/buildpacks/pack/internal/style"
+)
+
 const AssumedBuildpackAPIVersion = "0.1"
 const BuildpacksDir = "/cnb/buildpacks"
 
@@ -18,6 +24,13 @@ func (b BuildpackInfo) FullName() string {
 		return b.ID + "@" + b.Version
 	}
 	return b.ID
+}
+
+func (b BuildpackInfo) FullNameWithVersion() (string, error) {
+	if b.Version == "" {
+		return b.ID, errors.Errorf("buildpack %s does not have a version defined", style.Symbol(b.ID))
+	}
+	return b.ID + "@" + b.Version, nil
 }
 
 // Satisfy stringer


### PR DESCRIPTION
## Summary
The error for when pack encounters a malformed `buildpack.toml` order group entry referenced by `package.toml` wasn't very descriptive. This PR tries to update the methods used to fetch full name of a builpack complying with the documentation, and update the relevant error message.


I feel the change is quite small and kind of redundant 😬 , would be happy to rework this if there is something missing.
I avoided adding acceptance tests because that would only be possible by introducing new malformed `package.toml` and `buildpack.toml` file combination, but if we see value in them then I can write those as well.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1384 
