### PR TITLE
Change Slack link in README to CNCF slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GoDoc](https://godoc.org/github.com/buildpacks/pack?status.svg)](https://godoc.org/github.com/buildpacks/pack)
 [![GitHub license](https://img.shields.io/github/license/buildpacks/pack)](https://github.com/buildpacks/pack/blob/main/LICENSE)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4748/badge)](https://bestpractices.coreinfrastructure.org/projects/4748)
-[![Slack](https://img.shields.io/badge/slack-join-ff69b4.svg?logo=slack)](https://slack.buildpacks.io/)
+[![Slack](https://img.shields.io/badge/slack-join-ff69b4.svg?logo=slack)](https://slack.cncf.io/)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/buildpacks/pack)
 
 `pack` makes it easy for...


### PR DESCRIPTION
## Summary
The slack linked in the Readme is officially shut down, so the link should point to the CNCF slack.

Signed-off-by: Stefan Zabka <stefan.zabka@camunda.com>



