### PR TITLE
build: update to golang 1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - name: Set up go env for Unix
         if: runner.os != 'Windows'
         run: |
@@ -178,7 +178,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - name: Build
         run: |
           [[ $GITHUB_REF =~ ^refs\/heads\/release/(.*)$ ]] && version=${BASH_REMATCH[1]} || version=0.0.0

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - name: Set up go env
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ install:
 	cp ./out/$(PACK_BIN) ${DESTDIR}${BINDIR}/
 
 mod-tidy:
-	$(GOCMD) mod tidy  -compat=1.18
-	cd tools && $(GOCMD) mod tidy -compat=1.18
+	$(GOCMD) mod tidy  -compat=1.19
+	cd tools && $(GOCMD) mod tidy -compat=1.19
 
 tidy: mod-tidy format
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -177,7 +176,7 @@ func testWithoutSpecificBuilderRequirement(
 
 			it.Before(func() {
 				var err error
-				tmpDir, err = ioutil.TempDir("", "buildpack-package-tests")
+				tmpDir, err = os.MkdirTemp("", "buildpack-package-tests")
 				assert.Nil(err)
 
 				buildpackManager = buildpacks.NewBuildModuleManager(t, assert)
@@ -188,9 +187,9 @@ func testWithoutSpecificBuilderRequirement(
 				assert.Nil(os.RemoveAll(tmpDir))
 			})
 
-			generateAggregatePackageToml := func(buildpackURI, nestedPackageName, os string) string {
+			generateAggregatePackageToml := func(buildpackURI, nestedPackageName, operatingSystem string) string {
 				t.Helper()
-				packageTomlFile, err := ioutil.TempFile(tmpDir, "package_aggregate-*.toml")
+				packageTomlFile, err := os.CreateTemp(tmpDir, "package_aggregate-*.toml")
 				assert.Nil(err)
 
 				pack.FixtureManager().TemplateFixtureToFile(
@@ -199,7 +198,7 @@ func testWithoutSpecificBuilderRequirement(
 					map[string]interface{}{
 						"BuildpackURI": buildpackURI,
 						"PackageName":  nestedPackageName,
-						"OS":           os,
+						"OS":           operatingSystem,
 					},
 				)
 
@@ -402,7 +401,7 @@ func testWithoutSpecificBuilderRequirement(
 
 			it.Before(func() {
 				var err error
-				tmpDir, err = ioutil.TempDir("", "buildpack-inspect-tests")
+				tmpDir, err = os.MkdirTemp("", "buildpack-inspect-tests")
 				assert.Nil(err)
 			})
 
@@ -1159,7 +1158,7 @@ func testAcceptance(
 							h.SkipIf(t, imageManager.HostOS() == "windows", "temporarily disabled on WCOW due to CI flakiness")
 
 							var err error
-							tmpDir, err = ioutil.TempDir("", "archive-buildpacks-")
+							tmpDir, err = os.MkdirTemp("", "archive-buildpacks-")
 							assert.Nil(err)
 
 							buildpackManager.PrepareBuildModules(tmpDir, buildpacks.BpInternetCapable)
@@ -1229,12 +1228,12 @@ func testAcceptance(
 							}
 
 							var err error
-							tmpDir, err = ioutil.TempDir("", "volume-buildpack-tests-")
+							tmpDir, err = os.MkdirTemp("", "volume-buildpack-tests-")
 							assert.Nil(err)
 
 							buildpackManager.PrepareBuildModules(tmpDir, buildpacks.BpReadVolume, buildpacks.BpReadWriteVolume)
 
-							tmpVolumeSrc, err = ioutil.TempDir("", "volume-mount-source")
+							tmpVolumeSrc, err = os.MkdirTemp("", "volume-mount-source")
 							assert.Nil(err)
 							assert.Succeeds(os.Chmod(tmpVolumeSrc, 0777)) // Override umask
 
@@ -1243,7 +1242,7 @@ func testAcceptance(
 							tmpVolumeSrc, err = filepath.EvalSymlinks(tmpVolumeSrc)
 							assert.Nil(err)
 
-							err = ioutil.WriteFile(filepath.Join(tmpVolumeSrc, "some-file"), []byte("some-content\n"), 0777)
+							err = os.WriteFile(filepath.Join(tmpVolumeSrc, "some-file"), []byte("some-content\n"), 0777)
 							assert.Nil(err)
 						})
 
@@ -1354,7 +1353,7 @@ func testAcceptance(
 
 							it.Before(func() {
 								var err error
-								tmpDir, err = ioutil.TempDir("", "archive-buildpack-tests-")
+								tmpDir, err = os.MkdirTemp("", "archive-buildpack-tests-")
 								assert.Nil(err)
 							})
 
@@ -1385,7 +1384,7 @@ func testAcceptance(
 
 							it.Before(func() {
 								var err error
-								tmpDir, err = ioutil.TempDir("", "folder-buildpack-tests-")
+								tmpDir, err = os.MkdirTemp("", "folder-buildpack-tests-")
 								assert.Nil(err)
 							})
 
@@ -1465,7 +1464,7 @@ func testAcceptance(
 
 							it.Before(func() {
 								var err error
-								tmpDir, err = ioutil.TempDir("", "package-file")
+								tmpDir, err = os.MkdirTemp("", "package-file")
 								assert.Nil(err)
 							})
 
@@ -1542,7 +1541,7 @@ func testAcceptance(
 						var envPath string
 
 						it.Before(func() {
-							envfile, err := ioutil.TempFile("", "envfile")
+							envfile, err := os.CreateTemp("", "envfile")
 							assert.Nil(err)
 							defer envfile.Close()
 
@@ -1910,7 +1909,7 @@ func testAcceptance(
 						it.Before(func() {
 							h.SkipIf(t, !pack.SupportsFeature(invoke.Cache), "")
 							cacheBindName := fmt.Sprintf("%s-bind", repoName)
-							bindCacheDir, err := ioutil.TempDir("", cacheBindName)
+							bindCacheDir, err := os.MkdirTemp("", cacheBindName)
 							assert.Nil(err)
 							cacheFlags = fmt.Sprintf("type=build;format=bind;source=%s", bindCacheDir)
 						})
@@ -1957,10 +1956,10 @@ func testAcceptance(
 								h.SkipIf(t, runtime.GOOS == "windows", "buildpack directories not supported on windows")
 
 								var err error
-								tempAppDir, err = ioutil.TempDir("", "descriptor-app")
+								tempAppDir, err = os.MkdirTemp("", "descriptor-app")
 								assert.Nil(err)
 
-								tempWorkingDir, err = ioutil.TempDir("", "descriptor-app")
+								tempWorkingDir, err = os.MkdirTemp("", "descriptor-app")
 								assert.Nil(err)
 
 								origWorkingDir, err = os.Getwd()
@@ -1979,14 +1978,14 @@ func testAcceptance(
 
 								err = os.Mkdir(filepath.Join(tempAppDir, "media"), 0755)
 								assert.Nil(err)
-								err = ioutil.WriteFile(filepath.Join(tempAppDir, "media", "mountain.jpg"), []byte("fake image bytes"), 0755)
+								err = os.WriteFile(filepath.Join(tempAppDir, "media", "mountain.jpg"), []byte("fake image bytes"), 0755)
 								assert.Nil(err)
-								err = ioutil.WriteFile(filepath.Join(tempAppDir, "media", "person.png"), []byte("fake image bytes"), 0755)
+								err = os.WriteFile(filepath.Join(tempAppDir, "media", "person.png"), []byte("fake image bytes"), 0755)
 								assert.Nil(err)
 
-								err = ioutil.WriteFile(filepath.Join(tempAppDir, "cookie.jar"), []byte("chocolate chip"), 0755)
+								err = os.WriteFile(filepath.Join(tempAppDir, "cookie.jar"), []byte("chocolate chip"), 0755)
 								assert.Nil(err)
-								err = ioutil.WriteFile(filepath.Join(tempAppDir, "test.sh"), []byte("echo test"), 0755)
+								err = os.WriteFile(filepath.Join(tempAppDir, "test.sh"), []byte("echo test"), 0755)
 								assert.Nil(err)
 
 								projectToml := `
@@ -2001,7 +2000,7 @@ exclude = [ "*.sh", "media/person.png", "descriptor-buildpack" ]
 uri = "descriptor-buildpack"
 `
 								excludeDescriptorPath := filepath.Join(tempAppDir, "project.toml")
-								err = ioutil.WriteFile(excludeDescriptorPath, []byte(projectToml), 0755)
+								err = os.WriteFile(excludeDescriptorPath, []byte(projectToml), 0755)
 								assert.Nil(err)
 
 								// set working dir to be outside of the app we are building
@@ -2033,7 +2032,7 @@ uri = "descriptor-buildpack"
 								buildpackTgz = h.CreateTGZ(t, filepath.Join(bpDir, "descriptor-buildpack"), "./", 0755)
 
 								var err error
-								tempAppDir, err = ioutil.TempDir("", "descriptor-app")
+								tempAppDir, err = os.MkdirTemp("", "descriptor-app")
 								assert.Nil(err)
 
 								// Create test directories and files:
@@ -2053,32 +2052,32 @@ uri = "descriptor-buildpack"
 
 								err = os.Mkdir(filepath.Join(tempAppDir, "secrets"), 0755)
 								assert.Nil(err)
-								err = ioutil.WriteFile(filepath.Join(tempAppDir, "secrets", "api_keys.json"), []byte("{}"), 0755)
+								err = os.WriteFile(filepath.Join(tempAppDir, "secrets", "api_keys.json"), []byte("{}"), 0755)
 								assert.Nil(err)
-								err = ioutil.WriteFile(filepath.Join(tempAppDir, "secrets", "user_token"), []byte("token"), 0755)
+								err = os.WriteFile(filepath.Join(tempAppDir, "secrets", "user_token"), []byte("token"), 0755)
 								assert.Nil(err)
 
 								err = os.Mkdir(filepath.Join(tempAppDir, "nested"), 0755)
 								assert.Nil(err)
-								err = ioutil.WriteFile(filepath.Join(tempAppDir, "nested", "nested-cookie.jar"), []byte("chocolate chip"), 0755)
+								err = os.WriteFile(filepath.Join(tempAppDir, "nested", "nested-cookie.jar"), []byte("chocolate chip"), 0755)
 								assert.Nil(err)
 
-								err = ioutil.WriteFile(filepath.Join(tempAppDir, "other-cookie.jar"), []byte("chocolate chip"), 0755)
+								err = os.WriteFile(filepath.Join(tempAppDir, "other-cookie.jar"), []byte("chocolate chip"), 0755)
 								assert.Nil(err)
 
-								err = ioutil.WriteFile(filepath.Join(tempAppDir, "nested-cookie.jar"), []byte("chocolate chip"), 0755)
+								err = os.WriteFile(filepath.Join(tempAppDir, "nested-cookie.jar"), []byte("chocolate chip"), 0755)
 								assert.Nil(err)
 
 								err = os.Mkdir(filepath.Join(tempAppDir, "media"), 0755)
 								assert.Nil(err)
-								err = ioutil.WriteFile(filepath.Join(tempAppDir, "media", "mountain.jpg"), []byte("fake image bytes"), 0755)
+								err = os.WriteFile(filepath.Join(tempAppDir, "media", "mountain.jpg"), []byte("fake image bytes"), 0755)
 								assert.Nil(err)
-								err = ioutil.WriteFile(filepath.Join(tempAppDir, "media", "person.png"), []byte("fake image bytes"), 0755)
+								err = os.WriteFile(filepath.Join(tempAppDir, "media", "person.png"), []byte("fake image bytes"), 0755)
 								assert.Nil(err)
 
-								err = ioutil.WriteFile(filepath.Join(tempAppDir, "cookie.jar"), []byte("chocolate chip"), 0755)
+								err = os.WriteFile(filepath.Join(tempAppDir, "cookie.jar"), []byte("chocolate chip"), 0755)
 								assert.Nil(err)
-								err = ioutil.WriteFile(filepath.Join(tempAppDir, "test.sh"), []byte("echo test"), 0755)
+								err = os.WriteFile(filepath.Join(tempAppDir, "test.sh"), []byte("echo test"), 0755)
 								assert.Nil(err)
 							})
 
@@ -2096,7 +2095,7 @@ type = "MIT"
 exclude = [ "*.sh", "secrets/", "media/metadata", "/other-cookie.jar" ,"/nested-cookie.jar"]
 `
 								excludeDescriptorPath := filepath.Join(tempAppDir, "exclude.toml")
-								err := ioutil.WriteFile(excludeDescriptorPath, []byte(projectToml), 0755)
+								err := os.WriteFile(excludeDescriptorPath, []byte(projectToml), 0755)
 								assert.Nil(err)
 
 								output := pack.RunSuccessfully(
@@ -2127,7 +2126,7 @@ type = "MIT"
 include = [ "*.jar", "media/mountain.jpg", "/media/person.png", ]
 `
 								includeDescriptorPath := filepath.Join(tempAppDir, "include.toml")
-								err := ioutil.WriteFile(includeDescriptorPath, []byte(projectToml), 0755)
+								err := os.WriteFile(includeDescriptorPath, []byte(projectToml), 0755)
 								assert.Nil(err)
 
 								output := pack.RunSuccessfully(
@@ -2694,7 +2693,7 @@ func createComplexBuilder(t *testing.T,
 	t.Log("creating complex builder image...")
 
 	// CREATE TEMP WORKING DIR
-	tmpDir, err := ioutil.TempDir("", "create-complex-test-builder")
+	tmpDir, err := os.MkdirTemp("", "create-complex-test-builder")
 	if err != nil {
 		return "", err
 	}
@@ -2726,7 +2725,7 @@ func createComplexBuilder(t *testing.T,
 
 	fixtureManager := pack.FixtureManager()
 
-	nestedLevelOneConfigFile, err := ioutil.TempFile(tmpDir, "nested-level-1-package.toml")
+	nestedLevelOneConfigFile, err := os.CreateTemp(tmpDir, "nested-level-1-package.toml")
 	assert.Nil(err)
 	fixtureManager.TemplateFixtureToFile(
 		"nested-level-1-buildpack_package.toml",
@@ -2736,7 +2735,7 @@ func createComplexBuilder(t *testing.T,
 	err = nestedLevelOneConfigFile.Close()
 	assert.Nil(err)
 
-	nestedLevelTwoConfigFile, err := ioutil.TempFile(tmpDir, "nested-level-2-package.toml")
+	nestedLevelTwoConfigFile, err := os.CreateTemp(tmpDir, "nested-level-2-package.toml")
 	assert.Nil(err)
 	fixtureManager.TemplateFixtureToFile(
 		"nested-level-2-buildpack_package.toml",
@@ -2803,7 +2802,7 @@ func createComplexBuilder(t *testing.T,
 	}
 
 	// RENDER builder.toml
-	builderConfigFile, err := ioutil.TempFile(tmpDir, "nested_builder.toml")
+	builderConfigFile, err := os.CreateTemp(tmpDir, "nested_builder.toml")
 	if err != nil {
 		return "", err
 	}
@@ -2842,7 +2841,7 @@ func createBuilder(
 	t.Log("creating builder image...")
 
 	// CREATE TEMP WORKING DIR
-	tmpDir, err := ioutil.TempDir("", "create-test-builder")
+	tmpDir, err := os.MkdirTemp("", "create-test-builder")
 	assert.Nil(err)
 	defer os.RemoveAll(tmpDir)
 
@@ -2894,7 +2893,7 @@ func createBuilder(
 	// RENDER builder.toml
 	configFileName := "builder.toml"
 
-	builderConfigFile, err := ioutil.TempFile(tmpDir, "builder.toml")
+	builderConfigFile, err := os.CreateTemp(tmpDir, "builder.toml")
 	assert.Nil(err)
 
 	pack.FixtureManager().TemplateFixtureToFile(
@@ -2933,7 +2932,7 @@ func createBuilderWithExtensions(
 	t.Log("creating builder image with extensions...")
 
 	// CREATE TEMP WORKING DIR
-	tmpDir, err := ioutil.TempDir("", "create-test-builder-extensions")
+	tmpDir, err := os.MkdirTemp("", "create-test-builder-extensions")
 	assert.Nil(err)
 	defer os.RemoveAll(tmpDir)
 
@@ -2971,7 +2970,7 @@ func createBuilderWithExtensions(
 	// RENDER builder.toml
 	configFileName := "builder_extensions.toml"
 
-	builderConfigFile, err := ioutil.TempFile(tmpDir, "builder.toml")
+	builderConfigFile, err := os.CreateTemp(tmpDir, "builder.toml")
 	assert.Nil(err)
 
 	pack.FixtureManager().TemplateFixtureToFile(
@@ -3012,7 +3011,7 @@ func generatePackageTomlWithOS(
 ) string {
 	t.Helper()
 
-	packageTomlFile, err := ioutil.TempFile(tmpDir, "package-*.toml")
+	packageTomlFile, err := os.CreateTemp(tmpDir, "package-*.toml")
 	assert.Nil(err)
 
 	pack.FixtureManager().TemplateFixtureToFile(

--- a/acceptance/buildpacks/archive_buildpack.go
+++ b/acceptance/buildpacks/archive_buildpack.go
@@ -7,7 +7,6 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -54,7 +53,7 @@ func (a archiveBuildModule) FullPathIn(parentFolder string) string {
 }
 
 func (a archiveBuildModule) createTgz(sourceDir string) (string, error) {
-	tempFile, err := ioutil.TempFile("", "*.tgz")
+	tempFile, err := os.CreateTemp("", "*.tgz")
 	if err != nil {
 		return "", errors.Wrap(err, "creating temporary archive")
 	}

--- a/acceptance/buildpacks/package_file_buildpack.go
+++ b/acceptance/buildpacks/package_file_buildpack.go
@@ -6,7 +6,6 @@ package buildpacks
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,7 +53,7 @@ func (p PackageFile) Prepare(sourceDir, _ string) error {
 	p.testObject.Helper()
 	p.testObject.Log("creating package file from:", sourceDir)
 
-	tmpDir, err := ioutil.TempDir("", "package-buildpacks")
+	tmpDir, err := os.MkdirTemp("", "package-buildpacks")
 	if err != nil {
 		return fmt.Errorf("creating temp dir for package buildpacks: %w", err)
 	}

--- a/acceptance/buildpacks/package_image_buildpack.go
+++ b/acceptance/buildpacks/package_image_buildpack.go
@@ -5,7 +5,6 @@ package buildpacks
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -58,7 +57,7 @@ func (p PackageImage) Prepare(sourceDir, _ string) error {
 	p.testObject.Helper()
 	p.testObject.Log("creating package image from:", sourceDir)
 
-	tmpDir, err := ioutil.TempDir("", "package-buildpacks")
+	tmpDir, err := os.MkdirTemp("", "package-buildpacks")
 	if err != nil {
 		return fmt.Errorf("creating temp dir for package buildpacks: %w", err)
 	}

--- a/acceptance/config/asset_manager.go
+++ b/acceptance/config/asset_manager.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -248,7 +247,7 @@ func (b assetManagerBuilder) ensurePreviousPackFixtures() string {
 	sourceDir, err := b.githubAssetFetcher.FetchReleaseSource("buildpacks", "pack", version)
 	b.assert.Nil(err)
 
-	sourceDirFiles, err := ioutil.ReadDir(sourceDir)
+	sourceDirFiles, err := os.ReadDir(sourceDir)
 	b.assert.Nil(err)
 	// GitHub source tarballs have a top-level directory whose name includes the current commit sha.
 	innerDir := sourceDirFiles[0].Name()
@@ -346,7 +345,7 @@ func (b assetManagerBuilder) downloadLifecycleRelative(relativeVersion int) stri
 func (b assetManagerBuilder) buildPack(compileVersion string) string {
 	b.testObject.Helper()
 
-	packTmpDir, err := ioutil.TempDir("", "pack.acceptance.binary.")
+	packTmpDir, err := os.MkdirTemp("", "pack.acceptance.binary.")
 	b.assert.Nil(err)
 
 	packPath := filepath.Join(packTmpDir, acceptanceOS.PackBinaryName)

--- a/acceptance/config/github_asset_fetcher.go
+++ b/acceptance/config/github_asset_fetcher.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -330,7 +329,7 @@ func (f *GithubAssetFetcher) loadCacheManifest() (assetCache, error) {
 		return assetCache{}, nil
 	}
 
-	content, err := ioutil.ReadFile(filepath.Join(f.cacheDir, assetCacheManifest))
+	content, err := os.ReadFile(filepath.Join(f.cacheDir, assetCacheManifest))
 	if err != nil {
 		return nil, errors.Wrap(err, "reading cache manifest")
 	}
@@ -371,7 +370,7 @@ func (f *GithubAssetFetcher) writeCacheManifest(owner, repo string, op func(cach
 		return errors.Wrap(err, "marshaling cache manifest content")
 	}
 
-	return ioutil.WriteFile(filepath.Join(f.cacheDir, assetCacheManifest), content, 0644)
+	return os.WriteFile(filepath.Join(f.cacheDir, assetCacheManifest), content, 0644)
 }
 
 func (f *GithubAssetFetcher) downloadAndSave(assetURI, destPath string) error {

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -6,7 +6,6 @@ package invoke
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -45,7 +44,7 @@ func NewPackInvoker(
 
 	testObject.Helper()
 
-	home, err := ioutil.TempDir("", "buildpack.pack.home.")
+	home, err := os.MkdirTemp("", "buildpack.pack.home.")
 	if err != nil {
 		testObject.Fatalf("couldn't create home folder for pack: %s", err)
 	}
@@ -267,7 +266,7 @@ func (i *PackInvoker) atLeast(version string) bool {
 func (i *PackInvoker) ConfigFileContents() string {
 	i.testObject.Helper()
 
-	contents, err := ioutil.ReadFile(filepath.Join(i.home, "config.toml"))
+	contents, err := os.ReadFile(filepath.Join(i.home, "config.toml"))
 	i.assert.Nil(err)
 
 	return string(contents)

--- a/acceptance/invoke/pack_fixtures.go
+++ b/acceptance/invoke/pack_fixtures.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,7 +57,7 @@ func (m PackFixtureManager) VersionedFixtureOrFallbackLocation(pattern, version,
 func (m PackFixtureManager) TemplateFixture(templateName string, templateData map[string]interface{}) string {
 	m.testObject.Helper()
 
-	outputTemplate, err := ioutil.ReadFile(m.FixtureLocation(templateName))
+	outputTemplate, err := os.ReadFile(m.FixtureLocation(templateName))
 	m.assert.Nil(err)
 
 	return m.fillTemplate(outputTemplate, templateData)
@@ -69,7 +68,7 @@ func (m PackFixtureManager) TemplateVersionedFixture(
 	templateData map[string]interface{},
 ) string {
 	m.testObject.Helper()
-	outputTemplate, err := ioutil.ReadFile(m.VersionedFixtureOrFallbackLocation(versionedPattern, version, fallback))
+	outputTemplate, err := os.ReadFile(m.VersionedFixtureOrFallbackLocation(versionedPattern, version, fallback))
 	m.assert.Nil(err)
 
 	return m.fillTemplate(outputTemplate, templateData)

--- a/acceptance/testdata/mock_stack/windows/run/server.go
+++ b/acceptance/testdata/mock_stack/windows/run/server.go
@@ -6,9 +6,9 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -28,7 +28,7 @@ func main() {
 		}
 
 		for _, path := range paths {
-			contents, err := ioutil.ReadFile(filepath.Clean(path))
+			contents, err := os.ReadFile(filepath.Clean(path))
 			if err != nil {
 				panic(err.Error())
 			}

--- a/builder/config_reader_test.go
+++ b/builder/config_reader_test.go
@@ -1,7 +1,6 @@
 package builder_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +28,7 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 		)
 
 		it.Before(func() {
-			tmpDir, err = ioutil.TempDir("", "config-test")
+			tmpDir, err = os.MkdirTemp("", "config-test")
 			h.AssertNil(t, err)
 			builderConfigPath = filepath.Join(tmpDir, "builder.toml")
 		})
@@ -40,7 +39,7 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 
 		when("file is written properly", func() {
 			it.Before(func() {
-				h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`
+				h.AssertNil(t, os.WriteFile(builderConfigPath, []byte(`
 [[buildpacks]]
   id = "buildpack/1"
   version = "0.0.1"
@@ -90,7 +89,7 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 		when("detecting warnings", func() {
 			when("'groups' field is used", func() {
 				it.Before(func() {
-					h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`
+					h.AssertNil(t, os.WriteFile(builderConfigPath, []byte(`
 [[buildpacks]]
   id = "some.buildpack"
   version = "some.buildpack.version"
@@ -115,7 +114,7 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 
 			when("'order' is missing or empty", func() {
 				it.Before(func() {
-					h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`
+					h.AssertNil(t, os.WriteFile(builderConfigPath, []byte(`
 [[buildpacks]]
   id = "some.buildpack"
   version = "some.buildpack.version"
@@ -132,7 +131,7 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 
 			when("unknown buildpack key is present", func() {
 				it.Before(func() {
-					h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`
+					h.AssertNil(t, os.WriteFile(builderConfigPath, []byte(`
 [[buildpacks]]
 url = "noop-buildpack.tgz"
 `), 0666))
@@ -146,7 +145,7 @@ url = "noop-buildpack.tgz"
 
 			when("unknown array table is present", func() {
 				it.Before(func() {
-					h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`
+					h.AssertNil(t, os.WriteFile(builderConfigPath, []byte(`
 [[buidlpack]]
 uri = "noop-buildpack.tgz"
 `), 0666))

--- a/buildpackage/config_reader_test.go
+++ b/buildpackage/config_reader_test.go
@@ -1,7 +1,6 @@
 package buildpackage_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,7 +25,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			tmpDir, err = ioutil.TempDir("", "buildpackage-config-test")
+			tmpDir, err = os.MkdirTemp("", "buildpackage-config-test")
 			h.AssertNil(t, err)
 		})
 
@@ -37,7 +36,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 		it("returns correct config when provided toml file is valid", func() {
 			configFile := filepath.Join(tmpDir, "package.toml")
 
-			err := ioutil.WriteFile(configFile, []byte(validPackageToml), os.ModePerm)
+			err := os.WriteFile(configFile, []byte(validPackageToml), os.ModePerm)
 			h.AssertNil(t, err)
 
 			packageConfigReader := buildpackage.NewConfigReader()
@@ -54,7 +53,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 		it("returns a config with 'linux' as default when platform is missing", func() {
 			configFile := filepath.Join(tmpDir, "package.toml")
 
-			err := ioutil.WriteFile(configFile, []byte(validPackageWithoutPlatformToml), os.ModePerm)
+			err := os.WriteFile(configFile, []byte(validPackageWithoutPlatformToml), os.ModePerm)
 			h.AssertNil(t, err)
 
 			packageConfigReader := buildpackage.NewConfigReader()
@@ -68,7 +67,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 		it("returns an error when toml decode fails", func() {
 			configFile := filepath.Join(tmpDir, "package.toml")
 
-			err := ioutil.WriteFile(configFile, []byte(brokenPackageToml), os.ModePerm)
+			err := os.WriteFile(configFile, []byte(brokenPackageToml), os.ModePerm)
 			h.AssertNil(t, err)
 
 			packageConfigReader := buildpackage.NewConfigReader()
@@ -82,7 +81,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 		it("returns an error when buildpack uri is invalid", func() {
 			configFile := filepath.Join(tmpDir, "package.toml")
 
-			err := ioutil.WriteFile(configFile, []byte(invalidBPURIPackageToml), os.ModePerm)
+			err := os.WriteFile(configFile, []byte(invalidBPURIPackageToml), os.ModePerm)
 			h.AssertNil(t, err)
 
 			packageConfigReader := buildpackage.NewConfigReader()
@@ -96,7 +95,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 		it("returns an error when platform os is invalid", func() {
 			configFile := filepath.Join(tmpDir, "package.toml")
 
-			err := ioutil.WriteFile(configFile, []byte(invalidPlatformOSPackageToml), os.ModePerm)
+			err := os.WriteFile(configFile, []byte(invalidPlatformOSPackageToml), os.ModePerm)
 			h.AssertNil(t, err)
 
 			packageConfigReader := buildpackage.NewConfigReader()
@@ -110,7 +109,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 		it("returns an error when dependency uri is invalid", func() {
 			configFile := filepath.Join(tmpDir, "package.toml")
 
-			err := ioutil.WriteFile(configFile, []byte(invalidDepURIPackageToml), os.ModePerm)
+			err := os.WriteFile(configFile, []byte(invalidDepURIPackageToml), os.ModePerm)
 			h.AssertNil(t, err)
 
 			packageConfigReader := buildpackage.NewConfigReader()
@@ -124,7 +123,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 		it("returns an error when unknown array table is present", func() {
 			configFile := filepath.Join(tmpDir, "package.toml")
 
-			err := ioutil.WriteFile(configFile, []byte(invalidDepTablePackageToml), os.ModePerm)
+			err := os.WriteFile(configFile, []byte(invalidDepTablePackageToml), os.ModePerm)
 			h.AssertNil(t, err)
 
 			packageConfigReader := buildpackage.NewConfigReader()
@@ -140,7 +139,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 		it("returns an error when unknown buildpack key is present", func() {
 			configFile := filepath.Join(tmpDir, "package.toml")
 
-			err := ioutil.WriteFile(configFile, []byte(unknownBPKeyPackageToml), os.ModePerm)
+			err := os.WriteFile(configFile, []byte(unknownBPKeyPackageToml), os.ModePerm)
 			h.AssertNil(t, err)
 
 			packageConfigReader := buildpackage.NewConfigReader()
@@ -155,7 +154,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 		it("returns an error when multiple unknown keys are present", func() {
 			configFile := filepath.Join(tmpDir, "package.toml")
 
-			err := ioutil.WriteFile(configFile, []byte(multipleUnknownKeysPackageToml), os.ModePerm)
+			err := os.WriteFile(configFile, []byte(multipleUnknownKeysPackageToml), os.ModePerm)
 			h.AssertNil(t, err)
 
 			packageConfigReader := buildpackage.NewConfigReader()
@@ -171,7 +170,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 		it("returns an error when both dependency options are configured", func() {
 			configFile := filepath.Join(tmpDir, "package.toml")
 
-			err := ioutil.WriteFile(configFile, []byte(conflictingDependencyKeysPackageToml), os.ModePerm)
+			err := os.WriteFile(configFile, []byte(conflictingDependencyKeysPackageToml), os.ModePerm)
 			h.AssertNil(t, err)
 
 			packageConfigReader := buildpackage.NewConfigReader()
@@ -184,7 +183,7 @@ func testBuildpackageConfigReader(t *testing.T, when spec.G, it spec.S) {
 		it("returns an error no buildpack is configured", func() {
 			configFile := filepath.Join(tmpDir, "package.toml")
 
-			err := ioutil.WriteFile(configFile, []byte(missingBuildpackPackageToml), os.ModePerm)
+			err := os.WriteFile(configFile, []byte(missingBuildpackPackageToml), os.ModePerm)
 			h.AssertNil(t, err)
 
 			packageConfigReader := buildpackage.NewConfigReader()

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -23,8 +23,9 @@ type ConfigurableLogger interface {
 	WantVerbose(f bool)
 }
 
-//nolint:staticcheck
 // NewPackCommand generates a Pack command
+//
+//nolint:staticcheck
 func NewPackCommand(logger ConfigurableLogger) (*cobra.Command, error) {
 	cobra.EnableCommandSorting = false
 	cfg, cfgPath, err := initConfig()

--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-go 1.18
+go 1.19
 
 // Ensure compatibility with lifecycle/kaniko; match dependencies configured in:
 // https://github.com/GoogleContainerTools/kaniko/blob/f9aaa9fca7bf4077778ed527c1a8a6e09e60c53c/go.mod (v1.9.1)

--- a/internal/build/container_ops.go
+++ b/internal/build/container_ops.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -157,7 +156,7 @@ func copyDirWindows(ctx context.Context, ctrClient client.CommonAPIClient, conta
 		ctrClient,
 		ctr.ID,
 		container.DefaultHandler(
-			ioutil.Discard, // Suppress xcopy output
+			io.Discard, // Suppress xcopy output
 			stderr,
 		),
 	)
@@ -307,7 +306,7 @@ func EnsureVolumeAccess(uid, gid int, os string, volumeNames ...string) Containe
 			ctrClient,
 			ctr.ID,
 			container.DefaultHandler(
-				ioutil.Discard, // Suppress icacls output
+				io.Discard, // Suppress icacls output
 				stderr,
 			),
 		)

--- a/internal/build/container_ops_test.go
+++ b/internal/build/container_ops_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -281,30 +280,30 @@ drwsrwsrwt    2 123      456 (.*) some-vol
 			defer cleanupContainer(ctx, ctr.ID)
 
 			copyDirOp := build.CopyDir(filepath.Join("testdata", "fake-app"), containerDir, 123, 456, osType, false, nil)
-			err = copyDirOp(ctrClient, ctx, ctr.ID, ioutil.Discard, ioutil.Discard)
+			err = copyDirOp(ctrClient, ctx, ctr.ID, io.Discard, io.Discard)
 			h.AssertNil(t, err)
 
-			tarDestination, err := ioutil.TempFile("", "pack.container.ops.test.")
+			tarDestination, err := os.CreateTemp("", "pack.container.ops.test.")
 			h.AssertNil(t, err)
 			defer os.RemoveAll(tarDestination.Name())
 
 			handler := func(reader io.ReadCloser) error {
 				defer reader.Close()
 
-				contents, err := ioutil.ReadAll(reader)
+				contents, err := io.ReadAll(reader)
 				h.AssertNil(t, err)
 
-				err = ioutil.WriteFile(tarDestination.Name(), contents, 0600)
+				err = os.WriteFile(tarDestination.Name(), contents, 0600)
 				h.AssertNil(t, err)
 
 				return nil
 			}
 
 			copyOutDirsOp := build.CopyOut(handler, containerDir)
-			err = copyOutDirsOp(ctrClient, ctx, ctr.ID, ioutil.Discard, ioutil.Discard)
+			err = copyOutDirsOp(ctrClient, ctx, ctr.ID, io.Discard, io.Discard)
 			h.AssertNil(t, err)
 
-			err = container.RunWithHandler(ctx, ctrClient, ctr.ID, container.DefaultHandler(ioutil.Discard, ioutil.Discard))
+			err = container.RunWithHandler(ctx, ctrClient, ctr.ID, container.DefaultHandler(io.Discard, io.Discard))
 			h.AssertNil(t, err)
 
 			separator := "/"

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -95,7 +94,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 		// GGCR resolves the default keychain by inspecting DOCKER_CONFIG - this is used by the Analyze step
 		// when constructing the auth config (see `auth.BuildEnvVar` in phases.go).
 		var err error
-		dockerConfigDir, err = ioutil.TempDir("", "empty-docker-config-dir")
+		dockerConfigDir, err = os.MkdirTemp("", "empty-docker-config-dir")
 		h.AssertNil(t, err)
 		h.AssertNil(t, os.Setenv("DOCKER_CONFIG", dockerConfigDir))
 

--- a/internal/build/phase_test.go
+++ b/internal/build/phase_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -142,7 +141,7 @@ func testPhase(t *testing.T, when spec.G, it spec.S) {
 			it("runs the phase with provided handlers", func() {
 				var actual string
 				var handler container.Handler = func(bodyChan <-chan dcontainer.ContainerWaitOKBody, errChan <-chan error, reader io.Reader) error {
-					data, _ := ioutil.ReadAll(reader)
+					data, _ := io.ReadAll(reader)
 					actual = string(data)
 					return nil
 				}
@@ -225,7 +224,7 @@ func testPhase(t *testing.T, when spec.G, it spec.S) {
 					it.Before(func() {
 						h.SkipIf(t, os.Getuid() == 0, "Skipping b/c current user is root")
 
-						tmpFakeAppDir, err = ioutil.TempDir("", "fake-app")
+						tmpFakeAppDir, err = os.MkdirTemp("", "fake-app")
 						h.AssertNil(t, err)
 						dirWithoutAccess = filepath.Join(tmpFakeAppDir, "bad-dir")
 						err := os.MkdirAll(dirWithoutAccess, 0222)
@@ -299,7 +298,7 @@ func testPhase(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it("allows daemon access inside the container", func() {
-						tmp, err := ioutil.TempDir("", "testSocketDir")
+						tmp, err := os.MkdirTemp("", "testSocketDir")
 						if err != nil {
 							t.Fatal(err)
 						}
@@ -426,17 +425,17 @@ func testPhase(t *testing.T, when spec.G, it spec.S) {
 
 			when("#WithPostContainerRunOperations", func() {
 				it("runs the operation after the container command", func() {
-					tarDestinationPath, err := ioutil.TempFile("", "pack.phase.test.")
+					tarDestinationPath, err := os.CreateTemp("", "pack.phase.test.")
 					h.AssertNil(t, err)
 					defer os.RemoveAll(tarDestinationPath.Name())
 
 					handler := func(reader io.ReadCloser) error {
 						defer reader.Close()
 
-						contents, err := ioutil.ReadAll(reader)
+						contents, err := io.ReadAll(reader)
 						h.AssertNil(t, err)
 
-						err = ioutil.WriteFile(tarDestinationPath.Name(), contents, 0600)
+						err = os.WriteFile(tarDestinationPath.Name(), contents, 0600)
 						h.AssertNil(t, err)
 						return nil
 					}

--- a/internal/build/testdata/fake-lifecycle/phase.go
+++ b/internal/build/testdata/fake-lifecycle/phase.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -102,7 +101,7 @@ func testRegistryAccess(repoName string) {
 
 func testRead(filename string) {
 	fmt.Println("read test")
-	contents, err := ioutil.ReadFile(filepath.Clean(filename))
+	contents, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		fmt.Printf("failed to read file '%s'\n", filename)
 		os.Exit(1)
@@ -120,13 +119,13 @@ func testRead(filename string) {
 
 func testEnv() {
 	fmt.Println("env test")
-	fis, err := ioutil.ReadDir("/platform/env")
+	fis, err := os.ReadDir("/platform/env")
 	if err != nil {
 		fmt.Printf("failed to read /plaform/env dir: %s\n", err)
 		os.Exit(1)
 	}
 	for _, fi := range fis {
-		contents, err := ioutil.ReadFile(filepath.Join("/", "platform", "env", fi.Name()))
+		contents, err := os.ReadFile(filepath.Join("/", "platform", "env", fi.Name()))
 		if err != nil {
 			fmt.Printf("failed to read file /plaform/env/%s: %s\n", fi.Name(), err)
 			os.Exit(1)
@@ -186,7 +185,7 @@ func testBinds() {
 }
 
 func readDir(dir string) {
-	fis, err := ioutil.ReadDir(dir)
+	fis, err := os.ReadDir(dir)
 	if err != nil {
 		fmt.Printf("failed to read %s dir: %s\n", dir, err)
 		os.Exit(1)

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -310,7 +309,7 @@ func (b *Builder) Save(logger logging.Logger, creatorMetadata CreatorMetadata) e
 		logger.Debugf("-> %s", style.Symbol(bpInfo.FullName()))
 	}
 
-	tmpDir, err := ioutil.TempDir("", "create-builder-scratch")
+	tmpDir, err := os.MkdirTemp("", "create-builder-scratch")
 	if err != nil {
 		return err
 	}
@@ -808,7 +807,7 @@ func (b *Builder) embedLifecycleTar(tw archive.TarWriter) error {
 				return errors.Wrapf(err, "failed to write header for '%s'", header.Name)
 			}
 
-			buf, err := ioutil.ReadAll(tr)
+			buf, err := io.ReadAll(tr)
 			if err != nil {
 				return errors.Wrapf(err, "failed to read contents of '%s'", header.Name)
 			}

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -66,7 +65,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 			".", 0, 0, 0755, true, false, nil,
 		)
 
-		descriptorContents, err := ioutil.ReadFile(filepath.Join("testdata", "lifecycle", "platform-0.4", "lifecycle.toml"))
+		descriptorContents, err := os.ReadFile(filepath.Join("testdata", "lifecycle", "platform-0.4", "lifecycle.toml"))
 		h.AssertNil(t, err)
 
 		lifecycleDescriptor, err := builder.ParseDescriptor(string(descriptorContents))
@@ -427,7 +426,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("does not overwrite the order layer when SetOrder has not been called", func() {
-				tmpDir, err := ioutil.TempDir("", "")
+				tmpDir, err := os.MkdirTemp("", "")
 				h.AssertNil(t, err)
 				defer os.RemoveAll(tmpDir)
 

--- a/internal/builder/lifecycle_test.go
+++ b/internal/builder/lifecycle_test.go
@@ -3,7 +3,6 @@ package builder_test
 import (
 	"archive/tar"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -58,10 +57,10 @@ func testLifecycle(t *testing.T, when spec.G, it spec.S) {
 
 			it.Before(func() {
 				var err error
-				tmpDir, err = ioutil.TempDir("", "lifecycle")
+				tmpDir, err = os.MkdirTemp("", "lifecycle")
 				h.AssertNil(t, err)
 
-				h.AssertNil(t, ioutil.WriteFile(filepath.Join(tmpDir, "lifecycle.toml"), []byte(`
+				h.AssertNil(t, os.WriteFile(filepath.Join(tmpDir, "lifecycle.toml"), []byte(`
 [api]
   platform "0.1"
 `), 0711))
@@ -82,10 +81,10 @@ func testLifecycle(t *testing.T, when spec.G, it spec.S) {
 
 			it.Before(func() {
 				var err error
-				tmpDir, err = ioutil.TempDir("", "")
+				tmpDir, err = os.MkdirTemp("", "")
 				h.AssertNil(t, err)
 
-				h.AssertNil(t, ioutil.WriteFile(filepath.Join(tmpDir, "lifecycle.toml"), []byte(`
+				h.AssertNil(t, os.WriteFile(filepath.Join(tmpDir, "lifecycle.toml"), []byte(`
 [api]
   platform = "0.2"
   buildpack = "0.3"
@@ -95,9 +94,9 @@ func testLifecycle(t *testing.T, when spec.G, it spec.S) {
 `), os.ModePerm))
 
 				h.AssertNil(t, os.Mkdir(filepath.Join(tmpDir, "lifecycle"), os.ModePerm))
-				h.AssertNil(t, ioutil.WriteFile(filepath.Join(tmpDir, "lifecycle", "analyzer"), []byte("content"), os.ModePerm))
-				h.AssertNil(t, ioutil.WriteFile(filepath.Join(tmpDir, "lifecycle", "detector"), []byte("content"), os.ModePerm))
-				h.AssertNil(t, ioutil.WriteFile(filepath.Join(tmpDir, "lifecycle", "builder"), []byte("content"), os.ModePerm))
+				h.AssertNil(t, os.WriteFile(filepath.Join(tmpDir, "lifecycle", "analyzer"), []byte("content"), os.ModePerm))
+				h.AssertNil(t, os.WriteFile(filepath.Join(tmpDir, "lifecycle", "detector"), []byte("content"), os.ModePerm))
+				h.AssertNil(t, os.WriteFile(filepath.Join(tmpDir, "lifecycle", "builder"), []byte("content"), os.ModePerm))
 			})
 
 			it.After(func() {

--- a/internal/commands/add_registry_test.go
+++ b/internal/commands/add_registry_test.go
@@ -2,7 +2,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +39,7 @@ func testAddRegistryCommand(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			tmpDir, err = ioutil.TempDir("", "pack-home-*")
+			tmpDir, err = os.MkdirTemp("", "pack-home-*")
 			assert.Nil(err)
 
 			configFile = filepath.Join(tmpDir, "config.toml")
@@ -81,7 +81,7 @@ func testAddRegistryCommand(t *testing.T, when spec.G, it spec.S) {
 
 		when("validation", func() {
 			it("fails with missing args", func() {
-				command.SetOut(ioutil.Discard)
+				command.SetOut(io.Discard)
 				command.SetArgs([]string{})
 				err := command.Execute()
 				assert.ErrorContains(err, "accepts 2 arg")

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -298,7 +297,7 @@ func parseEnv(envFiles []string, envVars []string) (map[string]string, error) {
 
 func parseEnvFile(filename string) (map[string]string, error) {
 	out := make(map[string]string)
-	f, err := ioutil.ReadFile(filepath.Clean(filename))
+	f, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, errors.Wrapf(err, "open %s", filename)
 	}

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -3,7 +3,6 @@ package commands_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -238,7 +237,7 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 				var envPath string
 
 				it.Before(func() {
-					envfile, err := ioutil.TempFile("", "envfile")
+					envfile, err := os.CreateTemp("", "envfile")
 					h.AssertNil(t, err)
 					defer envfile.Close()
 
@@ -274,7 +273,7 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 				var envPath string
 
 				it.Before(func() {
-					envfile, err := ioutil.TempFile("", "envfile")
+					envfile, err := os.CreateTemp("", "envfile")
 					h.AssertNil(t, err)
 					defer envfile.Close()
 
@@ -301,14 +300,14 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 				var envPath2 string
 
 				it.Before(func() {
-					envfile1, err := ioutil.TempFile("", "envfile")
+					envfile1, err := os.CreateTemp("", "envfile")
 					h.AssertNil(t, err)
 					defer envfile1.Close()
 
 					envfile1.WriteString("KEY1=VALUE1\nKEY2=IGNORED")
 					envPath1 = envfile1.Name()
 
-					envfile2, err := ioutil.TempFile("", "envfile")
+					envfile2, err := os.CreateTemp("", "envfile")
 					h.AssertNil(t, err)
 					defer envfile2.Close()
 
@@ -526,7 +525,7 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 				var projectTomlPath string
 
 				it.Before(func() {
-					projectToml, err := ioutil.TempFile("", "project.toml")
+					projectToml, err := os.CreateTemp("", "project.toml")
 					h.AssertNil(t, err)
 					defer projectToml.Close()
 
@@ -569,7 +568,7 @@ version = "1.0"
 				var projectTomlPath string
 
 				it.Before(func() {
-					projectToml, err := ioutil.TempFile("", "project.toml")
+					projectToml, err := os.CreateTemp("", "project.toml")
 					h.AssertNil(t, err)
 					defer projectToml.Close()
 
@@ -611,7 +610,7 @@ builder = "my-builder"
 				var projectTomlPath string
 
 				it.Before(func() {
-					projectToml, err := ioutil.TempFile("", "project.toml")
+					projectToml, err := os.CreateTemp("", "project.toml")
 					h.AssertNil(t, err)
 					defer projectToml.Close()
 

--- a/internal/commands/builder_create_test.go
+++ b/internal/commands/builder_create_test.go
@@ -2,7 +2,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -66,7 +66,7 @@ func testCreateCommand(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "create-builder-test")
+		tmpDir, err = os.MkdirTemp("", "create-builder-test")
 		h.AssertNil(t, err)
 		builderConfigPath = filepath.Join(tmpDir, "builder.toml")
 		cfg = config.Config{}
@@ -137,7 +137,7 @@ func testCreateCommand(t *testing.T, when spec.G, it spec.S) {
 
 		when("warnings encountered in builder.toml", func() {
 			it.Before(func() {
-				h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`
+				h.AssertNil(t, os.WriteFile(builderConfigPath, []byte(`
 [[buildpacks]]
   id = "some.buildpack"
 `), 0666))
@@ -158,7 +158,7 @@ func testCreateCommand(t *testing.T, when spec.G, it spec.S) {
 
 		when("uses --builder-config", func() {
 			it.Before(func() {
-				h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(validConfig), 0666))
+				h.AssertNil(t, os.WriteFile(builderConfigPath, []byte(validConfig), 0666))
 			})
 
 			it("errors with a descriptive message", func() {
@@ -181,7 +181,7 @@ func testCreateCommand(t *testing.T, when spec.G, it spec.S) {
 
 		when("builder config has extensions but experimental isn't set in the config", func() {
 			it.Before(func() {
-				h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(validConfigWithExtensions), 0666))
+				h.AssertNil(t, os.WriteFile(builderConfigPath, []byte(validConfigWithExtensions), 0666))
 			})
 
 			it("errors", func() {

--- a/internal/commands/buildpack_new_test.go
+++ b/internal/commands/buildpack_new_test.go
@@ -2,7 +2,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func testBuildpackNewCommand(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "build-test")
+		tmpDir, err = os.MkdirTemp("", "build-test")
 		h.AssertNil(t, err)
 
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)

--- a/internal/commands/completion_test.go
+++ b/internal/commands/completion_test.go
@@ -2,7 +2,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +31,7 @@ func testCompletionCommand(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
 		var err error
-		packHome, err = ioutil.TempDir("", "")
+		packHome, err = os.MkdirTemp("", "")
 		assert.Nil(err)
 
 		// the CompletionCommand calls a method on its Parent(), so it needs to have

--- a/internal/commands/config_default_builder_test.go
+++ b/internal/commands/config_default_builder_test.go
@@ -3,7 +3,6 @@ package commands_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,7 +45,7 @@ func testConfigDefaultBuilder(t *testing.T, when spec.G, it spec.S) {
 		mockController = gomock.NewController(t)
 		mockClient = testmocks.NewMockPackClient(mockController)
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 		configPath = filepath.Join(tempPackHome, "config.toml")
 		cmd = commands.ConfigDefaultBuilder(logger, config.Config{}, configPath, mockClient)
@@ -95,7 +94,7 @@ func testConfigDefaultBuilder(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("gives clear error if unable to write to config", func() {
-				h.AssertNil(t, ioutil.WriteFile(configPath, []byte("some-data"), 0001))
+				h.AssertNil(t, os.WriteFile(configPath, []byte("some-data"), 0001))
 				cmd = commands.ConfigDefaultBuilder(logger, config.Config{DefaultBuilder: "some/builder"}, configPath, mockClient)
 				cmd.SetArgs([]string{"--unset"})
 				err := cmd.Execute()
@@ -123,7 +122,7 @@ func testConfigDefaultBuilder(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					it("gives clear error if unable to write to config", func() {
-						h.AssertNil(t, ioutil.WriteFile(configPath, []byte("some-data"), 0001))
+						h.AssertNil(t, os.WriteFile(configPath, []byte("some-data"), 0001))
 						mockClient.EXPECT().InspectBuilder(imageName, true).Return(&client.BuilderInfo{
 							Stack: "test.stack.id",
 						}, nil)

--- a/internal/commands/config_experimental_test.go
+++ b/internal/commands/config_experimental_test.go
@@ -3,7 +3,6 @@ package commands_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +38,7 @@ func testConfigExperimental(t *testing.T, when spec.G, it spec.S) {
 		var err error
 
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 		configPath = filepath.Join(tempPackHome, "config.toml")
 

--- a/internal/commands/config_lifecycle_image_test.go
+++ b/internal/commands/config_lifecycle_image_test.go
@@ -2,7 +2,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,7 +38,7 @@ func testConfigLifecycleImageCommand(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 		configFile = filepath.Join(tempPackHome, "config.toml")
 
@@ -115,7 +114,7 @@ func testConfigLifecycleImageCommand(t *testing.T, when spec.G, it spec.S) {
 					assert.Equal(readCfg.LifecycleImage, "custom-lifecycle/image:v1")
 				})
 				it("returns clear error if fails to write", func() {
-					assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+					assert.Nil(os.WriteFile(configFile, []byte("something"), 0001))
 					command := commands.ConfigLifecycleImage(logger, cfg, configFile)
 					command.SetArgs([]string{"custom-lifecycle/image:v1"})
 					assert.ErrorContains(command.Execute(), "failed to write to config at")
@@ -128,7 +127,7 @@ func testConfigLifecycleImageCommand(t *testing.T, when spec.G, it spec.S) {
 					h.AssertError(t, err, `Invalid image name`)
 				})
 				it("returns clear error if fails to write", func() {
-					assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+					assert.Nil(os.WriteFile(configFile, []byte("something"), 0001))
 					command := commands.ConfigLifecycleImage(logger, cfg, configFile)
 					command.SetArgs([]string{"custom-lifecycle/image:v1"})
 					assert.ErrorContains(command.Execute(), "failed to write to config at")
@@ -155,7 +154,7 @@ func testConfigLifecycleImageCommand(t *testing.T, when spec.G, it spec.S) {
 					assert.Equal(readCfg.LifecycleImage, "")
 				})
 				it("returns clear error if fails to write", func() {
-					assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+					assert.Nil(os.WriteFile(configFile, []byte("something"), 0001))
 					command := commands.ConfigLifecycleImage(logger, config.Config{LifecycleImage: "custom-lifecycle/image:v1"}, configFile)
 					command.SetArgs([]string{"--unset"})
 					assert.ErrorContains(command.Execute(), "failed to write to config at")

--- a/internal/commands/config_pull_policy_test.go
+++ b/internal/commands/config_pull_policy_test.go
@@ -2,7 +2,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,7 +38,7 @@ func testConfigPullPolicyCommand(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 		configFile = filepath.Join(tempPackHome, "config.toml")
 
@@ -154,7 +153,7 @@ func testConfigPullPolicyCommand(t *testing.T, when spec.G, it spec.S) {
 					assert.Equal(readCfg.PullPolicy, "never")
 				})
 				it("returns clear error if fails to write", func() {
-					assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+					assert.Nil(os.WriteFile(configFile, []byte("something"), 0001))
 					command := commands.ConfigPullPolicy(logger, cfg, configFile)
 					command.SetArgs([]string{"if-not-present"})
 					assert.ErrorContains(command.Execute(), "writing config to")
@@ -174,7 +173,7 @@ func testConfigPullPolicyCommand(t *testing.T, when spec.G, it spec.S) {
 				assert.Equal(cfg.PullPolicy, "")
 			})
 			it("returns clear error if fails to write", func() {
-				assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+				assert.Nil(os.WriteFile(configFile, []byte("something"), 0001))
 				command := commands.ConfigPullPolicy(logger, config.Config{PullPolicy: "never"}, configFile)
 				command.SetArgs([]string{"--unset"})
 				assert.ErrorContains(command.Execute(), "writing config to")

--- a/internal/commands/config_registries_default_test.go
+++ b/internal/commands/config_registries_default_test.go
@@ -3,7 +3,6 @@ package commands_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,7 +37,7 @@ func testConfigRegistriesDefaultCommand(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			tmpDir, err = ioutil.TempDir("", "pack-home-*")
+			tmpDir, err = os.MkdirTemp("", "pack-home-*")
 			assert.Nil(err)
 
 			configFile = filepath.Join(tmpDir, "config.toml")
@@ -97,7 +96,7 @@ func testConfigRegistriesDefaultCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("returns clear error if fails to write", func() {
-				assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+				assert.Nil(os.WriteFile(configFile, []byte("something"), 0001))
 				cfg := config.Config{
 					Registries: []config.Registry{
 						{
@@ -138,7 +137,7 @@ func testConfigRegistriesDefaultCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("returns clear error if fails to write", func() {
-				assert.Nil(ioutil.WriteFile(configFile, []byte("something"), 0001))
+				assert.Nil(os.WriteFile(configFile, []byte("something"), 0001))
 				command := commands.ConfigRegistriesDefault(logger, config.Config{DefaultRegistryName: "some-registry"}, configFile)
 				command.SetArgs([]string{"--unset"})
 				assert.ErrorContains(command.Execute(), "writing config to")

--- a/internal/commands/config_registries_test.go
+++ b/internal/commands/config_registries_test.go
@@ -2,7 +2,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +39,7 @@ func testConfigRegistries(t *testing.T, when spec.G, it spec.S) {
 		var err error
 
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		assert.Nil(err)
 		configPath = filepath.Join(tempPackHome, "config.toml")
 
@@ -210,7 +210,7 @@ func testConfigRegistries(t *testing.T, when spec.G, it spec.S) {
 
 		when("validation", func() {
 			it("fails with missing args", func() {
-				cmd.SetOut(ioutil.Discard)
+				cmd.SetOut(io.Discard)
 				cmd.SetArgs([]string{"add"})
 				err := cmd.Execute()
 				assert.ErrorContains(err, "accepts 2 arg")
@@ -253,7 +253,7 @@ func testConfigRegistries(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("returns clear error if fails to write", func() {
-				assert.Nil(ioutil.WriteFile(configPath, []byte("something"), 0001))
+				assert.Nil(os.WriteFile(configPath, []byte("something"), 0001))
 				cmd.SetArgs(args)
 				assert.ErrorContains(cmd.Execute(), "writing config to")
 			})
@@ -330,7 +330,7 @@ func testConfigRegistries(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("returns clear error if fails to write", func() {
-			assert.Nil(ioutil.WriteFile(configPath, []byte("something"), 0001))
+			assert.Nil(os.WriteFile(configPath, []byte("something"), 0001))
 			cmd.SetArgs([]string{"remove", "public registry"})
 			assert.ErrorContains(cmd.Execute(), "writing config to")
 		})

--- a/internal/commands/config_registry_mirrors_test.go
+++ b/internal/commands/config_registry_mirrors_test.go
@@ -3,7 +3,6 @@ package commands_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,7 +48,7 @@ func testConfigRegistryMirrorsCommand(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 		configPath = filepath.Join(tempPackHome, "config.toml")
 
@@ -96,7 +95,7 @@ func testConfigRegistryMirrorsCommand(t *testing.T, when spec.G, it spec.S) {
 		when("config path doesn't exist", func() {
 			it("fails to run", func() {
 				fakePath := filepath.Join(tempPackHome, "not-exist.toml")
-				h.AssertNil(t, ioutil.WriteFile(fakePath, []byte("something"), 0001))
+				h.AssertNil(t, os.WriteFile(fakePath, []byte("something"), 0001))
 				cmd = commands.ConfigRegistryMirrors(logger, config.Config{}, fakePath)
 				cmd.SetArgs([]string{"add", registry1, "-m", testMirror1})
 
@@ -165,7 +164,7 @@ func testConfigRegistryMirrorsCommand(t *testing.T, when spec.G, it spec.S) {
 		when("config path doesn't exist", func() {
 			it("fails to run", func() {
 				fakePath := filepath.Join(tempPackHome, "not-exist.toml")
-				h.AssertNil(t, ioutil.WriteFile(fakePath, []byte("something"), 0001))
+				h.AssertNil(t, os.WriteFile(fakePath, []byte("something"), 0001))
 				cmd = commands.ConfigRegistryMirrors(logger, testCfg, fakePath)
 				cmd.SetArgs([]string{"remove", registry1})
 

--- a/internal/commands/config_run_image_mirrors_test.go
+++ b/internal/commands/config_run_image_mirrors_test.go
@@ -3,7 +3,6 @@ package commands_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,7 +55,7 @@ func testConfigRunImageMirrorsCommand(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 		configPath = filepath.Join(tempPackHome, "config.toml")
 
@@ -104,7 +103,7 @@ func testConfigRunImageMirrorsCommand(t *testing.T, when spec.G, it spec.S) {
 		when("config path doesn't exist", func() {
 			it("fails to run", func() {
 				fakePath := filepath.Join(tempPackHome, "not-exist.toml")
-				h.AssertNil(t, ioutil.WriteFile(fakePath, []byte("something"), 0001))
+				h.AssertNil(t, os.WriteFile(fakePath, []byte("something"), 0001))
 				cmd = commands.ConfigRunImagesMirrors(logger, config.Config{}, fakePath)
 				cmd.SetArgs([]string{"add", runImage, "-m", testMirror1})
 
@@ -156,7 +155,7 @@ func testConfigRunImageMirrorsCommand(t *testing.T, when spec.G, it spec.S) {
 		when("config path doesn't exist", func() {
 			it("fails to run", func() {
 				fakePath := filepath.Join(tempPackHome, "not-exist.toml")
-				h.AssertNil(t, ioutil.WriteFile(fakePath, []byte("something"), 0001))
+				h.AssertNil(t, os.WriteFile(fakePath, []byte("something"), 0001))
 				cmd = commands.ConfigRunImagesMirrors(logger, testCfg, fakePath)
 				cmd.SetArgs([]string{"remove", runImage, "-m", testMirror1})
 

--- a/internal/commands/config_test.go
+++ b/internal/commands/config_test.go
@@ -2,7 +2,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,7 +42,7 @@ func testConfigCommand(t *testing.T, when spec.G, it spec.S) {
 		mockClient = testmocks.NewMockPackClient(mockController)
 
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 		configPath = filepath.Join(tempPackHome, "config.toml")
 

--- a/internal/commands/config_trusted_builder_test.go
+++ b/internal/commands/config_trusted_builder_test.go
@@ -3,7 +3,6 @@ package commands_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +38,7 @@ func testTrustedBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 		var err error
 
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 		configPath = filepath.Join(tempPackHome, "config.toml")
 
@@ -131,7 +130,7 @@ func testTrustedBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 		when("can't write to config path", func() {
 			it("fails", func() {
 				tempPath := filepath.Join(tempPackHome, "non-existent-file.toml")
-				h.AssertNil(t, ioutil.WriteFile(tempPath, []byte("something"), 0111))
+				h.AssertNil(t, os.WriteFile(tempPath, []byte("something"), 0111))
 				command = commands.ConfigTrustedBuilder(logger, config.Config{}, tempPath)
 				command.SetOut(logging.GetWriterForLevel(logger, logging.InfoLevel))
 				command.SetArgs(append(args, "some-builder"))
@@ -145,7 +144,7 @@ func testTrustedBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 					command.SetArgs(append(args, "some-builder"))
 					h.AssertNil(t, command.Execute())
 
-					b, err := ioutil.ReadFile(configPath)
+					b, err := os.ReadFile(configPath)
 					h.AssertNil(t, err)
 					h.AssertContains(t, string(b), `[[trusted-builders]]
   name = "some-builder"`)
@@ -156,13 +155,13 @@ func testTrustedBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 				it("does nothing", func() {
 					command.SetArgs(append(args, "some-already-trusted-builder"))
 					h.AssertNil(t, command.Execute())
-					oldContents, err := ioutil.ReadFile(configPath)
+					oldContents, err := os.ReadFile(configPath)
 					h.AssertNil(t, err)
 
 					command.SetArgs(append(args, "some-already-trusted-builder"))
 					h.AssertNil(t, command.Execute())
 
-					newContents, err := ioutil.ReadFile(configPath)
+					newContents, err := os.ReadFile(configPath)
 					h.AssertNil(t, err)
 					h.AssertEq(t, newContents, oldContents)
 				})
@@ -170,11 +169,11 @@ func testTrustedBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 			when("builder is a suggested builder", func() {
 				it("does nothing", func() {
-					h.AssertNil(t, ioutil.WriteFile(configPath, []byte(""), os.ModePerm))
+					h.AssertNil(t, os.WriteFile(configPath, []byte(""), os.ModePerm))
 
 					command.SetArgs(append(args, "paketobuildpacks/builder:base"))
 					h.AssertNil(t, command.Execute())
-					oldContents, err := ioutil.ReadFile(configPath)
+					oldContents, err := os.ReadFile(configPath)
 					h.AssertNil(t, err)
 					h.AssertEq(t, string(oldContents), "")
 				})
@@ -215,7 +214,7 @@ func testTrustedBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, command.Execute())
 
-				b, err := ioutil.ReadFile(configPath)
+				b, err := os.ReadFile(configPath)
 				h.AssertNil(t, err)
 				h.AssertNotContains(t, string(b), builderName)
 
@@ -235,7 +234,7 @@ func testTrustedBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, command.Execute())
 
-				b, err := ioutil.ReadFile(configPath)
+				b, err := os.ReadFile(configPath)
 				h.AssertNil(t, err)
 				h.AssertContains(t, string(b), stillTrustedBuilder)
 				h.AssertNotContains(t, string(b), untrustBuilder)
@@ -253,7 +252,7 @@ func testTrustedBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, command.Execute())
 
-				b, err := ioutil.ReadFile(configPath)
+				b, err := os.ReadFile(configPath)
 				h.AssertNil(t, err)
 				h.AssertContains(t, string(b), stillTrustedBuilder)
 				h.AssertNotContains(t, string(b), neverTrustedBuilder)

--- a/internal/commands/create_builder_test.go
+++ b/internal/commands/create_builder_test.go
@@ -2,7 +2,7 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -39,7 +39,7 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "create-builder-test")
+		tmpDir, err = os.MkdirTemp("", "create-builder-test")
 		h.AssertNil(t, err)
 		builderConfigPath = filepath.Join(tmpDir, "builder.toml")
 		cfg = config.Config{}
@@ -56,7 +56,7 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 	when("#CreateBuilder", func() {
 		it("gives deprecation warning", func() {
-			h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(validConfig), 0666))
+			h.AssertNil(t, os.WriteFile(builderConfigPath, []byte(validConfig), 0666))
 			mockClient.EXPECT().CreateBuilder(gomock.Any(), gomock.Any()).Return(nil)
 			command.SetArgs([]string{
 				"some/builder",
@@ -123,7 +123,7 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 		when("warnings encountered in builder.toml", func() {
 			it.Before(func() {
-				h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(`
+				h.AssertNil(t, os.WriteFile(builderConfigPath, []byte(`
 [[buildpacks]]
   id = "some.buildpack"
 `), 0666))
@@ -144,7 +144,7 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 		when("uses --builder-config", func() {
 			it.Before(func() {
-				h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(validConfig), 0666))
+				h.AssertNil(t, os.WriteFile(builderConfigPath, []byte(validConfig), 0666))
 			})
 
 			it("errors with a descriptive message", func() {
@@ -167,7 +167,7 @@ func testCreateBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 		when("builder config has extensions but experimental isn't set in the config", func() {
 			it.Before(func() {
-				h.AssertNil(t, ioutil.WriteFile(builderConfigPath, []byte(validConfigWithExtensions), 0666))
+				h.AssertNil(t, os.WriteFile(builderConfigPath, []byte(validConfigWithExtensions), 0666))
 			})
 
 			it("errors", func() {

--- a/internal/commands/list_trusted_builders_test.go
+++ b/internal/commands/list_trusted_builders_test.go
@@ -2,7 +2,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -37,7 +36,7 @@ func testListTrustedBuildersCommand(t *testing.T, when spec.G, it spec.S) {
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
 		command = commands.ListTrustedBuilders(logger, config.Config{})
 
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 		h.AssertNil(t, os.Setenv("PACK_HOME", tempPackHome))
 	})

--- a/internal/commands/remove_registry_test.go
+++ b/internal/commands/remove_registry_test.go
@@ -2,7 +2,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +36,7 @@ func testRemoveRegistryCommand(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			tmpDir, err = ioutil.TempDir("", "pack-home-*")
+			tmpDir, err = os.MkdirTemp("", "pack-home-*")
 			assert.Nil(err)
 
 			cfg = config.Config{

--- a/internal/commands/report.go
+++ b/internal/commands/report.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -57,7 +57,7 @@ Config:
 {{ .Config -}}`))
 
 	configData := ""
-	if data, err := ioutil.ReadFile(filepath.Clean(cfgPath)); err != nil {
+	if data, err := os.ReadFile(filepath.Clean(cfgPath)); err != nil {
 		configData = fmt.Sprintf("(no config file found at %s)", cfgPath)
 	} else {
 		var padded strings.Builder

--- a/internal/commands/report_test.go
+++ b/internal/commands/report_test.go
@@ -3,7 +3,6 @@ package commands_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,13 +35,13 @@ func testReportCommand(t *testing.T, when spec.G, it spec.S) {
 		var err error
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
 
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 
 		packConfigPath = filepath.Join(tempPackHome, "config.toml")
 		command = commands.Report(logger, testVersion, packConfigPath)
 		command.SetArgs([]string{})
-		h.AssertNil(t, ioutil.WriteFile(packConfigPath, []byte(`
+		h.AssertNil(t, os.WriteFile(packConfigPath, []byte(`
 default-builder-image = "some/image"
 experimental = true
 
@@ -59,7 +58,7 @@ experimental = true
   url = "https://github.com/super-secret-project/registry"
 `), 0666))
 
-		tempPackEmptyHome, err = ioutil.TempDir("", "")
+		tempPackEmptyHome, err = os.MkdirTemp("", "")
 		h.AssertNil(t, err)
 	})
 

--- a/internal/commands/set_default_builder_test.go
+++ b/internal/commands/set_default_builder_test.go
@@ -3,7 +3,6 @@ package commands_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,7 +43,7 @@ func testSetDefaultBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
 
 		var err error
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 		command = commands.SetDefaultBuilder(logger, config.Config{}, filepath.Join(tempPackHome, "config.toml"), mockClient)
 	})

--- a/internal/commands/set_default_registry_test.go
+++ b/internal/commands/set_default_registry_test.go
@@ -2,7 +2,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,7 +35,7 @@ func testSetDefaultRegistryCommand(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			tmpDir, err = ioutil.TempDir("", "pack-home-*")
+			tmpDir, err = os.MkdirTemp("", "pack-home-*")
 			assert.Nil(err)
 
 			configFile = filepath.Join(tmpDir, "config.toml")

--- a/internal/commands/set_run_image_mirrors_test.go
+++ b/internal/commands/set_run_image_mirrors_test.go
@@ -2,7 +2,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,7 +34,7 @@ func testSetRunImageMirrorsCommand(t *testing.T, when spec.G, it spec.S) {
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
 		cfg = config.Config{}
 		var err error
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 		cfgPath = filepath.Join(tempPackHome, "config.toml")
 

--- a/internal/commands/trust_builder_test.go
+++ b/internal/commands/trust_builder_test.go
@@ -2,7 +2,6 @@ package commands_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +36,7 @@ func testTrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 		var err error
 
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 		configPath = filepath.Join(tempPackHome, "config.toml")
 		command = commands.TrustBuilder(logger, config.Config{}, configPath)
@@ -61,7 +60,7 @@ func testTrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 					command.SetArgs([]string{"some-builder"})
 					h.AssertNil(t, command.Execute())
 
-					b, err := ioutil.ReadFile(configPath)
+					b, err := os.ReadFile(configPath)
 					h.AssertNil(t, err)
 					h.AssertContains(t, string(b), `[[trusted-builders]]
   name = "some-builder"`)
@@ -72,13 +71,13 @@ func testTrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 				it("does nothing", func() {
 					command.SetArgs([]string{"some-already-trusted-builder"})
 					h.AssertNil(t, command.Execute())
-					oldContents, err := ioutil.ReadFile(configPath)
+					oldContents, err := os.ReadFile(configPath)
 					h.AssertNil(t, err)
 
 					command.SetArgs([]string{"some-already-trusted-builder"})
 					h.AssertNil(t, command.Execute())
 
-					newContents, err := ioutil.ReadFile(configPath)
+					newContents, err := os.ReadFile(configPath)
 					h.AssertNil(t, err)
 					h.AssertEq(t, newContents, oldContents)
 				})
@@ -86,11 +85,11 @@ func testTrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 			when("builder is a suggested builder", func() {
 				it("does nothing", func() {
-					h.AssertNil(t, ioutil.WriteFile(configPath, []byte(""), os.ModePerm))
+					h.AssertNil(t, os.WriteFile(configPath, []byte(""), os.ModePerm))
 
 					command.SetArgs([]string{"paketobuildpacks/builder:base"})
 					h.AssertNil(t, command.Execute())
-					oldContents, err := ioutil.ReadFile(configPath)
+					oldContents, err := os.ReadFile(configPath)
 					h.AssertNil(t, err)
 					h.AssertEq(t, string(oldContents), "")
 				})

--- a/internal/commands/untrust_builder_test.go
+++ b/internal/commands/untrust_builder_test.go
@@ -3,7 +3,6 @@ package commands_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +38,7 @@ func testUntrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
 
-		tempPackHome, err = ioutil.TempDir("", "pack-home")
+		tempPackHome, err = os.MkdirTemp("", "pack-home")
 		h.AssertNil(t, err)
 		configPath = filepath.Join(tempPackHome, "config.toml")
 		configManager = newConfigManager(t, configPath)
@@ -73,7 +72,7 @@ func testUntrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, command.Execute())
 
-				b, err := ioutil.ReadFile(configPath)
+				b, err := os.ReadFile(configPath)
 				h.AssertNil(t, err)
 				h.AssertNotContains(t, string(b), builderName)
 
@@ -93,7 +92,7 @@ func testUntrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, command.Execute())
 
-				b, err := ioutil.ReadFile(configPath)
+				b, err := os.ReadFile(configPath)
 				h.AssertNil(t, err)
 				h.AssertContains(t, string(b), stillTrustedBuilder)
 				h.AssertNotContains(t, string(b), untrustBuilder)
@@ -111,7 +110,7 @@ func testUntrustBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, command.Execute())
 
-				b, err := ioutil.ReadFile(configPath)
+				b, err := os.ReadFile(configPath)
 				h.AssertNil(t, err)
 				h.AssertContains(t, string(b), stillTrustedBuilder)
 				h.AssertNotContains(t, string(b), neverTrustedBuilder)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "pack.config.test.")
+		tmpDir, err = os.MkdirTemp("", "pack.config.test.")
 		h.AssertNil(t, err)
 		configPath = filepath.Join(tmpDir, "config.toml")
 	})
@@ -74,7 +73,7 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 					},
 				}, configPath))
 
-				b, err := ioutil.ReadFile(configPath)
+				b, err := os.ReadFile(configPath)
 				h.AssertNil(t, err)
 				h.AssertContains(t, string(b), `default-builder-image = "some/builder"`)
 				h.AssertContains(t, string(b), `[[run-images]]
@@ -95,14 +94,14 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 
 		when("config on disk", func() {
 			it.Before(func() {
-				h.AssertNil(t, ioutil.WriteFile(configPath, []byte("some-old-contents"), 0777))
+				h.AssertNil(t, os.WriteFile(configPath, []byte("some-old-contents"), 0777))
 			})
 
 			it("replaces the file", func() {
 				h.AssertNil(t, config.Write(config.Config{
 					DefaultBuilder: "some/builder",
 				}, configPath))
-				b, err := ioutil.ReadFile(configPath)
+				b, err := os.ReadFile(configPath)
 				h.AssertNil(t, err)
 				h.AssertContains(t, string(b), `default-builder-image = "some/builder"`)
 				h.AssertNotContains(t, string(b), "some-old-contents")
@@ -116,7 +115,7 @@ func testConfig(t *testing.T, when spec.G, it spec.S) {
 					DefaultBuilder: "some/builder",
 				}, missingDirConfigPath))
 
-				b, err := ioutil.ReadFile(missingDirConfigPath)
+				b, err := os.ReadFile(missingDirConfigPath)
 				h.AssertNil(t, err)
 				h.AssertContains(t, string(b), `default-builder-image = "some/builder"`)
 			})

--- a/internal/fakes/fake_buildpack.go
+++ b/internal/fakes/fake_buildpack.go
@@ -45,14 +45,14 @@ func WithBpOpenError(err error) FakeBuildpackOption {
 
 // NewFakeBuildpack creates a fake buildpack with contents:
 //
-// 	\_ /cnb/buildpacks/{ID}
-// 	\_ /cnb/buildpacks/{ID}/{version}
-// 	\_ /cnb/buildpacks/{ID}/{version}/buildpack.toml
-// 	\_ /cnb/buildpacks/{ID}/{version}/bin
-// 	\_ /cnb/buildpacks/{ID}/{version}/bin/build
-//  	build-contents
-// 	\_ /cnb/buildpacks/{ID}/{version}/bin/detect
-//  	detect-contents
+//		\_ /cnb/buildpacks/{ID}
+//		\_ /cnb/buildpacks/{ID}/{version}
+//		\_ /cnb/buildpacks/{ID}/{version}/buildpack.toml
+//		\_ /cnb/buildpacks/{ID}/{version}/bin
+//		\_ /cnb/buildpacks/{ID}/{version}/bin/build
+//	 	build-contents
+//		\_ /cnb/buildpacks/{ID}/{version}/bin/detect
+//	 	detect-contents
 func NewFakeBuildpack(descriptor dist.BuildpackDescriptor, chmod int64, options ...FakeBuildpackOption) (buildpack.BuildModule, error) {
 	return &fakeBuildpack{
 		descriptor: descriptor,

--- a/internal/fakes/fake_buildpack_blob.go
+++ b/internal/fakes/fake_buildpack_blob.go
@@ -19,12 +19,12 @@ type fakeBuildpackBlob struct {
 
 // NewFakeBuildpackBlob creates a fake blob with contents:
 //
-// 	\_ buildpack.toml
-// 	\_ bin
-// 	\_ bin/build
-//  	build-contents
-// 	\_ bin/detect
-//  	detect-contents
+//		\_ buildpack.toml
+//		\_ bin
+//		\_ bin/build
+//	 	build-contents
+//		\_ bin/detect
+//	 	detect-contents
 func NewFakeBuildpackBlob(descriptor buildpack.Descriptor, chmod int64) (blob.Blob, error) {
 	return &fakeBuildpackBlob{
 		descriptor: descriptor,

--- a/internal/fakes/fake_buildpack_tar.go
+++ b/internal/fakes/fake_buildpack_tar.go
@@ -2,7 +2,7 @@ package fakes
 
 import (
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/buildpacks/pack/pkg/dist"
@@ -13,7 +13,7 @@ func CreateBuildpackTar(t *testing.T, tmpDir string, descriptor dist.BuildpackDe
 	buildpack, err := NewFakeBuildpackBlob(&descriptor, 0777)
 	h.AssertNil(t, err)
 
-	tempFile, err := ioutil.TempFile(tmpDir, "bp-*.tar")
+	tempFile, err := os.CreateTemp(tmpDir, "bp-*.tar")
 	h.AssertNil(t, err)
 	defer tempFile.Close()
 

--- a/internal/fakes/fake_extension.go
+++ b/internal/fakes/fake_extension.go
@@ -45,14 +45,14 @@ func WithExtOpenError(err error) FakeExtensionOption {
 
 // NewFakeExtension creates a fake extension with contents:
 //
-// 	\_ /cnb/extensions/{ID}
-// 	\_ /cnb/extensions/{ID}/{version}
-// 	\_ /cnb/extensions/{ID}/{version}/extension.toml
-// 	\_ /cnb/extensions/{ID}/{version}/bin
-// 	\_ /cnb/extensions/{ID}/{version}/bin/generate
-//  	generate-contents
-// 	\_ /cnb/extensions/{ID}/{version}/bin/detect
-//  	detect-contents
+//		\_ /cnb/extensions/{ID}
+//		\_ /cnb/extensions/{ID}/{version}
+//		\_ /cnb/extensions/{ID}/{version}/extension.toml
+//		\_ /cnb/extensions/{ID}/{version}/bin
+//		\_ /cnb/extensions/{ID}/{version}/bin/generate
+//	 	generate-contents
+//		\_ /cnb/extensions/{ID}/{version}/bin/detect
+//	 	detect-contents
 func NewFakeExtension(descriptor dist.ExtensionDescriptor, chmod int64, options ...FakeExtensionOption) (buildpack.BuildModule, error) {
 	return &fakeExtension{
 		descriptor: descriptor,

--- a/internal/name/name_test.go
+++ b/internal/name/name_test.go
@@ -1,7 +1,7 @@
 package name_test
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/sclevine/spec"
@@ -19,7 +19,7 @@ func TestTranslateRegistry(t *testing.T) {
 func testTranslateRegistry(t *testing.T, when spec.G, it spec.S) {
 	var (
 		assert = h.NewAssertionManager(t)
-		logger = logging.NewSimpleLogger(ioutil.Discard)
+		logger = logging.NewSimpleLogger(io.Discard)
 	)
 
 	when("#TranslateRegistry", func() {

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -57,7 +57,6 @@ func FilePathToURI(path, relativeTo string) (string, error) {
 // - windows drive: file:///C:/Documents%20and%20Settings/file.tgz
 //
 // - windows share: file://laptop/My%20Documents/file.tgz
-//
 func URIToFilePath(uri string) (string, error) {
 	var (
 		osPath string

--- a/internal/registry/git_test.go
+++ b/internal/registry/git_test.go
@@ -2,7 +2,6 @@ package registry_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,7 +33,7 @@ func testGit(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
 
-		tmpDir, err = ioutil.TempDir("", "registry")
+		tmpDir, err = os.MkdirTemp("", "registry")
 		h.AssertNil(t, err)
 
 		registryFixture = h.CreateRegistryFixture(t, tmpDir, filepath.Join("..", "..", "testdata", "registry"))

--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -171,7 +170,7 @@ func (r *Cache) Initialize() error {
 func (r *Cache) CreateCache() error {
 	r.logger.Debugf("Creating registry cache for %s/%s", r.url.Host, r.url.Path)
 
-	registryDir, err := ioutil.TempDir(filepath.Dir(r.Root), "registry")
+	registryDir, err := os.MkdirTemp(filepath.Dir(r.Root), "registry")
 	if err != nil {
 		return err
 	}

--- a/internal/registry/registry_cache_test.go
+++ b/internal/registry/registry_cache_test.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -37,7 +36,7 @@ func testRegistryCache(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
 
-		tmpDir, err = ioutil.TempDir("", "registry")
+		tmpDir, err = os.MkdirTemp("", "registry")
 		h.AssertNil(t, err)
 
 		registryFixture = h.CreateRegistryFixture(t, tmpDir, filepath.Join("..", "..", "testdata", "registry"))

--- a/internal/sshdialer/ssh_dialer.go
+++ b/internal/sshdialer/ssh_dialer.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	urlPkg "net/url"
 	"os"
@@ -350,7 +349,7 @@ func signersToAuthMethods(signers []ssh.Signer) []ssh.AuthMethod {
 // reads key from given path
 // if necessary it will decrypt it
 func loadSignerFromFile(path string, passphrase []byte, passPhraseCallback SecretCallback) (ssh.Signer, error) {
-	key, err := ioutil.ReadFile(path)
+	key, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read key file: %w", err)
 	}

--- a/internal/sshdialer/ssh_dialer_test.go
+++ b/internal/sshdialer/ssh_dialer_test.go
@@ -3,7 +3,7 @@ package sshdialer_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -436,7 +436,7 @@ func testCreateDialer(connConfig *SSHServer, tt testParams) func(t *testing.T, w
 			}
 			defer resp.Body.Close()
 
-			b, err := ioutil.ReadAll(resp.Body)
+			b, err := io.ReadAll(resp.Body)
 			th.AssertTrue(t, err == nil)
 			if err != nil {
 				return
@@ -476,7 +476,7 @@ func cp(src, dest string) error {
 		return fmt.Errorf("the cp() function failed to stat source file: %w", err)
 	}
 
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
 		return fmt.Errorf("the cp() function failed to read source file: %w", err)
 	}
@@ -486,7 +486,7 @@ func cp(src, dest string) error {
 		return fmt.Errorf("destination file already exists: %w", os.ErrExist)
 	}
 
-	return ioutil.WriteFile(dest, data, srcFs.Mode())
+	return os.WriteFile(dest, data, srcFs.Mode())
 }
 
 // puts key from ./testdata/{keyName} to $HOME/.ssh/{keyName}
@@ -545,7 +545,7 @@ func withCleanHome(t *testing.T) func() {
 	if runtime.GOOS == "windows" {
 		homeName = "USERPROFILE"
 	}
-	tmpDir, err := ioutil.TempDir("", "tmpHome")
+	tmpDir, err := os.MkdirTemp("", "tmpHome")
 	th.AssertNil(t, err)
 
 	oldHome, hadHome := os.LookupEnv(homeName)
@@ -584,7 +584,7 @@ func withKnowHosts(connConfig *SSHServer) setUpEnvFn {
 		serverKeysDir := filepath.Join("testdata", "etc", "ssh")
 		for _, k := range []string{"ecdsa"} {
 			keyPath := filepath.Join(serverKeysDir, fmt.Sprintf("ssh_host_%s_key.pub", k))
-			key, err := ioutil.ReadFile(keyPath)
+			key, err := os.ReadFile(keyPath)
 			th.AssertNil(t, err)
 
 			fmt.Fprintf(f, "%s %s", connConfig.hostIPv4, string(key))
@@ -753,7 +753,7 @@ func withBadSSHAgentSocket(t *testing.T) func() {
 func withGoodSSHAgent(t *testing.T) func() {
 	t.Helper()
 
-	key, err := ioutil.ReadFile(filepath.Join("testdata", "id_ed25519"))
+	key, err := os.ReadFile(filepath.Join("testdata", "id_ed25519"))
 	th.AssertNil(t, err)
 
 	signer, err := ssh.ParsePrivateKey(key)
@@ -778,7 +778,7 @@ func withSSHAgent(t *testing.T, ag agent.Agent) func() {
 	if runtime.GOOS == "windows" {
 		agentSocketPath = `\\.\pipe\openssh-ssh-agent-test`
 	} else {
-		tmpDirForSocket, err = ioutil.TempDir("", "forAuthSock")
+		tmpDirForSocket, err = os.MkdirTemp("", "forAuthSock")
 		th.AssertNil(t, err)
 
 		agentSocketPath = filepath.Join(tmpDirForSocket, "agent.sock")
@@ -946,7 +946,7 @@ SSH_BIN -o PasswordAuthentication=no -o ConnectTimeout=3 -o UserKnownHostsFile=%
 	}
 
 	sshScriptFullPath := filepath.Join(homeBin, sshScriptName)
-	err = ioutil.WriteFile(sshScriptFullPath, []byte(sshScript), 0700)
+	err = os.WriteFile(sshScriptFullPath, []byte(sshScript), 0700)
 	th.AssertNil(t, err)
 
 	oldPath := os.Getenv("PATH")

--- a/internal/stack/merge.go
+++ b/internal/stack/merge.go
@@ -12,44 +12,43 @@ const WildcardStack = "*"
 // MergeCompatible determines the allowable set of stacks that a combination of buildpacks may run on, given each
 // buildpack's set of stacks. Compatibility between the two sets of buildpack stacks is defined by the following rules:
 //
-//   1. The stack must be supported by both buildpacks. That is, any resulting stack ID must appear in both input sets.
-//   2. For each supported stack ID, all required mixins for all buildpacks must be provided by the result. That is,
-// 		mixins for the stack ID in both input sets are unioned.
-//   3. If there is a wildcard stack in either of the stack list, the stack list not having the wild card stack is returned.
-//   4. If both the stack lists contain a wildcard stack, a list containing just the wildcard stack is returned.
+//  1. The stack must be supported by both buildpacks. That is, any resulting stack ID must appear in both input sets.
+//  2. For each supported stack ID, all required mixins for all buildpacks must be provided by the result. That is,
+//     mixins for the stack ID in both input sets are unioned.
+//  3. If there is a wildcard stack in either of the stack list, the stack list not having the wild card stack is returned.
+//  4. If both the stack lists contain a wildcard stack, a list containing just the wildcard stack is returned.
 //
 // ---
 //
 // Examples:
 //
-// 	stacksA = [{ID: "stack1", mixins: ["build:mixinA", "mixinB", "run:mixinC"]}}]
-// 	stacksB = [{ID: "stack1", mixins: ["build:mixinA", "run:mixinC"]}}]
-// 	result = [{ID: "stack1", mixins: ["build:mixinA", "mixinB", "run:mixinC"]}}]
+//	stacksA = [{ID: "stack1", mixins: ["build:mixinA", "mixinB", "run:mixinC"]}}]
+//	stacksB = [{ID: "stack1", mixins: ["build:mixinA", "run:mixinC"]}}]
+//	result = [{ID: "stack1", mixins: ["build:mixinA", "mixinB", "run:mixinC"]}}]
 //
-// 	stacksA = [{ID: "stack1", mixins: ["build:mixinA"]}}, {ID: "stack2", mixins: ["mixinA"]}}]
-// 	stacksB = [{ID: "stack1", mixins: ["run:mixinC"]}}, {ID: "stack2", mixins: ["mixinA"]}}]
-// 	result = [{ID: "stack1", mixins: ["build:mixinA", "run:mixinC"]}}, {ID: "stack2", mixins: ["mixinA"]}}]
+//	stacksA = [{ID: "stack1", mixins: ["build:mixinA"]}}, {ID: "stack2", mixins: ["mixinA"]}}]
+//	stacksB = [{ID: "stack1", mixins: ["run:mixinC"]}}, {ID: "stack2", mixins: ["mixinA"]}}]
+//	result = [{ID: "stack1", mixins: ["build:mixinA", "run:mixinC"]}}, {ID: "stack2", mixins: ["mixinA"]}}]
 //
-// 	stacksA = [{ID: "stack1", mixins: ["build:mixinA"]}}, {ID: "stack2", mixins: ["mixinA"]}}]
-// 	stacksB = [{ID: "stack2", mixins: ["mixinA", "run:mixinB"]}}]
-// 	result = [{ID: "stack2", mixins: ["mixinA", "run:mixinB"]}}]
+//	stacksA = [{ID: "stack1", mixins: ["build:mixinA"]}}, {ID: "stack2", mixins: ["mixinA"]}}]
+//	stacksB = [{ID: "stack2", mixins: ["mixinA", "run:mixinB"]}}]
+//	result = [{ID: "stack2", mixins: ["mixinA", "run:mixinB"]}}]
 //
-// 	stacksA = [{ID: "stack1", mixins: ["build:mixinA"]}}]
-// 	stacksB = [{ID: "stack2", mixins: ["mixinA", "run:mixinB"]}}]
-// 	result = []
+//	stacksA = [{ID: "stack1", mixins: ["build:mixinA"]}}]
+//	stacksB = [{ID: "stack2", mixins: ["mixinA", "run:mixinB"]}}]
+//	result = []
 //
-// 	stacksA = [{ID: "*"}, {ID: "stack1", mixins: ["build:mixinC"]}]
-// 	stacksB = [{ID: "stack1", mixins: ["build:mixinA"]}, {ID: "stack2", mixins: ["mixinA", "run:mixinB"]}]
-// 	result = [{ID: "stack1", mixins: ["build:mixinA"]}, {ID: "stack2", mixins: ["mixinA", "run:mixinB"]}]
+//	stacksA = [{ID: "*"}, {ID: "stack1", mixins: ["build:mixinC"]}]
+//	stacksB = [{ID: "stack1", mixins: ["build:mixinA"]}, {ID: "stack2", mixins: ["mixinA", "run:mixinB"]}]
+//	result = [{ID: "stack1", mixins: ["build:mixinA"]}, {ID: "stack2", mixins: ["mixinA", "run:mixinB"]}]
 //
-// 	stacksA = [{ID: "stack1", mixins: ["build:mixinA"]}, {ID: "stack2", mixins: ["mixinA", "run:mixinB"]}]
-// 	stacksB = [{ID: "*"}, {ID: "stack1", mixins: ["build:mixinC"]}]
-// 	result = [{ID: "stack1", mixins: ["build:mixinA"]}, {ID: "stack2", mixins: ["mixinA", "run:mixinB"]}]
+//	stacksA = [{ID: "stack1", mixins: ["build:mixinA"]}, {ID: "stack2", mixins: ["mixinA", "run:mixinB"]}]
+//	stacksB = [{ID: "*"}, {ID: "stack1", mixins: ["build:mixinC"]}]
+//	result = [{ID: "stack1", mixins: ["build:mixinA"]}, {ID: "stack2", mixins: ["mixinA", "run:mixinB"]}]
 //
-// 	stacksA = [{ID: "*"}, {ID: "stack1", mixins: ["build:mixinA"]}, {ID: "stack2", mixins: ["mixinA", "run:mixinB"]}]
-// 	stacksB = [{ID: "*"}, {ID: "stack1", mixins: ["build:mixinC"]}]
-// 	result = [{ID: "*"}]
-//
+//	stacksA = [{ID: "*"}, {ID: "stack1", mixins: ["build:mixinA"]}, {ID: "stack2", mixins: ["mixinA", "run:mixinB"]}]
+//	stacksB = [{ID: "*"}, {ID: "stack1", mixins: ["build:mixinC"]}]
+//	result = [{ID: "*"}]
 func MergeCompatible(stacksA []dist.Stack, stacksB []dist.Stack) []dist.Stack {
 	set := map[string][]string{}
 	AHasWildcardStack, BHasWildcardStack := false, false

--- a/internal/termui/termui.go
+++ b/internal/termui/termui.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bufio"
 	"io"
-	"io/ioutil"
 	"path"
 	"path/filepath"
 	"strings"
@@ -118,7 +117,7 @@ func (s *Termui) Handler() container.Handler {
 		go func() {
 			defer w.Close()
 
-			_, err := stdcopy.StdCopy(w, ioutil.Discard, reader)
+			_, err := stdcopy.StdCopy(w, io.Discard, reader)
 			if err != nil {
 				copyErr <- err
 			}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -353,11 +353,11 @@ func finalizeHeader(header *tar.Header, uid, gid int, mode int64, normalizeModTi
 // NormalizeHeader normalizes a tar.Header
 //
 // Normalizes the following:
-// 	- ModTime
-// 	- GID
-// 	- UID
-// 	- User Name
-// 	- Group Name
+//   - ModTime
+//   - GID
+//   - UID
+//   - User Name
+//   - Group Name
 func NormalizeHeader(header *tar.Header, normalizeModTime bool) {
 	if normalizeModTime {
 		header.ModTime = NormalizedDateTime

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -5,7 +5,6 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -152,7 +151,7 @@ func ReadTarEntry(rc io.Reader, entryPath string) (*tar.Header, []byte, error) {
 		}
 
 		if paths.CanonicalTarPath(header.Name) == canonicalEntryPath {
-			buf, err := ioutil.ReadAll(tr)
+			buf, err := io.ReadAll(tr)
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "failed to read contents of '%s'", entryPath)
 			}
@@ -279,7 +278,7 @@ func WriteZipToTar(tw TarWriter, srcZip, basePath string, uid, gid int, mode int
 				defer r.Close()
 
 				// contents is the target of the symlink
-				target, err := ioutil.ReadAll(r)
+				target, err := io.ReadAll(r)
 				if err != nil {
 					return "", err
 				}

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -2,7 +2,6 @@ package archive_test
 
 import (
 	"archive/tar"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -36,7 +35,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "create-tar-test")
+		tmpDir, err = os.MkdirTemp("", "create-tar-test")
 		if err != nil {
 			t.Fatalf("failed to create tmp dir %s: %s", tmpDir, err)
 		}
@@ -112,7 +111,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 			tarFile *os.File
 		)
 		it.Before(func() {
-			tarFile, err = ioutil.TempFile(tmpDir, "file.tgz")
+			tarFile, err = os.CreateTemp(tmpDir, "file.tgz")
 			h.AssertNil(t, err)
 		})
 
@@ -375,7 +374,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 				)
 
 				it.Before(func() {
-					tmpSrcDir, err = ioutil.TempDir("", "socket-test")
+					tmpSrcDir, err = os.MkdirTemp("", "socket-test")
 					h.AssertNil(t, err)
 
 					fakeSocket, err = net.Listen(
@@ -383,7 +382,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 						filepath.Join(tmpSrcDir, "fake-socket"),
 					)
 
-					err = ioutil.WriteFile(filepath.Join(tmpSrcDir, "fake-file"), []byte("some-content"), 0777)
+					err = os.WriteFile(filepath.Join(tmpSrcDir, "fake-file"), []byte("some-content"), 0777)
 					h.AssertNil(t, err)
 				})
 
@@ -592,11 +591,11 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 		when("file is not a zip file", func() {
 			when("file has some content", func() {
 				it("returns false", func() {
-					file, err := ioutil.TempFile(tmpDir, "file.txt")
+					file, err := os.CreateTemp(tmpDir, "file.txt")
 					h.AssertNil(t, err)
 					defer file.Close()
 
-					err = ioutil.WriteFile(file.Name(), []byte("content"), os.ModePerm)
+					err = os.WriteFile(file.Name(), []byte("content"), os.ModePerm)
 					h.AssertNil(t, err)
 
 					isZip, err := archive.IsZip(file.Name())
@@ -607,7 +606,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 
 			when("file doesn't have content", func() {
 				it("returns false", func() {
-					file, err := ioutil.TempFile(tmpDir, "file.txt")
+					file, err := os.CreateTemp(tmpDir, "file.txt")
 					h.AssertNil(t, err)
 					defer file.Close()
 

--- a/pkg/archive/tar_builder_test.go
+++ b/pkg/archive/tar_builder_test.go
@@ -2,7 +2,6 @@ package archive_test
 
 import (
 	"archive/tar"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -33,7 +32,7 @@ func testTarBuilder(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "tar-builder-test")
+		tmpDir, err = os.MkdirTemp("", "tar-builder-test")
 		h.AssertNil(t, err)
 		tarBuilder = archive.TarBuilder{}
 	})

--- a/pkg/blob/downloader.go
+++ b/pkg/blob/downloader.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -99,7 +98,7 @@ func (d *downloader) handleHTTP(ctx context.Context, uri string) (string, error)
 
 	etag := ""
 	if etagExists {
-		bytes, err := ioutil.ReadFile(filepath.Clean(etagFile))
+		bytes, err := os.ReadFile(filepath.Clean(etagFile))
 		if err != nil {
 			return "", err
 		}
@@ -125,7 +124,7 @@ func (d *downloader) handleHTTP(ctx context.Context, uri string) (string, error)
 		return "", errors.Wrap(err, "writing cache")
 	}
 
-	if err = ioutil.WriteFile(etagFile, []byte(etag), 0744); err != nil {
+	if err = os.WriteFile(etagFile, []byte(etag), 0744); err != nil {
 		return "", errors.Wrap(err, "writing etag")
 	}
 

--- a/pkg/blob/downloader_test.go
+++ b/pkg/blob/downloader_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -36,9 +35,9 @@ func testDownloader(t *testing.T, when spec.G, it spec.S) {
 		)
 
 		it.Before(func() {
-			cacheDir, err = ioutil.TempDir("", "cache")
+			cacheDir, err = os.MkdirTemp("", "cache")
 			h.AssertNil(t, err)
-			subject = blob.NewDownloader(&logger{ioutil.Discard}, cacheDir)
+			subject = blob.NewDownloader(&logger{io.Discard}, cacheDir)
 		})
 
 		it.After(func() {

--- a/pkg/buildpack/builder.go
+++ b/pkg/buildpack/builder.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/buildpacks/imgutil/layer"
@@ -161,7 +160,7 @@ func (b *PackageBuilder) SaveAsFile(path, imageOS string) error {
 		return errors.Wrap(err, "creating layout image")
 	}
 
-	tmpDir, err := ioutil.TempDir("", "package-buildpack")
+	tmpDir, err := os.MkdirTemp("", "package-buildpack")
 	if err != nil {
 		return err
 	}
@@ -171,7 +170,7 @@ func (b *PackageBuilder) SaveAsFile(path, imageOS string) error {
 		return err
 	}
 
-	layoutDir, err := ioutil.TempDir(tmpDir, "oci-layout")
+	layoutDir, err := os.MkdirTemp(tmpDir, "oci-layout")
 	if err != nil {
 		return errors.Wrap(err, "creating oci-layout temp dir")
 	}
@@ -241,7 +240,7 @@ func (b *PackageBuilder) SaveAsImage(repoName string, publish bool, imageOS stri
 		return nil, errors.Wrapf(err, "creating image")
 	}
 
-	tmpDir, err := ioutil.TempDir("", "package-buildpack")
+	tmpDir, err := os.MkdirTemp("", "package-buildpack")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/buildpack/builder_test.go
+++ b/pkg/buildpack/builder_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -57,7 +56,7 @@ func testPackageBuilder(t *testing.T, when spec.G, it spec.S) {
 		}
 
 		var err error
-		tmpDir, err = ioutil.TempDir("", "package_builder_tests")
+		tmpDir, err = os.MkdirTemp("", "package_builder_tests")
 		h.AssertNil(t, err)
 	})
 
@@ -801,7 +800,7 @@ func testPackageBuilder(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNil(t, err)
 
 			// layer: application/vnd.docker.image.rootfs.diff.tar.gzip
-			expectedBaseLayerSHA, err := computeLayerSHA(ioutil.NopCloser(expectedBaseLayerReader))
+			expectedBaseLayerSHA, err := computeLayerSHA(io.NopCloser(expectedBaseLayerReader))
 			h.AssertNil(t, err)
 			h.AssertOnTarEntry(t, outputFile,
 				"/blobs/sha256/"+expectedBaseLayerSHA,
@@ -834,7 +833,7 @@ func computeLayerSHA(reader io.ReadCloser) (string, error) {
 	}
 	defer compressed.Close()
 
-	if _, err := io.Copy(ioutil.Discard, compressed); err != nil {
+	if _, err := io.Copy(io.Discard, compressed); err != nil {
 		return "", err
 	}
 

--- a/pkg/buildpack/buildpack_test.go
+++ b/pkg/buildpack/buildpack_test.go
@@ -3,7 +3,6 @@ package buildpack_test
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +31,7 @@ func testBuildpack(t *testing.T, when spec.G, it spec.S) {
 		bpReader, err := bp.Open()
 		h.AssertNil(t, err)
 
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		h.AssertNil(t, err)
 
 		p := filepath.Join(tmpDir, "bp.tar")
@@ -173,7 +172,7 @@ id = "some.stack.id"
 			bpReader, err := bp.Open()
 			h.AssertNil(t, err)
 
-			_, err = io.Copy(ioutil.Discard, bpReader)
+			_, err = io.Copy(io.Discard, bpReader)
 			h.AssertError(t, err, "error from errBlob")
 		})
 

--- a/pkg/buildpack/downloader_test.go
+++ b/pkg/buildpack/downloader_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -113,7 +112,7 @@ func testBuildpackDownloader(t *testing.T, when spec.G, it spec.S) {
 			AnyTimes()
 
 		var err error
-		tmpDir, err = ioutil.TempDir("", "buildpack-downloader-test")
+		tmpDir, err = os.MkdirTemp("", "buildpack-downloader-test")
 		h.AssertNil(t, err)
 	})
 

--- a/pkg/buildpack/parse_name.go
+++ b/pkg/buildpack/parse_name.go
@@ -37,7 +37,6 @@ func ParsePackageLocator(locator string) (imageName string) {
 // Supported formats:
 //   - <ns>/<name>[@<version>]
 //   - urn:cnb:registry:<ns>/<name>[@<version>]
-//
 func ParseRegistryID(registryID string) (namespace string, name string, version string, err error) {
 	id, version := ParseIDLocator(registryID)
 

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -50,16 +50,15 @@ const (
 // Implementations of the Lifecycle must execute the following phases by calling the
 // phase-specific lifecycle binary in order:
 //
-//  Detection:         /cnb/lifecycle/detector
-//  Analysis:          /cnb/lifecycle/analyzer
-//  Cache Restoration: /cnb/lifecycle/restorer
-//  Build:             /cnb/lifecycle/builder
-//  Export:            /cnb/lifecycle/exporter
+//	Detection:         /cnb/lifecycle/detector
+//	Analysis:          /cnb/lifecycle/analyzer
+//	Cache Restoration: /cnb/lifecycle/restorer
+//	Build:             /cnb/lifecycle/builder
+//	Export:            /cnb/lifecycle/exporter
 //
 // or invoke the single creator binary:
 //
-//  Creator:            /cnb/lifecycle/creator
-//
+//	Creator:            /cnb/lifecycle/creator
 type LifecycleExecutor interface {
 	// Execute is responsible for invoking each of these binaries
 	// with the desired configuration.
@@ -666,45 +665,45 @@ func (c *Client) processProxyConfig(config *ProxyConfig) ProxyConfig {
 //
 // Visual examples:
 //
-// 	BUILDER ORDER
-// 	----------
-//  - group:
-//		- A
-//		- B
-//  - group:
-//		- A
+//		BUILDER ORDER
+//		----------
+//	 - group:
+//			- A
+//			- B
+//	 - group:
+//			- A
 //
-//	WITH DECLARED: "from=builder", X
-// 	----------
-// 	- group:
-//		- A
-//		- B
-//		- X
-// 	 - group:
-//		- A
-//		- X
+//		WITH DECLARED: "from=builder", X
+//		----------
+//		- group:
+//			- A
+//			- B
+//			- X
+//		 - group:
+//			- A
+//			- X
 //
-//	WITH DECLARED: X, "from=builder", Y
-// 	----------
-// 	- group:
-//		- X
-//		- A
-//		- B
-//      - Y
-// 	- group:
-//		- X
-//		- A
-//      - Y
+//		WITH DECLARED: X, "from=builder", Y
+//		----------
+//		- group:
+//			- X
+//			- A
+//			- B
+//	     - Y
+//		- group:
+//			- X
+//			- A
+//	     - Y
 //
-//	WITH DECLARED: X
-// 	----------
-//	- group:
-//		- X
+//		WITH DECLARED: X
+//		----------
+//		- group:
+//			- X
 //
-//	WITH DECLARED: A
-// 	----------
-// 	- group:
-//		- A
+//		WITH DECLARED: A
+//		----------
+//		- group:
+//			- A
 func (c *Client) processBuildpacks(ctx context.Context, builderImage imgutil.Image, builderBPs []dist.ModuleInfo, builderOrder dist.Order, stackID string, opts BuildOptions) (fetchedBPs []buildpack.BuildModule, order dist.Order, err error) {
 	pullPolicy := opts.PullPolicy
 	publish := opts.Publish

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -915,7 +914,7 @@ func parseDigestFromImageID(id imgutil.Identifier) string {
 }
 
 func createInlineBuildpack(bp projectTypes.Buildpack, stackID string) (string, error) {
-	pathToInlineBuilpack, err := ioutil.TempDir("", "inline-cnb")
+	pathToInlineBuilpack, err := os.MkdirTemp("", "inline-cnb")
 	if err != nil {
 		return pathToInlineBuilpack, err
 	}

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -85,7 +84,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 		fakeImageFetcher = ifakes.NewFakeImageFetcher()
 		fakeLifecycle = &ifakes.FakeLifecycle{}
 
-		tmpDir, err = ioutil.TempDir("", "build-test")
+		tmpDir, err = os.MkdirTemp("", "build-test")
 		h.AssertNil(t, err)
 
 		defaultBuilderImage = newFakeBuilderImage(t, tmpDir, defaultBuilderName, defaultBuilderStackID, defaultRunImageName, builder.DefaultLifecycleVersion, newLinuxImage)
@@ -130,7 +129,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)
 
-		dlCacheDir, err := ioutil.TempDir(tmpDir, "dl-cache")
+		dlCacheDir, err := os.MkdirTemp(tmpDir, "dl-cache")
 		h.AssertNil(t, err)
 
 		blobDownloader := blob.NewDownloader(logger, dlCacheDir)
@@ -355,7 +354,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 				)
 
 				it.Before(func() {
-					tmpDir, err = ioutil.TempDir("", "build-symlink-test")
+					tmpDir, err = os.MkdirTemp("", "build-symlink-test")
 					h.AssertNil(t, err)
 
 					appDirPath := filepath.Join(tmpDir, appDirName)
@@ -1302,7 +1301,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 
 					it.Before(func() {
 						var err error
-						tmpDir, err = ioutil.TempDir("", "project-desc")
+						tmpDir, err = os.MkdirTemp("", "project-desc")
 						h.AssertNil(t, err)
 					})
 
@@ -1460,7 +1459,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 
 					it.Before(func() {
 						var err error
-						tmpDir, err = ioutil.TempDir("", "registry")
+						tmpDir, err = os.MkdirTemp("", "registry")
 						h.AssertNil(t, err)
 
 						packHome = filepath.Join(tmpDir, ".pack")
@@ -2317,7 +2316,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 				})
 				when("linux container", func() {
 					it("drive is transformed", func() {
-						dir, _ := ioutil.TempDir("", "pack-test-mount")
+						dir, _ := os.MkdirTemp("", "pack-test-mount")
 						volume := fmt.Sprintf("%v:/x", dir)
 						err := subject.Build(context.TODO(), BuildOptions{
 							Image:   "some/app",
@@ -2386,7 +2385,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 				})
 				when("windows container", func() {
 					it("drive is mounted", func() {
-						dir, _ := ioutil.TempDir("", "pack-test-mount")
+						dir, _ := os.MkdirTemp("", "pack-test-mount")
 						volume := fmt.Sprintf("%v:c:\\x", dir)
 						err := subject.Build(context.TODO(), BuildOptions{
 							Image:   "some/app",

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,11 +1,11 @@
 /*
 Package client provides all the functionally provided by pack as a library through a go api.
 
-Prerequisites
+# Prerequisites
 
 In order to use most functionality, you will need an OCI runtime such as Docker or podman installed.
 
-References
+# References
 
 This package provides functionality to create and manipulate all artifacts outlined in the Cloud Native Buildpacks specification.
 An introduction to these artifacts and their usage can be found at https://buildpacks.io/docs/.

--- a/pkg/client/create_builder_test.go
+++ b/pkg/client/create_builder_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -178,7 +177,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				PullPolicy: image.PullAlways,
 			}
 
-			tmpDir, err = ioutil.TempDir("", "create-builder-test")
+			tmpDir, err = os.MkdirTemp("", "create-builder-test")
 			h.AssertNil(t, err)
 		})
 

--- a/pkg/client/download_sbom_test.go
+++ b/pkg/client/download_sbom_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -62,17 +61,17 @@ func testDownloadSBOM(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			tmpDir, err = ioutil.TempDir("", "pack.download.sbom.test.")
+			tmpDir, err = os.MkdirTemp("", "pack.download.sbom.test.")
 			h.AssertNil(t, err)
 
-			f, err := ioutil.TempFile("", "pack.download.sbom.test.")
+			f, err := os.CreateTemp("", "pack.download.sbom.test.")
 			h.AssertNil(t, err)
 			tmpFile = f.Name()
 
 			err = archive.CreateSingleFileTar(tmpFile, "sbom", "some-sbom-content")
 			h.AssertNil(t, err)
 
-			data, err := ioutil.ReadFile(tmpFile)
+			data, err := os.ReadFile(tmpFile)
 			h.AssertNil(t, err)
 
 			hsh := sha256.New()
@@ -102,7 +101,7 @@ func testDownloadSBOM(t *testing.T, when spec.G, it spec.S) {
 			err := subject.DownloadSBOM("some/image", DownloadSBOMOptions{Daemon: true, DestinationDir: tmpDir})
 			h.AssertNil(t, err)
 
-			contents, err := ioutil.ReadFile(filepath.Join(tmpDir, "sbom"))
+			contents, err := os.ReadFile(filepath.Join(tmpDir, "sbom"))
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, string(contents), "some-sbom-content")

--- a/pkg/client/inspect_buildpack_test.go
+++ b/pkg/client/inspect_buildpack_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -184,7 +183,7 @@ func testInspectBuildpack(t *testing.T, when spec.G, it spec.S) {
 		apiVersion, err = api.NewVersion("0.2")
 		h.AssertNil(t, err)
 
-		tmpDir, err = ioutil.TempDir("", "inspectBuildpack")
+		tmpDir, err = os.MkdirTemp("", "inspectBuildpack")
 		h.AssertNil(t, err)
 
 		buildpackPath = filepath.Join(tmpDir, "buildpackTarFile.tar")
@@ -493,7 +492,7 @@ func testInspectBuildpack(t *testing.T, when spec.G, it spec.S) {
 			when("archive is not a buildpack", func() {
 				it.Before(func() {
 					invalidBuildpackPath := filepath.Join(tmpDir, "fake-buildpack-path")
-					h.AssertNil(t, ioutil.WriteFile(invalidBuildpackPath, []byte("not a buildpack"), os.ModePerm))
+					h.AssertNil(t, os.WriteFile(invalidBuildpackPath, []byte("not a buildpack"), os.ModePerm))
 
 					mockDownloader.EXPECT().Download(gomock.Any(), "https://invalid/buildpack").Return(blob.NewBlob(invalidBuildpackPath), nil)
 				})

--- a/pkg/client/new_buildpack.go
+++ b/pkg/client/new_buildpack.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -83,7 +82,7 @@ func createBinScript(path, name, contents string, c *Client) error {
 		// The following line's comment is for gosec, it will ignore rule 306 in this case
 		// G306: Expect WriteFile permissions to be 0600 or less
 		/* #nosec G306 */
-		err = ioutil.WriteFile(binFile, []byte(contents), 0755)
+		err = os.WriteFile(binFile, []byte(contents), 0755)
 		if err != nil {
 			return err
 		}

--- a/pkg/client/new_buildpack_test.go
+++ b/pkg/client/new_buildpack_test.go
@@ -3,7 +3,6 @@ package client_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -34,7 +33,7 @@ func testNewBuildpack(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		tmpDir, err = ioutil.TempDir("", "new-buildpack-test")
+		tmpDir, err = os.MkdirTemp("", "new-buildpack-test")
 		h.AssertNil(t, err)
 
 		subject, err = client.NewClient()
@@ -82,11 +81,11 @@ func testNewBuildpack(t *testing.T, when spec.G, it spec.S) {
 
 				err = os.MkdirAll(filepath.Join(tmpDir, "bin"), 0755)
 				h.AssertNil(t, err)
-				err = ioutil.WriteFile(filepath.Join(tmpDir, "buildpack.toml"), []byte("expected value"), 0655)
+				err = os.WriteFile(filepath.Join(tmpDir, "buildpack.toml"), []byte("expected value"), 0655)
 				h.AssertNil(t, err)
-				err = ioutil.WriteFile(filepath.Join(tmpDir, "bin", "build"), []byte("expected value"), 0755)
+				err = os.WriteFile(filepath.Join(tmpDir, "bin", "build"), []byte("expected value"), 0755)
 				h.AssertNil(t, err)
-				err = ioutil.WriteFile(filepath.Join(tmpDir, "bin", "detect"), []byte("expected value"), 0755)
+				err = os.WriteFile(filepath.Join(tmpDir, "bin", "detect"), []byte("expected value"), 0755)
 				h.AssertNil(t, err)
 			})
 
@@ -105,15 +104,15 @@ func testNewBuildpack(t *testing.T, when spec.G, it spec.S) {
 				})
 				h.AssertNil(t, err)
 
-				content, err := ioutil.ReadFile(filepath.Join(tmpDir, "buildpack.toml"))
+				content, err := os.ReadFile(filepath.Join(tmpDir, "buildpack.toml"))
 				h.AssertNil(t, err)
 				h.AssertEq(t, content, []byte("expected value"))
 
-				content, err = ioutil.ReadFile(filepath.Join(tmpDir, "bin", "build"))
+				content, err = os.ReadFile(filepath.Join(tmpDir, "bin", "build"))
 				h.AssertNil(t, err)
 				h.AssertEq(t, content, []byte("expected value"))
 
-				content, err = ioutil.ReadFile(filepath.Join(tmpDir, "bin", "detect"))
+				content, err = os.ReadFile(filepath.Join(tmpDir, "bin", "detect"))
 				h.AssertNil(t, err)
 				h.AssertEq(t, content, []byte("expected value"))
 			})

--- a/pkg/client/package_buildpack_test.go
+++ b/pkg/client/package_buildpack_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -419,7 +418,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 	when("FormatFile", func() {
 		when("simple package for both OS formats (experimental only)", func() {
 			it("creates package image in either OS format", func() {
-				tmpDir, err := ioutil.TempDir("", "package-buildpack")
+				tmpDir, err := os.MkdirTemp("", "package-buildpack")
 				h.AssertNil(t, err)
 				defer os.Remove(tmpDir)
 
@@ -484,7 +483,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 					}},
 				}
 
-				tmpDir, err = ioutil.TempDir("", "package-buildpack")
+				tmpDir, err = os.MkdirTemp("", "package-buildpack")
 				h.AssertNil(t, err)
 			})
 
@@ -712,7 +711,7 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 						}},
 					}
 
-					tmpDir, err = ioutil.TempDir("", "registry")
+					tmpDir, err = os.MkdirTemp("", "registry")
 					h.AssertNil(t, err)
 
 					packHome = filepath.Join(tmpDir, ".pack")

--- a/pkg/client/pull_buildpack_test.go
+++ b/pkg/client/pull_buildpack_test.go
@@ -3,7 +3,6 @@ package client_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -108,7 +107,7 @@ func testPullBuildpack(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			tmpDir, err = ioutil.TempDir("", "registry")
+			tmpDir, err = os.MkdirTemp("", "registry")
 			h.AssertNil(t, err)
 
 			packHome = filepath.Join(tmpDir, ".pack")

--- a/pkg/logging/logger_writers.go
+++ b/pkg/logging/logger_writers.go
@@ -4,7 +4,6 @@ package logging
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"sync"
 	"time"
@@ -91,7 +90,7 @@ func (lw *LogWithWriters) HandleLog(e *log.Entry) error {
 // WriterForLevel returns a Writer for the given Level
 func (lw *LogWithWriters) WriterForLevel(level Level) io.Writer {
 	if lw.Level > log.Level(level) {
-		return ioutil.Discard
+		return io.Discard
 	}
 
 	if level == ErrorLevel {

--- a/pkg/logging/logger_writers_test.go
+++ b/pkg/logging/logger_writers_test.go
@@ -3,7 +3,6 @@ package logging_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -78,7 +77,7 @@ func testLogWithWriters(t *testing.T, when spec.G, it spec.S) {
 
 		it("will return correct writers", func() {
 			h.AssertSameInstance(t, logger.Writer(), outCons)
-			h.AssertSameInstance(t, logger.WriterForLevel(logging.DebugLevel), ioutil.Discard)
+			h.AssertSameInstance(t, logger.WriterForLevel(logging.DebugLevel), io.Discard)
 		})
 
 		it("is only verbose for debug level", func() {
@@ -166,8 +165,8 @@ func testLogWithWriters(t *testing.T, when spec.G, it spec.S) {
 
 		it("will return correct writers", func() {
 			h.AssertSameInstance(t, logger.Writer(), outCons)
-			h.AssertSameInstance(t, logger.WriterForLevel(logging.DebugLevel), ioutil.Discard)
-			h.AssertSameInstance(t, logger.WriterForLevel(logging.InfoLevel), ioutil.Discard)
+			h.AssertSameInstance(t, logger.WriterForLevel(logging.DebugLevel), io.Discard)
+			h.AssertSameInstance(t, logger.WriterForLevel(logging.InfoLevel), io.Discard)
 		})
 	})
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -3,7 +3,6 @@ package logging
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/buildpacks/pack/internal/style"
 )
@@ -53,7 +52,7 @@ func GetWriterForLevel(logger Logger, level Level) io.Writer {
 
 // IsQuiet defines whether a pack logger is set to quiet mode
 func IsQuiet(logger Logger) bool {
-	if writer := GetWriterForLevel(logger, InfoLevel); writer == ioutil.Discard {
+	if writer := GetWriterForLevel(logger, InfoLevel); writer == io.Discard {
 		return true
 	}
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -2,7 +2,7 @@ package project
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
@@ -27,7 +27,7 @@ var parsers = map[string]func(string) (types.Descriptor, error){
 }
 
 func ReadProjectDescriptor(pathToFile string) (types.Descriptor, error) {
-	projectTomlContents, err := ioutil.ReadFile(filepath.Clean(pathToFile))
+	projectTomlContents, err := os.ReadFile(filepath.Clean(pathToFile))
 	if err != nil {
 		return types.Descriptor{}, err
 	}

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -1,7 +1,6 @@
 package project
 
 import (
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -366,7 +365,7 @@ name = "licenses should have either a type or uri defined"
 }
 
 func createTmpProjectTomlFile(projectToml string) (*os.File, error) {
-	tmpProjectToml, err := ioutil.TempFile(os.TempDir(), "project-")
+	tmpProjectToml, err := os.CreateTemp(os.TempDir(), "project-")
 	if err != nil {
 		log.Fatal("Failed to create temporary project toml file", err)
 	}

--- a/pkg/project/v02/metadata_test.go
+++ b/pkg/project/v02/metadata_test.go
@@ -2,7 +2,6 @@ package v02
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -38,7 +37,7 @@ func testMetadata(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		repoPath, err = ioutil.TempDir("", "test-repo")
+		repoPath, err = os.MkdirTemp("", "test-repo")
 		h.AssertNil(t, err)
 
 		repo, err = git.PlainInit(repoPath, false)
@@ -585,7 +584,7 @@ func createCommits(t *testing.T, repo *git.Repository, repoPath string, numberOf
 
 	var commitHashes []plumbing.Hash
 	for i := 0; i < numberOfCommits; i++ {
-		file, err := ioutil.TempFile(repoPath, h.RandString(10))
+		file, err := os.CreateTemp(repoPath, h.RandString(10))
 		h.AssertNil(t, err)
 		defer file.Close()
 

--- a/testhelpers/comparehelpers/deep_compare.go
+++ b/testhelpers/comparehelpers/deep_compare.go
@@ -9,13 +9,18 @@ import (
 // Note this method searches all objects in 'container' for containee
 // Contains is defined by the following relationship
 // basic data types (string, float, int,...):
-//    container == containee
+//
+//	container == containee
+//
 // maps:
-//    every key-value pair from containee is in container
-//    Ex: {"a": 1, "b": 2, "c": 3} contains {"a": 1, "c": 3}
+//
+//	every key-value pair from containee is in container
+//	Ex: {"a": 1, "b": 2, "c": 3} contains {"a": 1, "c": 3}
+//
 // arrays:
-//    every element in containee is present and ordered in an array in container
-//    Ex: [1, 1, 4, 3, 10, 4] contains [1, 3, 4 ]
+//
+//	every element in containee is present and ordered in an array in container
+//	Ex: [1, 1, 4, 3, 10, 4] contains [1, 3, 4 ]
 //
 // Limitaions:
 // Cannot handle the following types: Pointers, Func

--- a/testhelpers/registry.go
+++ b/testhelpers/registry.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -254,10 +253,10 @@ func generateHtpasswd(t *testing.T, username string, password string) io.ReadClo
 }
 
 func setupDockerConfigWithAuth(t *testing.T, username string, password string, runRegistryHost string, runRegistryPort string) string {
-	dockerConfigDir, err := ioutil.TempDir("", "pack.test.docker.config.dir")
+	dockerConfigDir, err := os.MkdirTemp("", "pack.test.docker.config.dir")
 	AssertNil(t, err)
 
-	AssertNil(t, ioutil.WriteFile(filepath.Join(dockerConfigDir, "config.json"), []byte(fmt.Sprintf(`{
+	AssertNil(t, os.WriteFile(filepath.Join(dockerConfigDir, "config.json"), []byte(fmt.Sprintf(`{
 			  "auths": {
 			    "%s": {
 			      "auth": "%s"

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildpacks/pack/tools
 
-go 1.18
+go 1.19
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
## Summary
403dd5051481aea7aedf48ac14e78d5b9eff72fa: Update GH Actions and go.mod with golang 1.19.
f774522845b33ef74bf6d32e3587edf5c1615933: `gofmt` had fresh complaints (did the style change?) so I reformatted with `make format`
745be45c1b3476be03b73a1378932794037802df: `golangci-lint` loudly complained about `io/ioutil` being deprecated so I refactored it to equivalents with find/replace. The only last sticky place was that `io.ioutil.ReadDir` returned `fs.FileInfo`, while the equivalent `os.ReadDir` returns `fs.DirEntry`. so there was an extra step to get the FileInfo. See also [ fs.DirEntry](https://pkg.go.dev/io/ioutil#ReadDir) for the recommended refactor pattern.

## Output
n/a


## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
