### PR TITLE
Added warning and test for lifecycle under which the builder is trusted

### DIFF
--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -103,6 +103,9 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 			trustBuilder := isTrustedBuilder(cfg, builder) || flags.TrustBuilder
 			if trustBuilder {
 				logger.Debugf("Builder %s is trusted", style.Symbol(builder))
+				if flags.LifecycleImage != "" {
+					logger.Warn("Ignoring the mentioned lifecycle image, going with default version")
+				}
 			} else {
 				logger.Debugf("Builder %s is untrusted", style.Symbol(builder))
 				logger.Debug("As a result, the phases of the lifecycle which require root access will be run in separate trusted ephemeral containers.")

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -104,7 +104,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 			if trustBuilder {
 				logger.Debugf("Builder %s is trusted", style.Symbol(builder))
 				if flags.LifecycleImage != "" {
-					logger.Warn("Ignoring the mentioned lifecycle image, going with default version")
+					logger.Warn("Ignoring the provided lifecycle image as the builder is trusted, running the creator in a single container using the provided builder")
 				}
 			} else {
 				logger.Debugf("Builder %s is untrusted", style.Symbol(builder))

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -90,18 +90,26 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			when("the builder is trusted", func() {
-				it("sets the trust builder option", func() {
+				it.Before(func() {
 					mockClient.EXPECT().
 						Build(gomock.Any(), EqBuildOptionsWithTrustedBuilder(true)).
 						Return(nil)
 
 					cfg := config.Config{TrustedBuilders: []config.TrustedBuilder{{Name: "my-builder"}}}
-					command := commands.Build(logger, cfg, mockClient)
-
+					command = commands.Build(logger, cfg, mockClient)
+				})
+				it("sets the trust builder option", func() {
 					logger.WantVerbose(true)
 					command.SetArgs([]string{"image", "--builder", "my-builder"})
 					h.AssertNil(t, command.Execute())
 					h.AssertContains(t, outBuf.String(), "Builder 'my-builder' is trusted")
+				})
+				when("a lifecycle-image is provided", func() {
+					it("ignoring the mentioned lifecycle image, going with default version", func() {
+						command.SetArgs([]string{"--builder", "my-builder", "image", "--lifecycle-image", "some-lifecycle-image"})
+						h.AssertNil(t, command.Execute())
+						h.AssertContains(t, outBuf.String(), "Warning: Ignoring the mentioned lifecycle image, going with default version")
+					})
 				})
 			})
 

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -108,7 +108,7 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 					it("ignoring the mentioned lifecycle image, going with default version", func() {
 						command.SetArgs([]string{"--builder", "my-builder", "image", "--lifecycle-image", "some-lifecycle-image"})
 						h.AssertNil(t, command.Execute())
-						h.AssertContains(t, outBuf.String(), "Warning: Ignoring the mentioned lifecycle image, going with default version")
+						h.AssertContains(t, outBuf.String(), "Warning: Ignoring the provided lifecycle image as the builder is trusted, running the creator in a single container using the provided builder")
 					})
 				})
 			})


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
Added a warning for `--lifecycle-image` if the builder is trusted. Along with this the test case of this scenario was also added in `./interal/commands/build_test.go` file 

## Output
<!-- If applicable, please provide examples of the output changes. -->
A warning appears while building lifecycle image that since the builder is trusted, it would have the default lifecycle version

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #1540 
