### PR TITLE
if lifecycle image is supplied, consider its apis

### DIFF
--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -171,6 +171,47 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("FindLatestSupported", func() {
+		it("chooses a shared version", func() {
+			version, err := build.FindLatestSupported([]*api.Version{api.MustParse("0.6"), api.MustParse("0.7"), api.MustParse("0.8")}, []string{"0.7"})
+			h.AssertNil(t, err)
+			h.AssertEq(t, version, api.MustParse("0.7"))
+		})
+
+		it("chooses a shared version, highest builder supported version", func() {
+			version, err := build.FindLatestSupported([]*api.Version{api.MustParse("0.4"), api.MustParse("0.5"), api.MustParse("0.7")}, []string{"0.7", "0.8"})
+			h.AssertNil(t, err)
+			h.AssertEq(t, version, api.MustParse("0.7"))
+		})
+
+		it("chooses a shared version, lowest builder supported version", func() {
+			version, err := build.FindLatestSupported([]*api.Version{api.MustParse("0.4"), api.MustParse("0.5"), api.MustParse("0.7")}, []string{"0.1", "0.2", "0.4"})
+			h.AssertNil(t, err)
+			h.AssertEq(t, version, api.MustParse("0.4"))
+		})
+
+		it("Interprets empty lifecycle versions list as lack of constraints", func() {
+			version, err := build.FindLatestSupported([]*api.Version{api.MustParse("0.6"), api.MustParse("0.7")}, []string{})
+			h.AssertNil(t, err)
+			h.AssertEq(t, version, api.MustParse("0.7"))
+		})
+
+		it("errors with no shared version, builder has no versions supported for some reason", func() {
+			_, err := build.FindLatestSupported([]*api.Version{}, []string{"0.7"})
+			h.AssertNotNil(t, err)
+		})
+
+		it("errors with no shared version, builder less than lifecycle", func() {
+			_, err := build.FindLatestSupported([]*api.Version{api.MustParse("0.4"), api.MustParse("0.5")}, []string{"0.7", "0.8"})
+			h.AssertNotNil(t, err)
+		})
+
+		it("errors with no shared version, builder greater than lifecycle", func() {
+			_, err := build.FindLatestSupported([]*api.Version{api.MustParse("0.8"), api.MustParse("0.9")}, []string{"0.6", "0.7"})
+			h.AssertNotNil(t, err)
+		})
+	})
+
 	when("Run", func() {
 		var (
 			imageName   name.Tag

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -72,6 +72,7 @@ type LifecycleOptions struct {
 	Builder              Builder
 	BuilderImage         string // differs from Builder.Name() and Builder.Image().Name() in that it includes the registry context
 	LifecycleImage       string
+	LifecycleApis        []string // optional - populated only if custom lifecycle image is downloaded, from that lifecycle's container's Labels.
 	RunImage             string
 	ProjectMetadata      platform.ProjectMetadata
 	ClearCache           bool

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -1702,6 +1702,20 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 							h.AssertEq(t, args.PullPolicy, image.PullAlways)
 							h.AssertEq(t, args.Platform, "linux/amd64")
 						})
+						it("uses the api versions of the lifecycle image", func() {
+							h.AssertTrue(t, true)
+						})
+						it("parses the versions correctly", func() {
+							fakeLifecycleImage.SetLabel("io.buildpacks.lifecycle.apis", "{\"platform\":{\"deprecated\":[\"0.1\"],\"supported\":[\"0.2\",\"0.3\",\"0.4\",\"0.5\"]}}")
+
+							h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+								Image:        "some/app",
+								Builder:      defaultBuilderName,
+								Publish:      true,
+								TrustBuilder: func(string) bool { return false },
+							}))
+							h.AssertSliceContainsInOrder(t, fakeLifecycle.Opts.LifecycleApis, "0.1", "0.2", "0.3", "0.4", "0.5")
+						})
 					})
 
 					when("lifecycle image is not available", func() {


### PR DESCRIPTION


## Summary
if we're injecting a custom lifecycle image into an untrusted builder, when we select the platform api version we'll consider the intersection between the builder, the lifecycle, and this instance of pack when choosing which version of the api to speak.

because this is a rare case, the default is that there is no lifecycle api list, which is treated as no constraints.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
technically you could've used a lifecycle that didn't support the highest common version supported by both pack and the builder, but in practice i think this never happened.

#### After
Now it really can't ever happen.


## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ x] No  -- imo this is a very niche case of interest primarily to lifecycle developers, but by all means let me know if i'm misunderstanding the use cases and/or the documentation needs of these valuable members of our community.

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves https://github.com/buildpacks/pack/issues/1091

