### PR TITLE
Pin chocolatey action version

### DIFF
--- a/.github/workflows/delivery-chocolatey.yml
+++ b/.github/workflows/delivery-chocolatey.yml
@@ -67,7 +67,7 @@ jobs:
           cp LICENSE $file
           cat $file
       - name: build-release
-        uses: crazy-max/ghaction-chocolatey@v2
+        uses: crazy-max/ghaction-chocolatey@v2.0.0
         with:
           args: pack ${{ env.CHOCO_PATH }}/pack.nuspec --outputdirectory ${{ env.CHOCO_PATH}}
       - name: list files
@@ -75,12 +75,12 @@ jobs:
           ls ${{ env.CHOCO_PATH }}
           ls ${{ env.CHOCO_PATH }}/tools
       - name: Test Release
-        uses: crazy-max/ghaction-chocolatey@v2
+        uses: crazy-max/ghaction-chocolatey@v2.0.0
         with:
           args: install pack -s ${{ env.CHOCO_PATH }}/pack.${{ env.PACK_VERSION }}.nupkg
       - name: Ensure Pack Installed
         run: pack help
       - name: Upload Release
-        uses: crazy-max/ghaction-chocolatey@v2
+        uses: crazy-max/ghaction-chocolatey@v2.0.0
         with:
           args: push ${{ env.CHOCO_PATH }}/pack.${{ env.PACK_VERSION }}.nupkg -s https://push.chocolatey.org/ -k ${{ secrets.CHOCO_KEY }}


### PR DESCRIPTION
Signed-off-by: David Freilich <david.freilich@appsflyer.com>

## Summary
<!-- Provide a high-level summary of the change. -->
[This action](https://github.com/buildpacks/pack/actions/runs/3632622132) is failing, with the error: 
```
Attempting to push pack.0.28.0.nupkg to https://push.chocolatey.org/
  Failed to process request. 'Gateway Timeout'. 
  The remote server returned an error: (504) Gateway Timeout..
```

I don't know what changed with the action, but I'm assuming that the regression was introduced in the [v2.1.0 release](https://github.com/crazy-max/ghaction-chocolatey/releases/tag/v2.1.0). This pins our version to a prior release until they fix it. 