### PR TITLE
Fix typo in pack stack suggest

### DIFF
--- a/internal/commands/stack_suggest.go
+++ b/internal/commands/stack_suggest.go
@@ -54,7 +54,7 @@ func stackSuggest(logger logging.Logger) *cobra.Command {
 		Use:     "suggest",
 		Args:    cobra.NoArgs,
 		Short:   "List the recommended stacks",
-		Example: "pack stacks suggest",
+		Example: "pack stack suggest",
 		RunE: logError(logger, func(*cobra.Command, []string) error {
 			Suggest(logger)
 			return nil


### PR DESCRIPTION
Stack suggest should use the singular of stack, not stacks.

## Documentation
This will be pulled into the documentation on rebuild

## Related
https://github.com/buildpacks/docs/issues/566
