### PR TITLE
Wait for non-running state to prevent concurrency

### DIFF
--- a/internal/container/run.go
+++ b/internal/container/run.go
@@ -20,7 +20,7 @@ type DockerClient interface {
 }
 
 func RunWithHandler(ctx context.Context, docker DockerClient, ctrID string, handler Handler) error {
-	bodyChan, errChan := docker.ContainerWait(ctx, ctrID, dcontainer.WaitConditionNextExit)
+	bodyChan, errChan := docker.ContainerWait(ctx, ctrID, dcontainer.WaitConditionNotRunning)
 
 	resp, err := docker.ContainerAttach(ctx, ctrID, types.ContainerAttachOptions{
 		Stream: true,

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -24,7 +24,7 @@ import (
 	"github.com/buildpacks/imgutil/fakes"
 
 	dockertypes "github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
+	dcontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -33,6 +33,7 @@ import (
 	"github.com/heroku/color"
 	"github.com/pkg/errors"
 
+	"github.com/buildpacks/pack/internal/container"
 	"github.com/buildpacks/pack/internal/stringset"
 	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/pkg/archive"
@@ -634,7 +635,7 @@ func SkipUnless(t *testing.T, expression bool, reason string) {
 }
 
 func RunContainer(ctx context.Context, dockerCli client.CommonAPIClient, id string, stdout io.Writer, stderr io.Writer) error {
-	bodyChan, errChan := dockerCli.ContainerWait(ctx, id, container.WaitConditionNextExit)
+	bodyChan, errChan := container.ContainerWaitWrapper(ctx, dockerCli, id, dcontainer.WaitConditionNextExit)
 
 	logs, err := dockerCli.ContainerAttach(ctx, id, dockertypes.ContainerAttachOptions{
 		Stream: true,


### PR DESCRIPTION
## Summary
During container creation, pack was using the Docker <1.30 container wait way of doing. This made building waits undefinitely in some cases.

#### Before
`ContainerWait` is blocking.

#### After
`ContainerWait` is not blocking and we use the channels to wait for the states we wants.

## Related
Resolves #1732
