### PR TITLE
Preserves test output for easier grepping

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,11 +55,15 @@ To run unit and integration tests:
 ```shell
 make unit
 ```
+Test output will be streamed to your terminal and also saved to the file
+out/unit
 
 To run acceptance tests:
 ```shell
 make acceptance
 ```
+Test output will be streamed to your terminal and also saved to the file
+out/acceptance
 
 Alternately, to run all tests:
 ```shell

--- a/Makefile
+++ b/Makefile
@@ -105,16 +105,16 @@ unit: GOTESTFLAGS:=$(GOTESTFLAGS) --tags=example
 endif
 unit: out
 	@echo "> Running unit/integration tests..."
-	$(GOCMD) test $(GOTESTFLAGS) -timeout=$(UNIT_TIMEOUT) ./...
+	$(GOCMD) test $(GOTESTFLAGS) -timeout=$(UNIT_TIMEOUT) ./... | tee out/unit
 
 acceptance: out
 	@echo "> Running acceptance tests..."
-	$(GOCMD) test $(GOTESTFLAGS) -timeout=$(ACCEPTANCE_TIMEOUT) -tags=acceptance ./acceptance
+	$(GOCMD) test $(GOTESTFLAGS) -timeout=$(ACCEPTANCE_TIMEOUT) -tags=acceptance ./acceptance | tee out/acceptance
 
 acceptance-all: export ACCEPTANCE_SUITE_CONFIG:=$(shell $(CAT) .$/acceptance$/testconfig$/all.json)
 acceptance-all:
 	@echo "> Running acceptance tests..."
-	$(GOCMD) test $(GOTESTFLAGS) -timeout=$(ACCEPTANCE_TIMEOUT) -tags=acceptance ./acceptance
+	$(GOCMD) test $(GOTESTFLAGS) -timeout=$(ACCEPTANCE_TIMEOUT) -tags=acceptance ./acceptance | tee out/acceptance
 
 clean:
 	@echo "> Cleaning workspace..."


### PR DESCRIPTION
Signed-off-by: Joe Kimmel <jkimmel@vmware.com>

## Summary
in addition to printing to the terminal test output now gets written a file.
that file is not version controlled.

## Output
<!-- If applicable, please provide examples of the output changes. -->
```
> make unit
[output omitted for brevity]
> ls out 
tests unit
```
above `unit` is a file.  
Other names I thought about included `unit.txt` or `unit.out`. - happy to change filenames if there's any opinions out there.

#### Before
If the tests failed, you had to scroll up in your terminal and use your human eyeballs to find the failure

#### After
If the tests fail you can point your favorite grep-like utility at the saved test output to find the failure

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
