### PR TITLE
Minor improvements to release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,23 +248,41 @@ jobs:
           prerelease: true
           files: pack-v${{ env.PACK_VERSION }}-*
           body: |
-            # pack v${{ env.PACK_VERSION }}
-            > This is a **beta** pre-release of the Cloud Native Buildpack local CLI. This platform implementation should be relatively stable and reliable, but breaking changes in the underlying [specification](https://github.com/buildpack/spec) may be implemented without notice. Note that pack is intended for local image builds, and thus requires a Docker daemon. The [lifecycle](https://github.com/buildpack/lifecycle) should be used directly when building on cloud platforms.
+            > This is a **beta** pre-release of the Cloud Native Buildpack local CLI. This platform implementation should be relatively stable and reliable, but breaking changes in the underlying [specification](https://github.com/buildpack/spec) may be implemented without notice.
 
             ## Prerequisites
 
-            - The [Docker daemon](https://www.docker.com/get-started) must be installed on your workstation or accessible over the network.
+            - A container runtime such as [Docker](https://www.docker.com/get-started) or [podman](https://podman.io/getting-started/) must be available to execute builds.
 
             ## Install
 
             #### Linux
 
-            ##### Command
+            ##### AMD64
 
             ```bash
             (curl -sSL "https://github.com/buildpacks/pack/releases/download/v${{ env.PACK_VERSION }}/pack-v${{ env.PACK_VERSION }}-linux.tgz" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv pack)
             ```
 
+            ##### ARM64
+
+            ```bash
+            (curl -sSL "https://github.com/buildpacks/pack/releases/download/v${{ env.PACK_VERSION }}/pack-v${{ env.PACK_VERSION }}-linux-arm64.tgz" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv pack)
+            ```
+
+            #### MacOS
+
+            ##### Intel
+
+            ```bash
+            (curl -sSL "https://github.com/buildpacks/pack/releases/download/v${{ env.PACK_VERSION }}/pack-v${{ env.PACK_VERSION }}-macos.tgz" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv pack)
+            ```
+
+            ##### Apple Silicon
+
+            ```bash
+            (curl -sSL "https://github.com/buildpacks/pack/releases/download/v${{ env.PACK_VERSION }}/pack-v${{ env.PACK_VERSION }}-macos-arm64.tgz" | sudo tar -C /usr/local/bin/ --no-same-owner -xzv pack)
+            ```
             #### Manually
 
             1. Download the `.tgz` or `.zip` file for your platform
@@ -300,12 +318,11 @@ jobs:
           draft: true
           files: pack-v${{ env.PACK_VERSION }}-*
           body: |
-            # pack v${{ env.PACK_VERSION }}
-            > This is a **beta** release of the Cloud Native Buildpack local CLI. This platform implementation should be relatively stable and reliable, but breaking changes in the underlying [specification](https://github.com/buildpack/spec) may be implemented without notice. Note that pack is intended for local image builds, and thus requires a Docker daemon. The [lifecycle](https://github.com/buildpack/lifecycle) should be used directly when building on cloud platforms.
+            > This is a **beta** release of the Cloud Native Buildpack local CLI. This platform implementation should be relatively stable and reliable, but breaking changes in the underlying [specification](https://github.com/buildpack/spec) may be implemented without notice.
 
             ## Prerequisites
 
-            - The [Docker daemon](https://www.docker.com/get-started) must be installed on your workstation or accessible over the network.
+            - A container runtime such as [Docker](https://www.docker.com/get-started) or [podman](https://podman.io/getting-started/) must be available to execute builds.
 
             ## Install
 


### PR DESCRIPTION
## Summary

A few changes to release notes:

1. Add `podman` as an alternative to the Docker daemon.
2. Remove prescribed mention on how `pack` vs `lifecycle` should be used.
3. Add more install command variants for Linux and macOS.
4. Remove duplicate heading (H1).

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
<img width="710" alt="image" src="https://user-images.githubusercontent.com/475559/172661629-5d885484-0adf-4966-a40f-a64577f846ca.png">


#### After

<img width="710" alt="image" src="https://user-images.githubusercontent.com/475559/172662221-3bed541d-7fbd-45d0-9be6-d73711051d25.png">
