### PR TITLE
Support for `pack build` with extensions (platform 0.10)

### DIFF
--- a/acceptance/testdata/pack_fixtures/report_output.txt
+++ b/acceptance/testdata/pack_fixtures/report_output.txt
@@ -4,7 +4,7 @@ Pack:
 
 Default Lifecycle Version:  0.14.1
 
-Supported Platform APIs:  0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9
+Supported Platform APIs:  0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10
 
 Config:
   default-builder-image = "{{ .DefaultBuilder }}"

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -1876,7 +1876,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			})
 			fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-			err := lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
+			err := lifecycle.Restore(context.Background(), "test", "", fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1892,7 +1892,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			lifecycle := newTestLifecycleExec(t, false, fakes.WithBuilder(fakeBuilder))
 			fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-			err = lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
+			err = lifecycle.Restore(context.Background(), "test", "", fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1908,7 +1908,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			fakePhase := &fakes.FakePhase{}
 			fakePhaseFactory := fakes.NewFakePhaseFactory(fakes.WhichReturnsForNew(fakePhase))
 
-			err := lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
+			err := lifecycle.Restore(context.Background(), "test", "", fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, fakePhase.CleanupCallCount, 1)
@@ -1919,7 +1919,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			lifecycle := newTestLifecycleExec(t, false)
 			fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-			err := lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
+			err := lifecycle.Restore(context.Background(), "test", "", fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1933,7 +1933,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			verboseLifecycle := newTestLifecycleExec(t, true)
 			fakePhaseFactory := fakes.NewFakePhaseFactory()
 
-			err := verboseLifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
+			err := verboseLifecycle.Restore(context.Background(), "test", "", fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1953,7 +1953,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			fakePhaseFactory := fakes.NewFakePhaseFactory()
 			expectedNetworkMode := "some-network-mode"
 
-			err := lifecycle.Restore(context.Background(), expectedNetworkMode, fakeCache, fakePhaseFactory)
+			err := lifecycle.Restore(context.Background(), expectedNetworkMode, "", fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1968,7 +1968,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			fakePhaseFactory := fakes.NewFakePhaseFactory()
 			expectedBind := "some-cache:/cache"
 
-			err := lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
+			err := lifecycle.Restore(context.Background(), "test", "", fakeCache, fakePhaseFactory)
 			h.AssertNil(t, err)
 
 			lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -1994,7 +1994,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				fakePhaseFactory = fakes.NewFakePhaseFactory()
 			})
 			it("configures the phase with a cache image", func() {
-				err := lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
+				err := lifecycle.Restore(context.Background(), "test", "", fakeCache, fakePhaseFactory)
 				h.AssertNil(t, err)
 
 				lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
@@ -2024,7 +2024,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					})
 				})
 				it("configures the phase with the expected arguments", func() {
-					err := lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
+					err := lifecycle.Restore(context.Background(), "test", "", fakeCache, fakePhaseFactory)
 					h.AssertNil(t, err)
 					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
 					h.AssertNotEq(t, lastCallIndex, -1)
@@ -2042,7 +2042,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					})
 				})
 				it("gid is not added to the expected arguments", func() {
-					err := lifecycle.Restore(context.Background(), "test", fakeCache, fakePhaseFactory)
+					err := lifecycle.Restore(context.Background(), "test", "", fakeCache, fakePhaseFactory)
 					h.AssertNil(t, err)
 					lastCallIndex := len(fakePhaseFactory.NewCalledWithProvider) - 1
 					h.AssertNotEq(t, lastCallIndex, -1)

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -28,6 +28,7 @@ var (
 		api.MustParse("0.7"),
 		api.MustParse("0.8"),
 		api.MustParse("0.9"),
+		api.MustParse("0.10"),
 	}
 )
 
@@ -68,6 +69,8 @@ type LifecycleOptions struct {
 	Image              name.Reference
 	Builder            Builder
 	LifecycleImage     string
+	BuildImage         string
+	BuildImageDigest   string
 	RunImage           string
 	ProjectMetadata    platform.ProjectMetadata
 	ClearCache         bool

--- a/internal/build/mount_paths.go
+++ b/internal/build/mount_paths.go
@@ -54,6 +54,10 @@ func (m mountPaths) cacheDir() string {
 	return m.join(m.volume, "cache")
 }
 
+func (m mountPaths) kanikoCacheDir() string {
+	return m.join(m.volume, "kaniko")
+}
+
 func (m mountPaths) launchCacheDir() string {
 	return m.join(m.volume, "launch-cache")
 }

--- a/internal/build/phase_config_provider.go
+++ b/internal/build/phase_config_provider.go
@@ -140,6 +140,9 @@ func WithArgs(args ...string) PhaseConfigProviderOperation {
 
 // WithFlags differs from WithArgs as flags are always prepended
 func WithFlags(flags ...string) PhaseConfigProviderOperation {
+	if len(flags) == 0 {
+		return NullOp()
+	}
 	return func(provider *PhaseConfigProvider) {
 		provider.ctrConf.Cmd = append(flags, provider.ctrConf.Cmd...)
 	}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,1 @@
+package cache

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -40,7 +40,7 @@ import (
 
 //go:generate mockgen -package testmocks -destination ../testmocks/mock_image_fetcher.go github.com/buildpacks/pack/pkg/client ImageFetcher
 
-// ImageFetcher is an interface representing the ability to fetch local and images.
+// ImageFetcher is an interface representing the ability to fetch local and remote images.
 type ImageFetcher interface {
 	// Fetch fetches an image by resolving it both remotely and locally depending on provided parameters.
 	// The pull behavior is dictated by the pullPolicy, which can have the following behavior


### PR DESCRIPTION
When extensions-phase-1 is merged, we can repoint the branch to main.

## Summary
`pack build` should support extensions

## Output
See docs PR which uses this branch: https://github.com/buildpacks/docs/pull/526

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see https://github.com/buildpacks/docs/issues/501
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1469 
