### PR TITLE
Bump default lifecycle from 0.15.1 to 0.15.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,7 @@ jobs:
         id: lifecycle_version
         run: |
           LIFECYCLE_VERSION=$(./pack-linux/pack report | grep 'Default Lifecycle Version:' | grep -o '[^ ]*$')
-          echo "::set-output name=version::$LIFECYCLE_VERSION"
+          echo "version=$LIFECYCLE_VERSION" >> $GITHUB_OUTPUT
       - name: Extract pack help
         id: pack_help
         # Replacements have to do with multiline output.
@@ -257,7 +257,7 @@ jobs:
           PACK_HELP="${PACK_HELP//'%'/'%25'}"
           PACK_HELP="${PACK_HELP//$'\n'/'%0A'}"
           PACK_HELP="${PACK_HELP//$'\r'/'%0D'}"
-          echo "::set-output name=help::$PACK_HELP"
+          echo "help=$PACK_HELP" >> $GITHUB_OUTPUT
       - name: Generate changelog
         uses: ./.github/workflows/actions/release-notes
         id: changelog

--- a/.github/workflows/delivery-archlinux-git.yml
+++ b/.github/workflows/delivery-archlinux-git.yml
@@ -26,9 +26,9 @@ jobs:
           version=$(echo "${git_description}" | awk -F- '{print $(1)}' | sed 's/^v//')
           revision=$(echo "${git_description}" | awk -F- '{print $(NF-1)}')
           commit=$(echo "${git_description}" | awk -F- '{print $(NF)}'  | sed 's/^g//')
-          echo "::set-output name=version::$version"
-          echo "::set-output name=revision::$revision"
-          echo "::set-output name=commit::$commit"
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "revision=$revision" >> $GITHUB_OUTPUT
+          echo "commit=$commit" >> $GITHUB_OUTPUT
       - name: Fill PKGBUILD
         uses: cschleiden/replace-tokens@v1
         with:

--- a/.github/workflows/delivery-archlinux.yml
+++ b/.github/workflows/delivery-archlinux.yml
@@ -45,8 +45,8 @@ jobs:
 
           curl -sSL "$url" -o "$fullpath"
           sha512=$(sha512sum "$fullpath" | awk '{ print $1 }')
-          echo "::set-output name=url::$url"
-          echo "::set-output name=sha512::$sha512"
+          echo "url=$url" >> $GITHUB_OUTPUT
+          echo "sha512=$sha512" >> $GITHUB_OUTPUT
       - name: Fill PKGBUILD
         uses: cschleiden/replace-tokens@v1
         with:
@@ -120,9 +120,8 @@ jobs:
         run: |
           curl -sSL ${{ steps.assets.outputs.linux_url }} -o ${{ steps.assets.outputs.linux_name }}
           sha512=$(sha512sum ${{ steps.assets.outputs.linux_name }} | cut -d ' ' -f1)
-
-          echo "::set-output name=url::${{ steps.assets.outputs.linux_url }}"
-          echo "::set-output name=sha512::$sha512"
+          echo "url=${{ steps.assets.outputs.linux_url }}" >> $GITHUB_OUTPUT
+          echo "sha512=$sha512" >> $GITHUB_OUTPUT
       - name: Fill PKGBUILD
         uses: cschleiden/replace-tokens@v1
         with:

--- a/.github/workflows/delivery-homebrew.yml
+++ b/.github/workflows/delivery-homebrew.yml
@@ -65,15 +65,15 @@ jobs:
         run: |
           curl -sSL ${{ steps.assets.outputs.linux_url }} -o ${{ steps.assets.outputs.linux_name }}
           linux_sha256=$(sha256sum ${{ steps.assets.outputs.linux_name }} | cut -d ' ' -f1)
-          echo "::set-output name=linux_sha256::$linux_sha256"
+          echo "linux_sha256=$linux_sha256" >> $GITHUB_OUTPUT
 
           curl -sSL ${{ steps.assets.outputs.macos_url }} -o ${{ steps.assets.outputs.macos_name }}
           macos_sha256=$(sha256sum ${{ steps.assets.outputs.macos_name }} | cut -d ' ' -f1)
-          echo "::set-output name=macos_sha256::$macos_sha256"
+          echo "macos_sha256=$macos_sha256" >> $GITHUB_OUTPUT
 
           curl -sSL ${{ steps.assets.outputs.macos_arm64_url }} -o ${{ steps.assets.outputs.macos_arm64_name }}
           macos_arm64_sha256=$(sha256sum ${{ steps.assets.outputs.macos_arm64_name }} | cut -d ' ' -f1)
-          echo "::set-output name=macos_arm64_sha256::$macos_arm64_sha256"
+          echo "macos_arm64_sha256=$macos_arm64_sha256" >> $GITHUB_OUTPUT
       - name: Fill pack.rb
         uses: cschleiden/replace-tokens@v1
         with:

--- a/.github/workflows/delivery-ubuntu.yml
+++ b/.github/workflows/delivery-ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
           - name: Metadata
             id: metadata
             run: |
-                echo "::set-output name=date::$(date +"%a, %d %b %Y %T %z")"
+                echo "date=$(date +"%a, %d %b %Y %T %z")" >> $GITHUB_OUTPUT
 
           - name: Determine version
             uses: actions/github-script@v6

--- a/acceptance/testdata/pack_fixtures/report_output.txt
+++ b/acceptance/testdata/pack_fixtures/report_output.txt
@@ -2,7 +2,7 @@ Pack:
   Version:  {{ .Version }}
   OS/Arch:  {{ .OS }}/{{ .Arch }}
 
-Default Lifecycle Version:  0.15.1
+Default Lifecycle Version:  0.15.2
 
 Supported Platform APIs:  0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10
 

--- a/internal/builder/lifecycle.go
+++ b/internal/builder/lifecycle.go
@@ -14,7 +14,7 @@ import (
 
 // A snapshot of the latest tested lifecycle version values
 const (
-	DefaultLifecycleVersion    = "0.15.1"
+	DefaultLifecycleVersion    = "0.15.2"
 	DefaultBuildpackAPIVersion = "0.2"
 )
 
@@ -24,6 +24,7 @@ type Blob interface {
 }
 
 // Lifecycle is an implementation of the CNB Lifecycle spec
+//
 //go:generate mockgen -package testmocks -destination testmocks/mock_lifecycle.go github.com/buildpacks/pack/internal/builder Lifecycle
 type Lifecycle interface {
 	Blob

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -1866,7 +1866,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.PullPolicy, image.PullNever)
 
-					args = fakeImageFetcher.FetchCalls["buildpacksio/lifecycle:0.15.1"]
+					args = fakeImageFetcher.FetchCalls[fmt.Sprintf("%s:%s", cfg.DefaultLifecycleImageRepo, builder.DefaultLifecycleVersion)]
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.PullPolicy, image.PullNever)
 					h.AssertEq(t, args.Platform, "linux/amd64")


### PR DESCRIPTION
This will pick up a small bugfix for builds with image extensions

@dfreilich it would be awesome to pull this into 0.28.0. Given the nature of the change, I don't think this requires a new RC, but up to you.
