### PR TITLE
Change suggested heroku stack images to the new url

### DIFF
--- a/internal/commands/stack_suggest.go
+++ b/internal/commands/stack_suggest.go
@@ -23,8 +23,8 @@ var suggestedStacks = []suggestedStack{
 		ID:          "heroku-20",
 		Description: "The official Heroku stack based on Ubuntu 20.04",
 		Maintainer:  "Heroku",
-		BuildImage:  "heroku/pack:20-build",
-		RunImage:    "heroku/pack:20",
+		BuildImage:  "heroku/heroku:20-cnb-build",
+		RunImage:    "heroku/heroku:20-cnb",
 	},
 	{
 		ID:          "io.buildpacks.stacks.bionic",

--- a/internal/commands/stack_suggest_test.go
+++ b/internal/commands/stack_suggest_test.go
@@ -35,8 +35,8 @@ func testStacksSuggestCommand(t *testing.T, when spec.G, it spec.S) {
     Stack ID: heroku-20
     Description: The official Heroku stack based on Ubuntu 20.04
     Maintainer: Heroku
-    Build Image: heroku/pack:20-build
-    Run Image: heroku/pack:20
+    Build Image: heroku/heroku:20-cnb-build
+    Run Image: heroku/heroku:20-cnb
 
     Stack ID: io.buildpacks.stacks.bionic
     Description: A minimal Paketo stack based on Ubuntu 18.04

--- a/internal/commands/suggest_stacks_test.go
+++ b/internal/commands/suggest_stacks_test.go
@@ -40,8 +40,8 @@ Stacks maintained by the community:
     Stack ID: heroku-20
     Description: The official Heroku stack based on Ubuntu 20.04
     Maintainer: Heroku
-    Build Image: heroku/pack:20-build
-    Run Image: heroku/pack:20
+    Build Image: heroku/heroku:20-cnb-build
+    Run Image: heroku/heroku:20-cnb
 
     Stack ID: io.buildpacks.stacks.bionic
     Description: A minimal Paketo stack based on Ubuntu 18.04


### PR DESCRIPTION
## Summary

The image names / locations for the CNB-compatible Heroku stack images have changed. `heroku/pack:*` images still exist, but they won't be updated in the future. `heroku/heroku:*-cnb(-build)` are published alongside each new release of the heroku stack (`heroku/heroku:*`). We've done this to hopefully alleviate some of the confusion around our image names.

## Output

#### Before
```
Stacks maintained by the community:

    Stack ID: heroku-20
    Description: The official Heroku stack based on Ubuntu 20.04
    Maintainer: Heroku
    Build Image: heroku/pack:20-build
    Run Image: heroku/pack:20
```

#### After

```
Stacks maintained by the community:

    Stack ID: heroku-20
    Description: The official Heroku stack based on Ubuntu 20.04
    Maintainer: Heroku
    Build Image: heroku/heroku:20-cnb-build
    Run Image: heroku/heroku:20-cnb
```


## Documentation

- Should this change be documented?
    - [x] No

## Related
Introduction of new image tags: https://github.com/heroku/stack-images/pull/213
