### PR TITLE
flags: Add `--cache` flag for build cache as image

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1759,6 +1759,7 @@ func testAcceptance(
 					when("--cache with options for build cache as image", func() {
 						var cacheImageName, cacheFlags string
 						it.Before(func() {
+							h.SkipIf(t, !pack.SupportsFeature(invoke.Cache), "")
 							cacheImageName = fmt.Sprintf("%s-cache", repoName)
 							cacheFlags = fmt.Sprintf("type=build;format=image;name=%s", cacheImageName)
 						})

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1756,6 +1756,46 @@ func testAcceptance(
 						})
 					})
 
+					when("--cache with options for build cache as image", func() {
+						var cacheImageName, cacheFlags string
+						it.Before(func() {
+							cacheImageName = fmt.Sprintf("%s-cache", repoName)
+							cacheFlags = fmt.Sprintf("type=build;format=image;name=%s", cacheImageName)
+						})
+
+						it("creates image and cache image on the registry", func() {
+							buildArgs := []string{
+								repoName,
+								"-p", filepath.Join("testdata", "mock_app"),
+								"--publish",
+								"--cache",
+								cacheFlags,
+							}
+							if imageManager.HostOS() != "windows" {
+								buildArgs = append(buildArgs, "--network", "host")
+							}
+
+							output := pack.RunSuccessfully("build", buildArgs...)
+							assertions.NewOutputAssertionManager(t, output).ReportsSuccessfulImageBuild(repoName)
+
+							cacheImageRef, err := name.ParseReference(cacheImageName, name.WeakValidation)
+							assert.Nil(err)
+
+							t.Log("checking that registry has contents")
+							assertImage.CanBePulledFromRegistry(repoName)
+							if imageManager.HostOS() == "windows" {
+								// Cache images are automatically Linux container images, and therefore can't be pulled
+								// and inspected correctly on WCOW systems
+								// https://github.com/buildpacks/lifecycle/issues/529
+								imageManager.PullImage(cacheImageRef.Name(), registryConfig.RegistryAuth())
+							} else {
+								assertImage.CanBePulledFromRegistry(cacheImageRef.Name())
+							}
+
+							defer imageManager.CleanupImages(cacheImageRef.Name())
+						})
+					})
+
 					when("ctrl+c", func() {
 						it("stops the execution", func() {
 							var buf = new(bytes.Buffer)

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -5,6 +5,7 @@ package invoke
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -210,19 +211,26 @@ func (i *PackInvoker) Supports(command string) bool {
 		search = command
 	}
 
+	re := regexp.MustCompile(fmt.Sprint(`\b%s\b`, search))
 	output, err := i.baseCmd(cmdParts...).CombinedOutput()
 	i.assert.Nil(err)
 
-	return strings.Contains(string(output), search) && !strings.Contains(string(output), "Unknown help topic")
+	return re.MatchString(string(output)) && !strings.Contains(string(output), "Unknown help topic")
 }
 
 type Feature int
 
-const CreationTime = iota
+const (
+	CreationTime = iota
+	Cache
+)
 
 var featureTests = map[Feature]func(i *PackInvoker) bool{
 	CreationTime: func(i *PackInvoker) bool {
 		return i.Supports("build --creation-time")
+	},
+	Cache: func(i *PackInvoker) bool {
+		return i.Supports("build --cache")
 	},
 }
 

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -124,7 +124,7 @@ func (l *LifecycleExecution) PrevImageName() string {
 func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseFactoryCreator) error {
 	phaseFactory := phaseFactoryCreator(l)
 	var buildCache Cache
-	if l.opts.CacheImage != "" || (l.opts.Cache.CacheType == "build" && l.opts.Cache.Format == "image") {
+	if l.opts.CacheImage != "" || (l.opts.Cache.CacheType == cache.Build && l.opts.Cache.Format == cache.CacheImage) {
 		cacheImageName := l.opts.CacheImage
 		if cacheImageName == "" {
 			cacheImageName = l.opts.Cache.Source

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -124,7 +124,7 @@ func (l *LifecycleExecution) PrevImageName() string {
 func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseFactoryCreator) error {
 	phaseFactory := phaseFactoryCreator(l)
 	var buildCache Cache
-	if l.opts.CacheImage != "" || l.opts.Cache.CacheType == "image" {
+	if l.opts.CacheImage != "" || (l.opts.Cache.CacheType == "build" && l.opts.Cache.Format == "image") {
 		cacheImageName := l.opts.CacheImage
 		if cacheImageName == "" {
 			cacheImageName = l.opts.Cache.Source

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -124,8 +124,12 @@ func (l *LifecycleExecution) PrevImageName() string {
 func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseFactoryCreator) error {
 	phaseFactory := phaseFactoryCreator(l)
 	var buildCache Cache
-	if l.opts.CacheImage != "" {
-		cacheImage, err := name.ParseReference(l.opts.CacheImage, name.WeakValidation)
+	if l.opts.CacheImage != "" || l.opts.Cache.CacheType == "image" {
+		cacheImageName := l.opts.CacheImage
+		if cacheImageName == "" {
+			cacheImageName = l.opts.Cache.Source
+		}
+		cacheImage, err := name.ParseReference(cacheImageName, name.WeakValidation)
 		if err != nil {
 			return fmt.Errorf("invalid cache image name: %s", err)
 		}

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -352,7 +352,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 						return fakePhaseFactory
 					})
 
-					h.AssertError(t, err, fmt.Sprintf("invalid cache image name: %s", "could not parse reference: %%!(NOVERB)"))
+					h.AssertError(t, err, fmt.Sprintf("invalid cache image name: %s", "could not parse reference: %%"))
 				})
 
 				it("fails for cache flags", func() {
@@ -365,8 +365,8 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 						TrustBuilder: false,
 						UseCreator:   false,
 						Cache: cache.CacheOpts{
-							CacheType: "build",
-							Format:    "image",
+							CacheType: cache.Build,
+							Format:    cache.CacheImage,
 							Source:    "%%%",
 						},
 						Termui: fakeTermui,
@@ -379,7 +379,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 						return fakePhaseFactory
 					})
 
-					h.AssertError(t, err, fmt.Sprintf("invalid cache image name: %s", "could not parse reference: %%!(NOVERB)"))
+					h.AssertError(t, err, fmt.Sprintf("invalid cache image name: %s", "could not parse reference: %%"))
 				})
 			})
 		})

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -331,8 +331,8 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("Error cases", func() {
-			when("passed invalid cache-image", func() {
-				it("fails", func() {
+			when("passed invalid", func() {
+				it("fails for cache-image", func() {
 					opts := build.LifecycleOptions{
 						Publish:      false,
 						ClearCache:   false,
@@ -343,6 +343,33 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 						UseCreator:   false,
 						CacheImage:   "%%%",
 						Termui:       fakeTermui,
+					}
+
+					lifecycle, err := build.NewLifecycleExecution(logger, docker, opts)
+					h.AssertNil(t, err)
+
+					err = lifecycle.Run(context.Background(), func(execution *build.LifecycleExecution) build.PhaseFactory {
+						return fakePhaseFactory
+					})
+
+					h.AssertError(t, err, fmt.Sprintf("invalid cache image name: %s", "could not parse reference: %%!(NOVERB)"))
+				})
+
+				it("fails for cache flags", func() {
+					opts := build.LifecycleOptions{
+						Publish:      false,
+						ClearCache:   false,
+						RunImage:     "test",
+						Image:        imageName,
+						Builder:      fakeBuilder,
+						TrustBuilder: false,
+						UseCreator:   false,
+						Cache: cache.CacheOpts{
+							CacheType: "build",
+							Format:    "image",
+							Source:    "%%%",
+						},
+						Termui: fakeTermui,
 					}
 
 					lifecycle, err := build.NewLifecycleExecution(logger, docker, opts)

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -77,6 +77,7 @@ type LifecycleOptions struct {
 	Interactive        bool
 	Termui             Termui
 	DockerHost         string
+	Cache              cache.CacheOpts
 	CacheImage         string
 	HTTPProxy          string
 	HTTPSProxy         string

--- a/internal/cache/cache_opts.go
+++ b/internal/cache/cache_opts.go
@@ -1,0 +1,88 @@
+package cache
+
+import (
+	"encoding/csv"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type CacheOpts struct {
+	CacheType string
+	Format    string
+	Source    string
+}
+
+func (c *CacheOpts) Set(value string) error {
+	csvReader := csv.NewReader(strings.NewReader(value))
+	csvReader.Comma = ';'
+	fields, err := csvReader.Read()
+	if err != nil {
+		return err
+	}
+
+	for _, field := range fields {
+		parts := strings.SplitN(field, "=", 2)
+
+		if len(parts) == 2 {
+			key := strings.ToLower(parts[0])
+			value := strings.ToLower(parts[1])
+			switch key {
+			case "type":
+				if value != "build" {
+					return errors.Errorf("invalid cache type '%s'", value)
+				}
+				c.CacheType = value
+			case "format":
+				if value != "image" {
+					return errors.Errorf("invalid cache format '%s'", value)
+				}
+				c.Format = value
+			case "name":
+				c.Source = value
+			}
+		}
+
+		if len(parts) != 2 {
+			return errors.Errorf("invalid field '%s' must be a key=value pair", field)
+		}
+	}
+
+	err = populateMissing(c)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CacheOpts) String() string {
+	var cacheFlag string
+	if c.CacheType != "" {
+		cacheFlag += fmt.Sprintf("type=%s;", c.CacheType)
+	}
+	if c.Format != "" {
+		cacheFlag += fmt.Sprintf("format=%s;", c.Format)
+	}
+	if c.Source != "" {
+		cacheFlag += fmt.Sprintf("name=%s", c.Source)
+	}
+	return cacheFlag
+}
+
+func (c *CacheOpts) Type() string {
+	return "cache"
+}
+
+func populateMissing(c *CacheOpts) error {
+	if c.CacheType == "" {
+		c.CacheType = "build"
+	}
+	if c.Format == "" {
+		c.Format = "volume"
+	}
+	if c.Source == "" {
+		return errors.Errorf("cache 'name' is required")
+	}
+	return nil
+}

--- a/internal/cache/cache_opts.go
+++ b/internal/cache/cache_opts.go
@@ -30,7 +30,7 @@ func (c *CacheOpts) Set(value string) error {
 			value := strings.ToLower(parts[1])
 			switch key {
 			case "type":
-				if value != "build" {
+				if value != "build" && value != "launch" {
 					return errors.Errorf("invalid cache type '%s'", value)
 				}
 				c.CacheType = value

--- a/internal/cache/cache_opts_test.go
+++ b/internal/cache/cache_opts_test.go
@@ -105,5 +105,41 @@ func testCacheOpts(t *testing.T, when spec.G, it spec.S) {
 				}
 			}
 		})
+
+		it("image cache format with invalid options", func() {
+			testcases := []CacheOptTestCase{
+				{
+					name:       "Invalid cache type",
+					input:      "type=invalid_cache;format=image;name=io.test.io/myorg/my-cache:build",
+					output:     "invalid cache type 'invalid_cache'",
+					shouldFail: true,
+				},
+				{
+					name:       "Invalid cache format",
+					input:      "type=launch;format=invalid_format;name=io.test.io/myorg/my-cache:build",
+					output:     "invalid cache format 'invalid_format'",
+					shouldFail: true,
+				},
+				{
+					name:       "Not a key=value pair",
+					input:      "launch;format=image;name=io.test.io/myorg/my-cache:build",
+					output:     "invalid field 'launch' must be a key=value pair",
+					shouldFail: true,
+				},
+				{
+					name:       "Extra semicolon",
+					input:      "type=launch;format=image;name=io.test.io/myorg/my-cache:build;",
+					output:     "invalid field '' must be a key=value pair",
+					shouldFail: true,
+				},
+			}
+
+			for _, testcase := range testcases {
+				var cacheFlags CacheOpts
+				t.Logf("Testing cache type: %s", testcase.name)
+				err := cacheFlags.Set(testcase.input)
+				h.AssertError(t, err, testcase.output)
+			}
+		})
 	})
 }

--- a/internal/cache/cache_opts_test.go
+++ b/internal/cache/cache_opts_test.go
@@ -1,0 +1,98 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+type CacheOptTestCase struct {
+	name       string
+	input      string
+	output     string
+	shouldFail bool
+}
+
+func TestMetadata(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "Metadata", testCacheOpts, spec.Sequential(), spec.Report(report.Terminal{}))
+}
+
+func testCacheOpts(t *testing.T, when spec.G, it spec.S) {
+	when("cache options are passed", func() {
+		it("image cache format with complete options", func() {
+			testcases := []CacheOptTestCase{
+				{
+					name:   "Build cache as Image",
+					input:  "type=build;format=image;name=io.test.io/myorg/my-cache:build",
+					output: "type=build;format=image;name=io.test.io/myorg/my-cache:build",
+				},
+			}
+
+			for _, testcase := range testcases {
+				var cacheFlags CacheOpts
+				t.Logf("Testing cache type: %s", testcase.name)
+				err := cacheFlags.Set(testcase.input)
+				h.AssertNil(t, err)
+				h.AssertEq(t, testcase.output, cacheFlags.String())
+			}
+		})
+
+		it("image cache format with missing options", func() {
+			successTestCases := []CacheOptTestCase{
+				{
+					name:   "Build cache as Image missing: type",
+					input:  "format=image;name=io.test.io/myorg/my-cache:build",
+					output: "type=build;format=image;name=io.test.io/myorg/my-cache:build",
+				},
+				{
+					name:   "Build cache as Image missing: format",
+					input:  "type=build;name=io.test.io/myorg/my-cache:build",
+					output: "type=build;format=volume;name=io.test.io/myorg/my-cache:build",
+				},
+				{
+					name:   "Build cache as Image missing: type, format",
+					input:  "name=io.test.io/myorg/my-cache:build",
+					output: "type=build;format=volume;name=io.test.io/myorg/my-cache:build",
+				},
+				{
+					name:       "Build cache as Image missing: name",
+					input:      "type=build;format=image",
+					output:     "cache 'name' is required",
+					shouldFail: true,
+				},
+				{
+					name:       "Build cache as Image missing: format, name",
+					input:      "type=build",
+					output:     "cache 'name' is required",
+					shouldFail: true,
+				},
+				{
+					name:       "Build cache as Image missing: type, name",
+					input:      "format=image",
+					output:     "cache 'name' is required",
+					shouldFail: true,
+				},
+			}
+
+			for _, testcase := range successTestCases {
+				var cacheFlags CacheOpts
+				t.Logf("Testing cache type: %s", testcase.name)
+				err := cacheFlags.Set(testcase.input)
+
+				if testcase.shouldFail {
+					h.AssertError(t, err, testcase.output)
+				} else {
+					h.AssertNil(t, err)
+					output := cacheFlags.String()
+					h.AssertEq(t, testcase.output, output)
+				}
+			}
+		})
+	})
+}

--- a/internal/cache/cache_opts_test.go
+++ b/internal/cache/cache_opts_test.go
@@ -32,6 +32,11 @@ func testCacheOpts(t *testing.T, when spec.G, it spec.S) {
 					input:  "type=build;format=image;name=io.test.io/myorg/my-cache:build",
 					output: "type=build;format=image;name=io.test.io/myorg/my-cache:build",
 				},
+				{
+					name:   "Launch cache as Image",
+					input:  "type=launch;format=image;name=io.test.io/myorg/my-cache:build",
+					output: "type=launch;format=image;name=io.test.io/myorg/my-cache:build",
+				},
 			}
 
 			for _, testcase := range testcases {
@@ -75,6 +80,12 @@ func testCacheOpts(t *testing.T, when spec.G, it spec.S) {
 				{
 					name:       "Build cache as Image missing: type, name",
 					input:      "format=image",
+					output:     "cache 'name' is required",
+					shouldFail: true,
+				},
+				{
+					name:       "Launch cache as Image missing: name",
+					input:      "type=launch;format=image",
 					output:     "cache 'name' is required",
 					shouldFail: true,
 				},

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/buildpacks/pack/internal/cache"
 	"github.com/buildpacks/pack/internal/config"
 	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/pkg/client"
@@ -28,6 +29,7 @@ type BuildFlags struct {
 	Interactive        bool
 	DockerHost         string
 	CacheImage         string
+	Cache              cache.CacheOpts
 	AppPath            string
 	Builder            string
 	Registry           string
@@ -159,6 +161,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				DefaultProcessType:       flags.DefaultProcessType,
 				ProjectDescriptorBaseDir: filepath.Dir(actualDescriptorPath),
 				ProjectDescriptor:        descriptor,
+				Cache:                    flags.Cache,
 				CacheImage:               flags.CacheImage,
 				Workspace:                flags.Workspace,
 				LifecycleImage:           lifecycleImage,
@@ -200,6 +203,7 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringVarP(&buildFlags.AppPath, "path", "p", "", "Path to app dir or zip-formatted file (defaults to current working directory)")
 	cmd.Flags().StringSliceVarP(&buildFlags.Buildpacks, "buildpack", "b", nil, "Buildpack to use. One of:\n  a buildpack by id and version in the form of '<buildpack>@<version>',\n  path to a buildpack directory (not supported on Windows),\n  path/URL to a buildpack .tar or .tgz file, or\n  a packaged buildpack image name in the form of '<hostname>/<repo>[:<tag>]'"+stringSliceHelp("buildpack"))
 	cmd.Flags().StringVarP(&buildFlags.Builder, "builder", "B", cfg.DefaultBuilder, "Builder image")
+	cmd.Flags().Var(&buildFlags.Cache, "cache", "Cache used to define different cache options.")
 	cmd.Flags().StringVar(&buildFlags.CacheImage, "cache-image", "", `Cache build layers in remote registry. Requires --publish`)
 	cmd.Flags().BoolVar(&buildFlags.ClearCache, "clear-cache", false, "Clear image's associated cache before building")
 	cmd.Flags().StringVar(&buildFlags.DateTime, "creation-time", "", "Desired create time in the output image config. Accepted values are Unix timestamps (e.g., '1641013200'), or 'now'. Platform API version must be at least 0.9 to use this feature.")
@@ -235,6 +239,14 @@ This option may set DOCKER_HOST environment variable for the build container if 
 func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackClient, logger logging.Logger) error {
 	if flags.Registry != "" && !cfg.Experimental {
 		return client.NewExperimentError("Support for buildpack registries is currently experimental.")
+	}
+
+	if flags.Cache.String() != "" && flags.CacheImage != "" {
+		return errors.New("'cache' flag cannot be used with 'cache-image' flag.")
+	}
+
+	if flags.Cache.Format == "image" && !flags.Publish {
+		return errors.New("image cache format requires the 'publish' flag.")
 	}
 
 	if flags.CacheImage != "" && !flags.Publish {

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -241,15 +241,15 @@ func validateBuildFlags(flags *BuildFlags, cfg config.Config, packClient PackCli
 		return client.NewExperimentError("Support for buildpack registries is currently experimental.")
 	}
 
-	if flags.Cache.CacheType == "launch" && flags.Cache.Format == "image" {
+	if flags.Cache.CacheType == cache.Launch && flags.Cache.Format == cache.CacheImage {
 		logger.Warn("cache definition: 'launch' cache in format 'image' is not supported.")
 	}
 
-	if flags.Cache.String() != "" && flags.CacheImage != "" {
-		return errors.New("'cache' flag cannot be used with 'cache-image' flag.")
+	if flags.Cache.Format == cache.CacheImage && flags.CacheImage != "" {
+		return errors.New("'cache' flag with 'image' format cannot be used with 'cache-image' flag.")
 	}
 
-	if flags.Cache.Format == "image" && !flags.Publish {
+	if flags.Cache.Format == cache.CacheImage && !flags.Publish {
 		return errors.New("image cache format requires the 'publish' flag")
 	}
 

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -347,6 +347,33 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("cache flag with 'format=image' is passed", func() {
+			when("--publish is not used", func() {
+				it("errors", func() {
+					command.SetArgs([]string{"--builder", "my-builder", "image", "--cache", "type=build;format=image;name=myorg/myimage:cache"})
+					err := command.Execute()
+					h.AssertError(t, err, "image cache format requires the 'publish' flag")
+				})
+			})
+			when("--publish is used", func() {
+				it("succeeds", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithCacheFlags("type=build;format=image;name=myorg/myimage:cache")).
+						Return(nil)
+
+					command.SetArgs([]string{"--builder", "my-builder", "image", "--cache", "type=build;format=image;name=myorg/myimage:cache", "--publish"})
+					h.AssertNil(t, command.Execute())
+				})
+			})
+			when("used together with --cache-image", func() {
+				it("errors", func() {
+					command.SetArgs([]string{"--builder", "my-builder", "image", "--cache-image", "some-cache-image", "--cache", "type=build;format=image;name=myorg/myimage:cache"})
+					err := command.Execute()
+					h.AssertError(t, err, "'cache' flag cannot be used with 'cache-image' flag.")
+				})
+			})
+		})
+
 		when("a valid lifecycle-image is provided", func() {
 			when("only the image repo is provided", func() {
 				it("uses the provided lifecycle-image and parses it correctly", func() {
@@ -856,6 +883,15 @@ func EqBuildOptionsWithCacheImage(cacheImage string) gomock.Matcher {
 		description: fmt.Sprintf("CacheImage=%s", cacheImage),
 		equals: func(o client.BuildOptions) bool {
 			return o.CacheImage == cacheImage
+		},
+	}
+}
+
+func EqBuildOptionsWithCacheFlags(cacheFlags string) gomock.Matcher {
+	return buildOptionsMatcher{
+		description: fmt.Sprintf("CacheFlags=%s", cacheFlags),
+		equals: func(o client.BuildOptions) bool {
+			return o.Cache.String() == cacheFlags
 		},
 	}
 }

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -369,7 +369,18 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 				it("errors", func() {
 					command.SetArgs([]string{"--builder", "my-builder", "image", "--cache-image", "some-cache-image", "--cache", "type=build;format=image;name=myorg/myimage:cache"})
 					err := command.Execute()
-					h.AssertError(t, err, "'cache' flag cannot be used with 'cache-image' flag.")
+					h.AssertError(t, err, "'cache' flag with 'image' format cannot be used with 'cache-image' flag")
+				})
+			})
+			when("''type=launch;format=image' is used", func() {
+				it("warns", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithCacheFlags("type=launch;format=image;name=myorg/myimage:cache")).
+						Return(nil)
+
+					command.SetArgs([]string{"--builder", "my-builder", "image", "--cache", "type=launch;format=image;name=myorg/myimage:cache", "--publish"})
+					h.AssertNil(t, command.Execute())
+					h.AssertContains(t, outBuf.String(), "Warning: cache definition: 'launch' cache in format 'image' is not supported.")
 				})
 			})
 		})

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/buildpacks/pack/internal/build"
 	"github.com/buildpacks/pack/internal/builder"
+	"github.com/buildpacks/pack/internal/cache"
 	internalConfig "github.com/buildpacks/pack/internal/config"
 	pname "github.com/buildpacks/pack/internal/name"
 	"github.com/buildpacks/pack/internal/stack"
@@ -105,6 +106,9 @@ type BuildOptions struct {
 	// User provided environment variables to the buildpacks.
 	// Buildpacks may both read and overwrite these values.
 	Env map[string]string
+
+	// Used to configure various cache available options
+	Cache cache.CacheOpts
 
 	// Option only valid if Publish is true
 	// Create an additional image that contains cache=true layers and push it to the registry.
@@ -345,6 +349,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		TrustBuilder:       opts.TrustBuilder(opts.Builder),
 		UseCreator:         false,
 		DockerHost:         opts.DockerHost,
+		Cache:              opts.Cache,
 		CacheImage:         opts.CacheImage,
 		HTTPProxy:          proxyConfig.HTTPProxy,
 		HTTPSProxy:         proxyConfig.HTTPSProxy,


### PR DESCRIPTION
Add `--cache` flag for configuring build and launch cache as image.
```bash
pack build --cache 'type=build;format=image;name=<image name/image registry address>'
```

## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1475 
Resolves #1457
