### PR TITLE
Fix docker & archlinuex release pipelines

### DIFF
--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Setup Working Dir
         shell: bash
         run: |
+          rm project.toml || true
           cp head/.github/workflows/delivery/docker/project.toml project.toml
-          rm buildpack.yml
       - name: Determine App Name
         run: 'echo "IMG_NAME=${{ env.USERNAME }}/${{ env.IMG_NAME }}" >> $GITHUB_ENV'
       - name: Login to Dockerhub

--- a/.github/workflows/delivery/archlinux/publish-package.sh
+++ b/.github/workflows/delivery/archlinux/publish-package.sh
@@ -40,6 +40,9 @@ echo '> Cloning aur...'
 git clone "ssh://aur@aur.archlinux.org/${PACKAGE_NAME}.git" "${PACKAGE_AUR_DIR}"
 chown -R archie "${PACKAGE_AUR_DIR}"
 pushd "${PACKAGE_AUR_DIR}" > /dev/null
+  echo '> Declare directory ${PACKAGE_AUR_DIR} as safe'
+  git config --global --add safe.directory "${PACKAGE_AUR_DIR}"
+
   echo '> Checking out master...'
   git checkout master
 


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->

For release v0.26.0, we saw failures in the `docker` and `archlinux` pipelines. This PR fixes them, by adjusting their scripts slightly. 

Using this branch, the pipelines were run successfully here: 
* Docker: [here](https://github.com/buildpacks/pack/runs/6341704691?check_suite_focus=true)
* Archlinux: [here](https://github.com/buildpacks/pack/actions/runs/2290018877)