### PR TITLE
Add TOC to code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @buildpacks/platform-maintainers
+* @buildpacks/toc


### PR DESCRIPTION
## Summary
Add TOC to code owners. This allows TOC members to also approve PRs.