### PR TITLE
add Extensions (no DetectionOrder yet)

### DIFF
--- a/internal/builder/inspect.go
+++ b/internal/builder/inspect.go
@@ -22,6 +22,7 @@ type Info struct {
 	BuildpackLayers dist.ModuleLayers
 	Lifecycle       LifecycleDescriptor
 	CreatedBy       CreatorMetadata
+	Extensions      []dist.ModuleInfo
 }
 
 type Inspectable interface {
@@ -127,6 +128,7 @@ func (i *Inspector) Inspect(name string, daemon bool, orderDetectionDepth int) (
 		BuildpackLayers: layers,
 		Lifecycle:       lifecycle,
 		CreatedBy:       metadata.CreatedBy,
+		Extensions:      metadata.Extensions,
 	}, nil
 }
 

--- a/internal/builder/writer/human_readable_test.go
+++ b/internal/builder/writer/human_readable_test.go
@@ -86,6 +86,14 @@ Detection Order:
  │  │           └ test.bp.one@test.bp.one.version    (optional)[cyclic]
  │  └ test.bp.two@test.bp.two.version                (optional)
  └ test.bp.three@test.bp.three.version
+
+Extensions:
+  ID                     NAME        VERSION                        HOMEPAGE
+  test.top.nested        -           test.top.nested.version        -
+  test.nested            -                                          http://geocities.com/top-bp
+  test.bp.one            -           test.bp.one.version            http://geocities.com/cool-bp
+  test.bp.two            -           test.bp.two.version            -
+  test.bp.three          -           test.bp.three.version          -
 `
 
 		expectedLocalOutput = `
@@ -139,6 +147,14 @@ Detection Order:
  │  │           └ test.bp.one@test.bp.one.version    (optional)[cyclic]
  │  └ test.bp.two@test.bp.two.version                (optional)
  └ test.bp.three@test.bp.three.version
+
+Extensions:
+  ID                     NAME        VERSION                        HOMEPAGE
+  test.top.nested        -           test.top.nested.version        -
+  test.nested            -                                          http://geocities.com/top-bp
+  test.bp.one            -           test.bp.one.version            http://geocities.com/cool-bp
+  test.bp.two            -           test.bp.two.version            -
+  test.bp.three          -           test.bp.three.version          -
 `
 		expectedVerboseStack = `
 Stack:
@@ -185,6 +201,7 @@ REMOTE:
 				RunImageMirrors: []string{"first/default", "second/default"},
 				Buildpacks:      buildpacks,
 				Order:           order,
+				Extensions:      buildpacks,
 				BuildpackLayers: dist.ModuleLayers{},
 				Lifecycle: builder.LifecycleDescriptor{
 					Info: builder.LifecycleInfo{
@@ -217,6 +234,7 @@ REMOTE:
 				RunImageMirrors: []string{"first/local-default", "second/local-default"},
 				Buildpacks:      buildpacks,
 				Order:           order,
+				Extensions:      buildpacks,
 				BuildpackLayers: dist.ModuleLayers{},
 				Lifecycle: builder.LifecycleDescriptor{
 					Info: builder.LifecycleInfo{

--- a/pkg/client/inspect_builder.go
+++ b/pkg/client/inspect_builder.go
@@ -48,6 +48,10 @@ type BuilderInfo struct {
 	// Name and Version information from tooling used
 	// to produce this builder.
 	CreatedBy builder.CreatorMetadata
+
+	// Extension (metadata?) included with builder image
+	// to be displayed in cmd line
+	Extensions []dist.ModuleInfo
 }
 
 // BuildpackInfoKey contains all information needed to determine buildpack equivalence.
@@ -102,5 +106,6 @@ func (c *Client) InspectBuilder(name string, daemon bool, modifiers ...BuilderIn
 		BuildpackLayers: info.BuildpackLayers,
 		Lifecycle:       info.Lifecycle,
 		CreatedBy:       info.CreatedBy,
+		Extensions:      info.Extensions,
 	}, nil
 }


### PR DESCRIPTION
## Summary
Adding Extensions section to the output of `pack builder inspect`

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
(picked from Unit test output to confirm output format)
```
REMOTE:

Description: Some remote description

Created By:
  Name: Pack CLI
  Version: 1.2.3

Trusted: No

Stack:
  ID: test.stack.id

Lifecycle:
  Version: 6.7.8
  Buildpack APIs:
    Deprecated: (none)
    Supported: 1.2, 2.3
  Platform APIs:
    Deprecated: 0.1, 1.2
    Supported: 4.5

Run Images:
  first/local     (user-configured)
  second/local    (user-configured)
  some/run-image
  first/default
  second/default

Buildpacks:
  ID                     NAME        VERSION                        HOMEPAGE
  test.top.nested        -           test.top.nested.version        -
  test.nested            -                                          http://geocities.com/top-bp
  test.bp.one            -           test.bp.one.version            http://geocities.com/cool-bp
  test.bp.two            -           test.bp.two.version            -
  test.bp.three          -           test.bp.three.version          -

Detection Order:
 ├ Group #1:
 │  ├ test.top.nested@test.top.nested.version
 │  │  └ Group #1:
 │  │     ├ test.nested
 │  │     │  └ Group #1:
 │  │     │     └ test.bp.one@test.bp.one.version      (optional)
 │  │     ├ test.bp.three@test.bp.three.version        (optional)
 │  │     └ test.nested.two@test.nested.two.version
 │  │        └ Group #2:
 │  │           └ test.bp.one@test.bp.one.version    (optional)[cyclic]
 │  └ test.bp.two@test.bp.two.version                (optional)
 └ test.bp.three@test.bp.three.version
```
#### After

(picked from Unit test output to confirm output format)
```
REMOTE:

Description: Some remote description

Created By:
  Name: Pack CLI
  Version: 1.2.3

Trusted: No

Stack:
  ID: test.stack.id

Lifecycle:
  Version: 6.7.8
  Buildpack APIs:
    Deprecated: (none)
    Supported: 1.2, 2.3
  Platform APIs:
    Deprecated: 0.1, 1.2
    Supported: 4.5

Run Images:
  first/local     (user-configured)
  second/local    (user-configured)
  some/run-image
  first/default
  second/default

Buildpacks:
  ID                     NAME        VERSION                        HOMEPAGE
  test.top.nested        -           test.top.nested.version        -
  test.nested            -                                          http://geocities.com/top-bp
  test.bp.one            -           test.bp.one.version            http://geocities.com/cool-bp
  test.bp.two            -           test.bp.two.version            -
  test.bp.three          -           test.bp.three.version          -

Detection Order:
 ├ Group #1:
 │  ├ test.top.nested@test.top.nested.version
 │  │  └ Group #1:
 │  │     ├ test.nested
 │  │     │  └ Group #1:
 │  │     │     └ test.bp.one@test.bp.one.version      (optional)
 │  │     ├ test.bp.three@test.bp.three.version        (optional)
 │  │     └ test.nested.two@test.nested.two.version
 │  │        └ Group #2:
 │  │           └ test.bp.one@test.bp.one.version    (optional)[cyclic]
 │  └ test.bp.two@test.bp.two.version                (optional)
 └ test.bp.three@test.bp.three.version

Extensions:
  ID                     NAME        VERSION                        HOMEPAGE
  test.top.nested        -           test.top.nested.version        -
  test.nested            -                                          http://geocities.com/top-bp
  test.bp.one            -           test.bp.one.version            http://geocities.com/cool-bp
  test.bp.two            -           test.bp.two.version            -
  test.bp.three          -           test.bp.three.version          -
```


## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and the link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x ] Yes, see buildpacks/spec #316
    - [ ] No

## Related
#1488 
#1478 

Resolves #1488 
