### PR TITLE
Add Github token to tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,8 @@ jobs:
       - name: Test
         env:
           TEST_COVERAGE: 1
-        run: make test
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make test       
       - name: Upload Coverage
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
injecting the Github Token should help ensure that tests, particular the wcow test, don't fail for issues with pulling Github artifacts

Signed-off-by: David Freilich <freilich.david@gmail.com>
