### PR TITLE
Disable AUR git publishing because we got revoked

### DIFF
--- a/.github/workflows/delivery-archlinux-git.yml
+++ b/.github/workflows/delivery-archlinux-git.yml
@@ -1,9 +1,9 @@
 name: delivery / archlinux / git
 
 on:
-  push:
-    branches:
-      - main
+#  push:
+#    branches:
+#      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Disable the AUR git repo because we were publishing too frequently and got revoked:

https://aur.archlinux.org/packages/pack-cli-git#comment-897395

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
