### PR TITLE
Create benchmark.yml and add end-to-end benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,57 @@
+name: benchmark
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  benchmark:
+    name: Run Go benchmark example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.19"
+      - name: Set up go env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+        shell: bash
+      - name: Run benchmark
+        run: |
+             mkdir out || (exit 0)
+             go test -bench=. -benchtime=1s ./benchmarks/... -tags=benchmarks | tee ./out/benchmark.txt
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Go Benchmark
+          tool: 'go'
+          output-file-path: ./out/benchmark.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@edithwuly'
+
+      - name: Store benchmark result - separate results repo
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Go Benchmark
+          tool: 'go'
+          output-file-path: ./out/benchmark.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@edithwuly'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,17 +41,3 @@ jobs:
           comment-on-alert: true
           fail-on-alert: true
           alert-comment-cc-users: '@edithwuly'
-
-      - name: Store benchmark result - separate results repo
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Go Benchmark
-          tool: 'go'
-          output-file-path: ./out/benchmark.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
-          # Show alert with commit comment on detecting possible performance regression
-          alert-threshold: '200%'
-          comment-on-alert: true
-          fail-on-alert: true
-          alert-comment-cc-users: '@edithwuly'

--- a/benchmarks/build_test.go
+++ b/benchmarks/build_test.go
@@ -21,11 +21,11 @@ import (
 )
 
 var (
-	baseImg     = "some-org/" + h.RandString(10)
-	trustedImg  = baseImg + "-trusted-"
-	builder     = "cnbs/sample-builder:bionic"
-	mockAppPath = filepath.Join("..", "acceptance", "testdata", "mock_app")
-	paketoBuilder = "paketobuildpacks/builder:base"
+	baseImg             = "some-org/" + h.RandString(10)
+	trustedImg          = baseImg + "-trusted-"
+	builder             = "cnbs/sample-builder:bionic"
+	mockAppPath         = filepath.Join("..", "acceptance", "testdata", "mock_app")
+	paketoBuilder       = "paketobuildpacks/builder:base"
 	additionalBuildapck = "docker://cnbs/sample-package:hello-universe"
 )
 

--- a/benchmarks/build_test.go
+++ b/benchmarks/build_test.go
@@ -6,6 +6,7 @@ package benchmarks
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,15 +22,16 @@ import (
 )
 
 var (
-	baseImg             = "some-org/" + h.RandString(10)
-	trustedImg          = baseImg + "-trusted-"
-	builder             = "cnbs/sample-builder:bionic"
-	mockAppPath         = filepath.Join("..", "acceptance", "testdata", "mock_app")
-	paketoBuilder       = "paketobuildpacks/builder:base"
-	additionalBuildapck = "docker://cnbs/sample-package:hello-universe"
+	baseImg             string
+	trustedImg          string
+	builder             string
+	mockAppPath         string
+	paketoBuilder       string
+	additionalBuildapck string
 )
 
 func BenchmarkBuild(b *testing.B) {
+	setEnv()
 	dockerClient, err := dockerCli.NewClientWithOpts(dockerCli.FromEnv, dockerCli.WithVersion("1.38"))
 	if err != nil {
 		b.Error(errors.Wrap(err, "creating docker client"))
@@ -95,4 +97,23 @@ func createCmd(b *testing.B, docker *dockerCli.Client) *cobra.Command {
 		b.Error(errors.Wrap(err, "creating packClient"))
 	}
 	return commands.Build(logger, cfg.Config{}, packClient)
+}
+
+func setEnv() {
+	if baseImg = os.Getenv("baseImg"); baseImg == "" {
+		baseImg = "some-org/" + h.RandString(10)
+	}
+	trustedImg = baseImg + "-trusted-"
+	if builder = os.Getenv("builder"); builder == "" {
+		builder = "cnbs/sample-builder:bionic"
+	}
+	if mockAppPath = os.Getenv("mockAppPath"); mockAppPath == "" {
+		mockAppPath = filepath.Join("..", "acceptance", "testdata", "mock_app")
+	}
+	if paketoBuilder = os.Getenv("paketoBuilder"); paketoBuilder == "" {
+		paketoBuilder = "paketobuildpacks/builder:base"
+	}
+	if additionalBuildapck = os.Getenv("additionalBuildapck"); additionalBuildapck == "" {
+		additionalBuildapck = "docker://cnbs/sample-package:hello-universe"
+	}
 }

--- a/benchmarks/build_test.go
+++ b/benchmarks/build_test.go
@@ -25,6 +25,8 @@ var (
 	trustedImg  = baseImg + "-trusted-"
 	builder     = "cnbs/sample-builder:bionic"
 	mockAppPath = filepath.Join("..", "acceptance", "testdata", "mock_app")
+	paketoBuilder = "paketobuildpacks/builder:base"
+	additionalBuildapck = "docker://cnbs/sample-package:hello-universe"
 )
 
 func BenchmarkBuild(b *testing.B) {
@@ -53,6 +55,16 @@ func BenchmarkBuild(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			// perform the operation we're analyzing
 			cmd.SetArgs([]string{fmt.Sprintf("%s%d", trustedImg, i), "-p", mockAppPath, "-B", builder, "--trust-builder"})
+			if err = cmd.Execute(); err != nil {
+				b.Error(errors.Wrapf(err, "running build #%d", i))
+			}
+		}
+	})
+
+	b.Run("with Addtional Buildpack", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			// perform the operation we're analyzing
+			cmd.SetArgs([]string{fmt.Sprintf("%s%d", trustedImg, i), "-p", mockAppPath, "-B", paketoBuilder, "--buildpack", additionalBuildapck})
 			if err = cmd.Execute(); err != nil {
 				b.Error(errors.Wrapf(err, "running build #%d", i))
 			}


### PR DESCRIPTION
## Summary
Create git action to keep runing benchmarks and graphing the results each time push on main branch. Benchmark for `pack build --buildpack` is added as well.

## Output
The graphs for benchmark results will be shown in [https://buildpack.github.io/pack/dev/bench/](url).

#### Before
Brank branch `gh-pages` is required for saving benchmark result data. index.html and data.js will be created automatically. `alert-threshold` and `alert-comment-cc-users` field should be decided.

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
