### PR TITLE
Use OS-default permissions when creating archive root

### DIFF
--- a/internal/build/container_ops_test.go
+++ b/internal/build/container_ops_test.go
@@ -181,7 +181,7 @@ drwxrwxrwx    2 123      456 (.*) some-vol
 					} else {
 						// Expected results
 						h.AssertContainsMatch(t, outBuf.String(), `
-drwsrwsrwt    2 123      456 (.*) some-vol
+drwxr-xr-x    2 123      456 (.*) some-vol
 `)
 					}
 				}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -5,6 +5,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -16,6 +17,7 @@ import (
 )
 
 var NormalizedDateTime time.Time
+var Umask fs.FileMode
 
 func init() {
 	NormalizedDateTime = time.Date(1980, time.January, 1, 0, 0, 1, 0, time.UTC)
@@ -171,6 +173,9 @@ func WriteDirToTar(tw TarWriter, srcDir, basePath string, uid, gid int, mode int
 			Typeflag: tar.TypeDir,
 			Name:     basePath,
 			Mode:     mode,
+		}
+		if rootHeader.Mode == -1 {
+			rootHeader.Mode = int64(fs.ModePerm &^ Umask)
 		}
 		finalizeHeader(rootHeader, uid, gid, mode, normalizeModTime)
 		if err := tw.WriteHeader(rootHeader); err != nil {

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -2,6 +2,7 @@ package archive_test
 
 import (
 	"archive/tar"
+	"io/fs"
 	"math/rand"
 	"net"
 	"os"
@@ -246,7 +247,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 
 				tw := tar.NewWriter(fh)
 
-				err = archive.WriteDirToTar(tw, src, "/nested/dir/dir-in-archive", 1234, 2345, -1, true, false, nil)
+				err = archive.WriteDirToTar(tw, src, "/nested/dir/dir-in-archive", 1234, 2345, -1, true, true, nil)
 				h.AssertNil(t, err)
 				h.AssertNil(t, tw.Close())
 				h.AssertNil(t, fh.Close())
@@ -258,6 +259,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 				tr := tar.NewReader(file)
 
 				verify := h.NewTarVerifier(t, tr, 1234, 2345)
+				verify.NextDirectory("/nested/dir/dir-in-archive", int64(fs.ModePerm&^archive.Umask))
 				verify.NextFile("/nested/dir/dir-in-archive/some-file.txt", "some-content", fileMode(t, filepath.Join(src, "some-file.txt")))
 				verify.NextDirectory("/nested/dir/dir-in-archive/sub-dir", fileMode(t, filepath.Join(src, "sub-dir")))
 				if runtime.GOOS != "windows" {

--- a/pkg/archive/umask_unix.go
+++ b/pkg/archive/umask_unix.go
@@ -1,0 +1,13 @@
+//go:build unix
+
+package archive
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+func init() {
+	Umask = fs.FileMode(syscall.Umask(0))
+	syscall.Umask(int(Umask))
+}


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
The `archive.WriteDirToTar` function takes a boolean, `includeRoot`, as an argument that controls whether the tar archive created should include a root directory. It also allows users to pass a sentinel value of -1 when specifying the `mode` argument which results in the archive adopting the file permissions for the existing files and directories from the given source.

When these two features combine, we have some strange behavior. The root directory is created adhoc in the tar archive with its mode set to the given value of the `mode` argument. When that value is -1, this translates into an `fs.FileMode`, which is a type of `uint32`, with a value that looks like `dalTLDpSugct?rwxrwxrwx`. If that looks odd, it looks less so in octal, `37777777777`. Simply said, the permission bits overflow and results in a value of `7777` or `rwsrwsrwt` being set.

The key issue here is that we've triggered the special bits on the permission set. Specifically, we're setting SUID, SGID, and Sticky. This is strange to do in a function that simply wants to archive a directory.

This change causes the `archive.WriteDirToTar` function to follow the more standardized default permissions for directory creation, that is to use 0777 and apply the `umask`. This results in much more reasonable permission settings for this root archive directory.

## Output
<!-- If applicable, please provide examples of the output changes. -->

Given the following program:

```go
package main

import (
	"archive/tar"
	"bytes"
	"fmt"
	"io"
	"io/fs"
	"os"

	"github.com/buildpacks/pack/pkg/archive"
)

func main() {
	dir, err := os.MkdirTemp("", "")
	if err != nil {
		panic(err)
	}

	reader := archive.ReadDirAsTar(dir, "/workspace", 123, 456, -1, false, true, nil)
	buffer := bytes.NewBuffer(nil)
	_, err = io.Copy(buffer, reader)
	if err != nil {
		panic(err)
	}

	tr := tar.NewReader(buffer)
	for {
		hdr, err := tr.Next()
		if err == io.EOF {
			break
		}
		if err != nil {
			panic(err)
		}

		fmt.Printf("%s %s\n", fs.FileMode(hdr.Mode), hdr.Name)
	}
}
```

#### Before

```
dalTLDpSugct?rwxrwxrwx /workspace
```

#### After

```
-rwxr-xr-x /workspace
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No