### PR TITLE
Use arm64 lifecycle for arm64 linux base image

### DIFF
--- a/pkg/client/create_builder_test.go
+++ b/pkg/client/create_builder_test.go
@@ -443,6 +443,24 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 			})
 
+			it("should download from predetermined uri for arm64", func() {
+				prepareFetcherWithBuildImage()
+				prepareFetcherWithRunImages()
+				opts.Config.Lifecycle.URI = ""
+				opts.Config.Lifecycle.Version = "3.4.5"
+				h.AssertNil(t, fakeBuildImage.SetArchitecture("arm64"))
+
+				mockDownloader.EXPECT().Download(
+					gomock.Any(),
+					"https://github.com/buildpacks/lifecycle/releases/download/v3.4.5/lifecycle-v3.4.5+linux.arm64.tgz",
+				).Return(
+					blob.NewBlob(filepath.Join("testdata", "lifecycle", "platform-0.4")), nil,
+				)
+
+				err := subject.CreateBuilder(context.TODO(), opts)
+				h.AssertNil(t, err)
+			})
+
 			when("windows", func() {
 				it("should download from predetermined uri", func() {
 					packClientWithExperimental, err := client.NewClient(
@@ -484,6 +502,28 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 					gomock.Any(),
 					fmt.Sprintf(
 						"https://github.com/buildpacks/lifecycle/releases/download/v%s/lifecycle-v%s+linux.x86-64.tgz",
+						builder.DefaultLifecycleVersion,
+						builder.DefaultLifecycleVersion,
+					),
+				).Return(
+					blob.NewBlob(filepath.Join("testdata", "lifecycle", "platform-0.4")), nil,
+				)
+
+				err := subject.CreateBuilder(context.TODO(), opts)
+				h.AssertNil(t, err)
+			})
+
+			it("should download default lifecycle on arm64", func() {
+				prepareFetcherWithBuildImage()
+				prepareFetcherWithRunImages()
+				opts.Config.Lifecycle.URI = ""
+				opts.Config.Lifecycle.Version = ""
+				h.AssertNil(t, fakeBuildImage.SetArchitecture("arm64"))
+
+				mockDownloader.EXPECT().Download(
+					gomock.Any(),
+					fmt.Sprintf(
+						"https://github.com/buildpacks/lifecycle/releases/download/v%s/lifecycle-v%s+linux.arm64.tgz",
 						builder.DefaultLifecycleVersion,
 						builder.DefaultLifecycleVersion,
 					),


### PR DESCRIPTION
## Summary

This change installs the arm64 lifecycle when creating a builder on an arm64 linux base image. Tests were also added to verify expected behavior.

Unit and acceptance tests were run locally.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

The current behavior is that it always downloads the x86-64 lifecycle.

#### After

I verified the correct behavior by building pack on an arm64 machine and creating a builder on an arm64 stack. See the output from a small script used to test the change below and the correct lifecycle url being used. it also verifies that the lifecycle binary can be executed inside the container.

```
++ git clone -q https://github.com/jpena-r7/pack.git
++ cd pack
++ git checkout --track origin/use-arm64-lifecycle-on-arm64
Branch 'use-arm64-lifecycle-on-arm64' set up to track remote branch 'use-arm64-lifecycle-on-arm64' from 'origin'.
Switched to a new branch 'use-arm64-lifecycle-on-arm64'
++ make build
mkdir out/tests || (exit 0)
> Building...
go build -ldflags "-s -w -X 'github.com/buildpacks/pack.Version=0.0.0+git-b02475c' -extldflags " -trimpath -o ./out/pack -a ./cmd/pack
++ cd ..
++ git clone -q https://github.com/jericop/amazonlinux-builder-buildpackless-base.git
++ ./pack/out/pack builder create amazonlinux-builder:arm --config amazonlinux-builder-buildpackless-base/builder.toml
Warning: builder configuration: empty order definition
base-cnb: Pulling from jericop/amazonlinux-run
Digest: sha256:f4e33a89725f6a9aa47dc28ae36ed32595db78d1eef28155fd75511199eb2238
Status: Image is up to date for jericop/amazonlinux-run:base-cnb
base-cnb: Pulling from jericop/amazonlinux-build
Digest: sha256:d775ff59e9b4a4a8e9e0c2449114fafe5b183be68115263679940c1782984589
Status: Image is up to date for jericop/amazonlinux-build:base-cnb
Downloading from https://github.com/buildpacks/lifecycle/releases/download/v0.14.1/lifecycle-v0.14.1+linux.arm64.tgz
5.17 MB/5.17 MB
Successfully created builder image amazonlinux-builder:arm
Tip: Run pack build <image-name> --builder amazonlinux-builder:arm to use this builder
++ docker run -it --rm --entrypoint /cnb/lifecycle/lifecycle amazonlinux-builder:arm
ERROR: failed to parse arguments
++ pack builder inspect amazonlinux-builder:arm
++ grep -A1 Run
Run Images:
  jericop/amazonlinux-run:base-cnb
++ docker inspect jericop/amazonlinux-run:base-cnb
++ jq '.[].Architecture'
"arm64"
++ arch
aarch64
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1518
