### PR TITLE
Fix crash when loading buildpack from OCI archive with relative paths

### DIFF
--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -3,6 +3,7 @@ package paths
 import (
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -132,4 +133,9 @@ func WindowsPathSID(uid, gid int) string {
 		return "S-1-5-32-544" // BUILTIN\Administrators
 	}
 	return "S-1-5-32-545" // BUILTIN\Users
+}
+
+// CanonicalTarPath return a cleaned path (see path.Clean) with leading slashes removed
+func CanonicalTarPath(p string) string {
+	return strings.TrimPrefix(path.Clean(p), "/")
 }

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -259,4 +259,41 @@ func testPaths(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 	})
+
+	when("#CanonicalTarPath", func() {
+		for _, params := range []struct {
+			desc     string
+			path     string
+			expected string
+		}{
+			{
+				desc:     "noop",
+				path:     "my/clean/path",
+				expected: "my/clean/path",
+			},
+			{
+				desc:     "leading slash",
+				path:     "/my/path",
+				expected: "my/path",
+			},
+			{
+				desc:     "dot",
+				path:     "my/./path",
+				expected: "my/path",
+			},
+			{
+				desc:     "dotdot",
+				path:     "my/../my/path",
+				expected: "my/path",
+			},
+		} {
+			params := params
+
+			when(params.desc+":"+params.path, func() {
+				it(fmt.Sprintf("returns %v", params.expected), func() {
+					h.AssertEq(t, paths.CanonicalTarPath(params.path), params.expected)
+				})
+			})
+		}
+	})
 }

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -7,12 +7,13 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"time"
 
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/pkg/errors"
+
+	"github.com/buildpacks/pack/internal/paths"
 )
 
 var NormalizedDateTime time.Time
@@ -139,6 +140,7 @@ func IsEntryNotExist(err error) bool {
 
 // ReadTarEntry reads and returns a tar file
 func ReadTarEntry(rc io.Reader, entryPath string) (*tar.Header, []byte, error) {
+	canonicalEntryPath := paths.CanonicalTarPath(entryPath)
 	tr := tar.NewReader(rc)
 	for {
 		header, err := tr.Next()
@@ -149,7 +151,7 @@ func ReadTarEntry(rc io.Reader, entryPath string) (*tar.Header, []byte, error) {
 			return nil, nil, errors.Wrap(err, "failed to get next tar entry")
 		}
 
-		if path.Clean(header.Name) == entryPath {
+		if paths.CanonicalTarPath(header.Name) == canonicalEntryPath {
 			buf, err := ioutil.ReadAll(tr)
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "failed to read contents of '%s'", entryPath)

--- a/pkg/buildpack/oci_layout_package.go
+++ b/pkg/buildpack/oci_layout_package.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 
+	"github.com/buildpacks/pack/internal/paths"
 	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/pkg/archive"
 	blob2 "github.com/buildpacks/pack/pkg/blob"
@@ -125,7 +126,7 @@ func (o *ociLayoutPackage) GetLayer(diffID string) (io.ReadCloser, error) {
 	}
 
 	layerDescriptor := o.manifest.Layers[index]
-	layerPath := pathFromDescriptor(layerDescriptor)
+	layerPath := paths.CanonicalTarPath(pathFromDescriptor(layerDescriptor))
 
 	blobReader, err := o.blob.Open()
 	if err != nil {
@@ -142,7 +143,7 @@ func (o *ociLayoutPackage) GetLayer(diffID string) (io.ReadCloser, error) {
 			return nil, errors.Wrap(err, "failed to get next tar entry")
 		}
 
-		if path.Clean(header.Name) == path.Clean(layerPath) {
+		if paths.CanonicalTarPath(header.Name) == layerPath {
 			finalReader := blobReader
 
 			if strings.HasSuffix(layerDescriptor.MediaType, ".gzip") {


### PR DESCRIPTION

## Summary

- tar files can be absolute (`/my/path`) or relative (`my/path`).
- The [OCI Image spec](https://github.com/opencontainers/image-spec/blob/v1.0/image-layout.md) does not specify which style to use
- Some tools (like `skopeo` for example) use the relative style
- When reading buildpacks from an archive, `pack` assumes the absolute style

## Output

### Prepare

Download a buildpack with skopeo

```bash
skopeo copy docker://gcr.io/paketo-buildpacks/java oci-archive:java.cnb --format v2s2
```

Prepare `some.jar` as an executable jar file.

#### Before

```console
$ pack build --builder paketobuildpacks/builder-jammy-buildpackless-base --buildpack java.cnb --path some.jar dev-null --trust-builder
latest: Pulling from paketobuildpacks/builder-jammy-buildpackless-base
Digest: sha256:5517fc3198bbfa84d3f31509c2bc3a14087e5aa718790bdfe9c561b0a19cf91b
Status: Image is up to date for paketobuildpacks/builder-jammy-buildpackless-base:latest
latest: Pulling from paketobuildpacks/run-jammy-base
Digest: sha256:36eddd3a51d37b4e11e7ff958b5c2568f4160e432dd526806a3940ec9369697b
Status: Image is up to date for paketobuildpacks/run-jammy-base:latest
ERROR: failed to build: downloading buildpack: extracting from file:///home/d060677/workspace/pack/java.cnb: reading buildpack: reading buildpack.toml: could not find entry path 'buildpack.toml': not exist
```

#### After

```console
$ pack build --builder paketobuildpacks/builder-jammy-buildpackless-base --buildpack java.cnb --path some.jar dev-null --trust-builder                                                                                                                                          
latest: Pulling from paketobuildpacks/builder-jammy-buildpackless-base                                                                                                                                                                                                                                                                                
Digest: sha256:5517fc3198bbfa84d3f31509c2bc3a14087e5aa718790bdfe9c561b0a19cf91b                                                                                                                                                                                                                                                                       
Status: Image is up to date for paketobuildpacks/builder-jammy-buildpackless-base:latest                                                                                                                                                                                                                                                              
latest: Pulling from paketobuildpacks/run-jammy-base                                                                                                                                                                                                                                                                                                  
Digest: sha256:36eddd3a51d37b4e11e7ff958b5c2568f4160e432dd526806a3940ec9369697b                                                                                                                                                                                                                                                                       
Status: Image is up to date for paketobuildpacks/run-jammy-base:latest                                                                                                                                                                                                                                                                                
Restoring data for SBOM from previous image                                                                                                                                                                                                                                                                                                           
===> DETECTING                                                                                                                                                                                                                                                                                                                                        
6 of 24 buildpacks participating                                                                                                                                                                                                                                                                                                                      
paketo-buildpacks/ca-certificates   3.3.0                                                                                                                                                                                                                                                                                                             
paketo-buildpacks/bellsoft-liberica 9.6.1                                                                                                                                                                                                                                                                                                             
paketo-buildpacks/syft              1.18.0                                                                                                                                                                                                                                                                                                            
paketo-buildpacks/executable-jar    6.4.0                                                                                                                                                                                                                                                                                                             
paketo-buildpacks/dist-zip          5.3.0                                                                                                                                                                                                                                                                                                             
paketo-buildpacks/spring-boot       5.18.0
[...]
Successfully built image dev-null
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

