### PR TITLE
show extensions only if they are present for humanreadable format

### DIFF
--- a/pkg/client/inspect_builder.go
+++ b/pkg/client/inspect_builder.go
@@ -97,6 +97,23 @@ func (c *Client) InspectBuilder(name string, daemon bool, modifiers ...BuilderIn
 		return nil, err
 	}
 
+	if info.Extensions != nil {
+		return &BuilderInfo{
+			Description:     info.Description,
+			Stack:           info.StackID,
+			Mixins:          info.Mixins,
+			RunImage:        info.RunImage,
+			RunImageMirrors: info.RunImageMirrors,
+			Buildpacks:      info.Buildpacks,
+			Order:           info.Order,
+			BuildpackLayers: info.BuildpackLayers,
+			Lifecycle:       info.Lifecycle,
+			CreatedBy:       info.CreatedBy,
+			Extensions:      info.Extensions,
+			OrderExtensions: info.OrderExtensions,
+		}, nil
+	}
+
 	return &BuilderInfo{
 		Description:     info.Description,
 		Stack:           info.StackID,
@@ -108,7 +125,5 @@ func (c *Client) InspectBuilder(name string, daemon bool, modifiers ...BuilderIn
 		BuildpackLayers: info.BuildpackLayers,
 		Lifecycle:       info.Lifecycle,
 		CreatedBy:       info.CreatedBy,
-		Extensions:      info.Extensions,
-		OrderExtensions: info.OrderExtensions,
 	}, nil
 }


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->

## Output
With Extensions:
![image](https://user-images.githubusercontent.com/95537957/230483280-9f131fec-fa36-4183-bafb-6047202017b2.png)

Without Extensions:
![image](https://user-images.githubusercontent.com/95537957/230483420-6f7aee60-af09-47bb-bc6f-ccd88225cf5d.png)

#### Before
![image](https://user-images.githubusercontent.com/95537957/230484016-2b36352d-91bf-4d39-9f21-b2151139b0c0.png)

#### After
![image](https://user-images.githubusercontent.com/95537957/230483280-9f131fec-fa36-4183-bafb-6047202017b2.png)

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1613
