### PR TITLE
Buildpack URL formatted incorrect when using a registry mirror

### DIFF
--- a/internal/name/name.go
+++ b/internal/name/name.go
@@ -19,7 +19,6 @@ type Logger interface {
 }
 
 func TranslateRegistry(name string, registryMirrors map[string]string, logger Logger) (string, error) {
-	logger.Infof("input %s", name)
 	if registryMirrors == nil {
 		return name, nil
 	}

--- a/internal/name/name_test.go
+++ b/internal/name/name_test.go
@@ -66,5 +66,17 @@ func testTranslateRegistry(t *testing.T, when spec.G, it spec.S) {
 			assert.Nil(err)
 			assert.Equal(output, expected)
 		})
+
+		it("translate a buildpack referenced by a digest", func() {
+			input := "buildpack/bp@sha256:7f48a442c056cd19ea48462e05faa2837ac3a13732c47616d20f11f8c847a8c4"
+			expected := "myregistry.com/buildpack/bp@sha256:7f48a442c056cd19ea48462e05faa2837ac3a13732c47616d20f11f8c847a8c4"
+			registryMirrors := map[string]string{
+				"index.docker.io": "myregistry.com",
+			}
+
+			output, err := name.TranslateRegistry(input, registryMirrors, logger)
+			assert.Nil(err)
+			assert.Equal(output, expected)
+		})
 	})
 }


### PR DESCRIPTION
## Summary
When a mirror is used and a buildpack that points to a digest reference must be downloaded, pack is not parsing correctly the digest.

## Output
No errors are thrown

#### Before

``` =bash
ERROR: failed to build: downloading buildpack: extracting from registry urn:cnb:registry:heroku/ruby: fetching image: could not parse reference: registry.apppackcdn.net/heroku/buildpack-ruby:sha256:7f48a442c056cd19ea48462e05faa2837ac3a13732c47616d20f11f8c847a8c4
```

#### After

``` =bash
Digest: sha256:7f48a442c056cd19ea48462e05faa2837ac3a13732c47616d20f11f8c847a8c4
Status: Downloaded newer image for registry.apppackcdn.net/heroku/buildpack-ruby@sha256:7f48a442c056cd19ea48462e05faa2837ac3a13732c47616d20f11f8c847a8c4
Using mirror registry.apppackcdn.net/heroku/heroku:20-cnb for heroku/heroku:20-cnb
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1618 

Signed-off-by: Juan Bustamante <jbustamante@vmware.com>