### PR TITLE
Use Windows artifact from WCOW worker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
           PACK_BUILD: ${{ github.run_number }}
         shell: powershell
       - uses: actions/upload-artifact@v3
-        if: matrix.config != 'windows-wcow'
+        if: matrix.config != 'windows-lcow'
         with:
           name: pack-${{ matrix.os }}
           path: out/${{ env.PACK_BIN }}


### PR DESCRIPTION
In this scenario the LCOW self-hosted worker would be used only for tests, improving our security posture.