### PR TITLE
cleanup: narrow docker interface

### DIFF
--- a/internal/build/container_ops.go
+++ b/internal/build/container_ops.go
@@ -12,7 +12,6 @@ import (
 	"github.com/buildpacks/lifecycle/platform"
 	"github.com/docker/docker/api/types"
 	dcontainer "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
 	darchive "github.com/docker/docker/pkg/archive"
 	"github.com/pkg/errors"
 
@@ -22,11 +21,11 @@ import (
 	"github.com/buildpacks/pack/pkg/archive"
 )
 
-type ContainerOperation func(ctrClient client.CommonAPIClient, ctx context.Context, containerID string, stdout, stderr io.Writer) error
+type ContainerOperation func(ctrClient DockerClient, ctx context.Context, containerID string, stdout, stderr io.Writer) error
 
 // CopyOut copies container directories to a handler function. The handler is responsible for closing the Reader.
 func CopyOut(handler func(closer io.ReadCloser) error, srcs ...string) ContainerOperation {
-	return func(ctrClient client.CommonAPIClient, ctx context.Context, containerID string, stdout, stderr io.Writer) error {
+	return func(ctrClient DockerClient, ctx context.Context, containerID string, stdout, stderr io.Writer) error {
 		for _, src := range srcs {
 			reader, _, err := ctrClient.CopyFromContainer(ctx, containerID, src)
 			if err != nil {
@@ -58,7 +57,7 @@ func CopyOutTo(src, dest string) ContainerOperation {
 // CopyDir copies a local directory (src) to the destination on the container while filtering files and changing it's UID/GID.
 // if includeRoot is set the UID/GID will be set on the dst directory.
 func CopyDir(src, dst string, uid, gid int, os string, includeRoot bool, fileFilter func(string) bool) ContainerOperation {
-	return func(ctrClient client.CommonAPIClient, ctx context.Context, containerID string, stdout, stderr io.Writer) error {
+	return func(ctrClient DockerClient, ctx context.Context, containerID string, stdout, stderr io.Writer) error {
 		tarPath := dst
 		if os == "windows" {
 			tarPath = paths.WindowsToSlash(dst)
@@ -77,7 +76,7 @@ func CopyDir(src, dst string, uid, gid int, os string, includeRoot bool, fileFil
 	}
 }
 
-func copyDir(ctx context.Context, ctrClient client.CommonAPIClient, containerID string, appReader io.Reader) error {
+func copyDir(ctx context.Context, ctrClient DockerClient, containerID string, appReader io.Reader) error {
 	var clientErr, err error
 
 	doneChan := make(chan interface{})
@@ -104,7 +103,7 @@ func copyDir(ctx context.Context, ctrClient client.CommonAPIClient, containerID 
 // for Windows containers and does not work. Instead, we perform the copy from inside a container
 // using xcopy.
 // See: https://github.com/moby/moby/issues/40771
-func copyDirWindows(ctx context.Context, ctrClient client.CommonAPIClient, containerID string, reader io.Reader, dst string, stdout, stderr io.Writer) error {
+func copyDirWindows(ctx context.Context, ctrClient DockerClient, containerID string, reader io.Reader, dst string, stdout, stderr io.Writer) error {
 	info, err := ctrClient.ContainerInspect(ctx, containerID)
 	if err != nil {
 		return err
@@ -173,7 +172,7 @@ func findMount(info types.ContainerJSON, dst string) (types.MountPoint, error) {
 
 // WriteProjectMetadata
 func WriteProjectMetadata(p string, metadata platform.ProjectMetadata, os string) ContainerOperation {
-	return func(ctrClient client.CommonAPIClient, ctx context.Context, containerID string, stdout, stderr io.Writer) error {
+	return func(ctrClient DockerClient, ctx context.Context, containerID string, stdout, stderr io.Writer) error {
 		buf := &bytes.Buffer{}
 		err := toml.NewEncoder(buf).Encode(metadata)
 		if err != nil {
@@ -202,7 +201,7 @@ func WriteProjectMetadata(p string, metadata platform.ProjectMetadata, os string
 
 // WriteStackToml writes a `stack.toml` based on the StackMetadata provided to the destination path.
 func WriteStackToml(dstPath string, stack builder.StackMetadata, os string) ContainerOperation {
-	return func(ctrClient client.CommonAPIClient, ctx context.Context, containerID string, stdout, stderr io.Writer) error {
+	return func(ctrClient DockerClient, ctx context.Context, containerID string, stdout, stderr io.Writer) error {
 		buf := &bytes.Buffer{}
 		err := toml.NewEncoder(buf).Encode(stack)
 		if err != nil {
@@ -252,7 +251,7 @@ func createReader(src, dst string, uid, gid int, includeRoot bool, fileFilter fu
 // Changing permissions on volumes through stopped containers does not work on Docker for Windows so we start the container and make change using icacls
 // See: https://github.com/moby/moby/issues/40771
 func EnsureVolumeAccess(uid, gid int, os string, volumeNames ...string) ContainerOperation {
-	return func(ctrClient client.CommonAPIClient, ctx context.Context, containerID string, stdout, stderr io.Writer) error {
+	return func(ctrClient DockerClient, ctx context.Context, containerID string, stdout, stderr io.Writer) error {
 		if os != "windows" {
 			return nil
 		}

--- a/internal/build/docker.go
+++ b/internal/build/docker.go
@@ -1,0 +1,24 @@
+package build
+
+import (
+	"context"
+	"io"
+
+	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
+	networktypes "github.com/docker/docker/api/types/network"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type DockerClient interface {
+	ImageRemove(ctx context.Context, image string, options types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error)
+	VolumeRemove(ctx context.Context, volumeID string, force bool) error
+	ContainerWait(ctx context.Context, container string, condition containertypes.WaitCondition) (<-chan containertypes.ContainerWaitOKBody, <-chan error)
+	ContainerAttach(ctx context.Context, container string, options types.ContainerAttachOptions) (types.HijackedResponse, error)
+	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error
+	ContainerCreate(ctx context.Context, config *containertypes.Config, hostConfig *containertypes.HostConfig, networkingConfig *networktypes.NetworkingConfig, platform *specs.Platform, containerName string) (containertypes.ContainerCreateCreatedBody, error)
+	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
+	ContainerInspect(ctx context.Context, container string) (types.ContainerJSON, error)
+	ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error
+	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
+}

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/auth"
-	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
@@ -28,7 +27,7 @@ const (
 
 type LifecycleExecution struct {
 	logger       logging.Logger
-	docker       client.CommonAPIClient
+	docker       DockerClient
 	platformAPI  *api.Version
 	layersVolume string
 	appVolume    string
@@ -37,7 +36,7 @@ type LifecycleExecution struct {
 	opts         LifecycleOptions
 }
 
-func NewLifecycleExecution(logger logging.Logger, docker client.CommonAPIClient, opts LifecycleOptions) (*LifecycleExecution, error) {
+func NewLifecycleExecution(logger logging.Logger, docker DockerClient, opts LifecycleOptions) (*LifecycleExecution, error) {
 	latestSupportedPlatformAPI, err := FindLatestSupported(append(
 		opts.Builder.LifecycleDescriptor().APIs.Platform.Deprecated,
 		opts.Builder.LifecycleDescriptor().APIs.Platform.Supported...,

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -9,7 +9,6 @@ import (
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/platform"
-	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/name"
 
 	"github.com/buildpacks/pack/internal/builder"
@@ -45,7 +44,7 @@ type Builder interface {
 
 type LifecycleExecutor struct {
 	logger logging.Logger
-	docker client.CommonAPIClient
+	docker DockerClient
 }
 
 type Cache interface {
@@ -100,7 +99,7 @@ type LifecycleOptions struct {
 	CreationTime         *time.Time
 }
 
-func NewLifecycleExecutor(logger logging.Logger, docker client.CommonAPIClient) *LifecycleExecutor {
+func NewLifecycleExecutor(logger logging.Logger, docker DockerClient) *LifecycleExecutor {
 	return &LifecycleExecutor{logger: logger, docker: docker}
 }
 

--- a/internal/build/phase.go
+++ b/internal/build/phase.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	dcontainer "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
 
 	"github.com/buildpacks/pack/internal/container"
@@ -16,7 +15,7 @@ type Phase struct {
 	name                string
 	infoWriter          io.Writer
 	errorWriter         io.Writer
-	docker              client.CommonAPIClient
+	docker              DockerClient
 	handler             container.Handler
 	ctrConf             *dcontainer.Config
 	hostConf            *dcontainer.HostConfig

--- a/internal/cache/bind_cache.go
+++ b/internal/cache/bind_cache.go
@@ -3,16 +3,14 @@ package cache
 import (
 	"context"
 	"os"
-
-	"github.com/docker/docker/client"
 )
 
 type BindCache struct {
-	docker client.CommonAPIClient
+	docker DockerClient
 	bind   string
 }
 
-func NewBindCache(cacheType CacheInfo, dockerClient client.CommonAPIClient) *BindCache {
+func NewBindCache(cacheType CacheInfo, dockerClient DockerClient) *BindCache {
 	return &BindCache{
 		bind:   cacheType.Source,
 		docker: dockerClient,

--- a/internal/cache/image_cache.go
+++ b/internal/cache/image_cache.go
@@ -9,11 +9,16 @@ import (
 )
 
 type ImageCache struct {
-	docker client.CommonAPIClient
+	docker DockerClient
 	image  string
 }
 
-func NewImageCache(imageRef name.Reference, dockerClient client.CommonAPIClient) *ImageCache {
+type DockerClient interface {
+	ImageRemove(ctx context.Context, image string, options types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error)
+	VolumeRemove(ctx context.Context, volumeID string, force bool) error
+}
+
+func NewImageCache(imageRef name.Reference, dockerClient DockerClient) *ImageCache {
 	return &ImageCache{
 		image:  imageRef.Name(),
 		docker: dockerClient,

--- a/internal/cache/volume_cache.go
+++ b/internal/cache/volume_cache.go
@@ -13,11 +13,11 @@ import (
 )
 
 type VolumeCache struct {
-	docker client.CommonAPIClient
+	docker DockerClient
 	volume string
 }
 
-func NewVolumeCache(imageRef name.Reference, cacheType CacheInfo, suffix string, dockerClient client.CommonAPIClient) *VolumeCache {
+func NewVolumeCache(imageRef name.Reference, cacheType CacheInfo, suffix string, dockerClient DockerClient) *VolumeCache {
 	var volumeName string
 	if cacheType.Source == "" {
 		sum := sha256.Sum256([]byte(imageRef.Name()))

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -85,7 +85,7 @@ type BuildpackDownloader interface {
 // All settings on this object should be changed through ClientOption functions.
 type Client struct {
 	logger logging.Logger
-	docker dockerClient.CommonAPIClient
+	docker DockerClient
 
 	keychain            authn.Keychain
 	imageFactory        ImageFactory
@@ -151,7 +151,7 @@ func WithCacheDir(path string) Option {
 }
 
 // WithDockerClient supply your own docker client.
-func WithDockerClient(docker dockerClient.CommonAPIClient) Option {
+func WithDockerClient(docker DockerClient) Option {
 	return func(c *Client) {
 		c.docker = docker
 	}
@@ -260,7 +260,7 @@ func (r *registryResolver) Resolve(registryName, bpName string) (string, error) 
 }
 
 type imageFactory struct {
-	dockerClient dockerClient.CommonAPIClient
+	dockerClient local.DockerClient
 	keychain     authn.Keychain
 }
 

--- a/pkg/client/docker.go
+++ b/pkg/client/docker.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"context"
+	"io"
+
+	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
+	networktypes "github.com/docker/docker/api/types/network"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// DockerClient is the subset of CommonAPIClient which required by this package
+type DockerClient interface {
+	ImageInspectWithRaw(ctx context.Context, image string) (types.ImageInspect, []byte, error)
+	ImageTag(ctx context.Context, image, ref string) error
+	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error)
+	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
+	ImageRemove(ctx context.Context, image string, options types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error)
+	ImagePull(ctx context.Context, ref string, options types.ImagePullOptions) (io.ReadCloser, error)
+	Info(ctx context.Context) (types.Info, error)
+	VolumeRemove(ctx context.Context, volumeID string, force bool) error
+	ContainerCreate(ctx context.Context, config *containertypes.Config, hostConfig *containertypes.HostConfig, networkingConfig *networktypes.NetworkingConfig, platform *specs.Platform, containerName string) (containertypes.ContainerCreateCreatedBody, error)
+	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
+	ContainerInspect(ctx context.Context, container string) (types.ContainerJSON, error)
+	ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error
+	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
+	ContainerWait(ctx context.Context, container string, condition containertypes.WaitCondition) (<-chan containertypes.ContainerWaitOKBody, <-chan error)
+	ContainerAttach(ctx context.Context, container string, options types.ContainerAttachOptions) (types.HijackedResponse, error)
+	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error
+}

--- a/pkg/image/fetcher.go
+++ b/pkg/image/fetcher.go
@@ -40,8 +40,13 @@ func WithKeychain(keychain authn.Keychain) FetcherOption {
 	}
 }
 
+type DockerClient interface {
+	local.DockerClient
+	ImagePull(ctx context.Context, ref string, options types.ImagePullOptions) (io.ReadCloser, error)
+}
+
 type Fetcher struct {
-	docker          client.CommonAPIClient
+	docker          DockerClient
 	logger          logging.Logger
 	registryMirrors map[string]string
 	keychain        authn.Keychain
@@ -53,7 +58,7 @@ type FetchOptions struct {
 	PullPolicy PullPolicy
 }
 
-func NewFetcher(logger logging.Logger, docker client.CommonAPIClient, opts ...FetcherOption) *Fetcher {
+func NewFetcher(logger logging.Logger, docker DockerClient, opts ...FetcherOption) *Fetcher {
 	fetcher := &Fetcher{
 		logger:   logger,
 		docker:   docker,


### PR DESCRIPTION
## Summary

Narrow used docker interface by defining interface that is a subset of `CommonAPIClient` and only contains functions that we really need.