### PR TITLE
Allow Maintainers OR TOC to approve PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @buildpacks/platform-maintainers
-* @buildpacks/toc
+* @buildpacks/platform-maintainers @buildpacks/toc


### PR DESCRIPTION
Per https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file, this file was malformed. It seems like later matches take precedence, and therefore, `TOC` was the only one allowed to approve PRs, and not the `platform-maintainers` team. This fixes that, defining both teams (`TOC` and `platform-maintainers`) as being allowed to review (with an OR)

Signed-off-by: David Freilich <freilich.david@gmail.com>

This resolves a bug introduced by https://github.com/buildpacks/pack/pull/1515