### PR TITLE
fix: Registry cache for Azure DevOps

### DIFF
--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -180,7 +180,7 @@ func (r *Cache) CreateCache() error {
 
 	r.RegistryDir = registryDir
 
-	if strings.Contains(r.url.String(), "dev.azure.com/") {
+	if r.url.Host == "dev.azure.com" {
 		err = exec.Command("git", "clone", r.url.String(), r.RegistryDir).Run()
 		if err != nil {
 			return errors.Wrap(err, "cloning remote registry")

--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -183,7 +183,7 @@ func (r *Cache) CreateCache() error {
 	if r.url.Host == "dev.azure.com" {
 		err = exec.Command("git", "clone", r.url.String(), r.RegistryDir).Run()
 		if err != nil {
-			return errors.Wrap(err, "cloning remote registry")
+			return errors.Wrap(err, "cloning remote registry using native git")
 		}
 
 		repository, err = git.PlainOpen(r.RegistryDir)

--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5"


### PR DESCRIPTION
## Summary
Go Git doesn't work with Azure DevOps due to unsupported protocol: https://github.com/go-git/go-git/issues/64

## Output
If `dev.azure.com/` URL is used for Git, `git clone` is used instead of Go Git library, the downside is `git` must be installed locally
