### PR TITLE
CI: Fix setup-go on windows-lcow runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,9 @@ jobs:
           }
         shell: powershell
       - name: Set up go
-        uses: actions/setup-go@v3
+        # Temporary fix for Windows related issue: https://github.com/actions/setup-go/issues/241
+        # Can be reverted after the following is merged: https://github.com/actions/setup-go/pull/250
+        uses: jromero/setup-go@feature/windows-download-filename
         with:
           go-version: '1.17'
       - name: Set up go env for Unix


### PR DESCRIPTION
This PR temporarily addresses an issue in the setup-go action that prevents downloading new go versions on Windows. 

These changes can be reverted after https://github.com/actions/setup-go/issues/241 is resolved.