### PR TITLE
Improve the `flatten-exclude` flag behavior when a composite buildpack is provided

### DIFF
--- a/pkg/buildpack/buildpack_tar_writer.go
+++ b/pkg/buildpack/buildpack_tar_writer.go
@@ -91,6 +91,7 @@ func (b *BuildModuleWriter) writeBuildModuleToTar(tw archive.TarWriter, module B
 			return errors.Wrap(err, "failed to get next tar entry")
 		}
 
+		b.logger.Debugf("header.Name = %s", header.Name)
 		if (*parentFolderAdded)[header.Name] {
 			b.logger.Debugf("folder %s was already added, skipping it", style.Symbol(header.Name))
 			continue

--- a/pkg/buildpack/buildpack_tar_writer.go
+++ b/pkg/buildpack/buildpack_tar_writer.go
@@ -58,6 +58,7 @@ func (b *BuildModuleWriter) NToLayerTar(tarPath, filename string, modules []Buil
 			if !parentFolderAdded[rootPath] {
 				parentFolderAdded[rootPath] = true
 			}
+			b.logger.Debugf("root path %s was added", style.Symbol(rootPath))
 		} else {
 			b.logger.Debugf("skipping %s, it was already added", style.Symbol(module.Descriptor().Info().FullName()))
 		}

--- a/pkg/buildpack/buildpack_tar_writer_test.go
+++ b/pkg/buildpack/buildpack_tar_writer_test.go
@@ -25,8 +25,6 @@ func TestBuildModuleWriter(t *testing.T) {
 	spec.Run(t, "testBuildModuleWriter", testBuildModuleWriter, spec.Parallel(), spec.Report(report.Terminal{}))
 }
 
-type void struct{}
-
 func testBuildModuleWriter(t *testing.T, when spec.G, it spec.S) {
 	var (
 		outBuf            bytes.Buffer

--- a/pkg/buildpack/buildpack_tar_writer_test.go
+++ b/pkg/buildpack/buildpack_tar_writer_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sclevine/spec/report"
 
 	ifakes "github.com/buildpacks/pack/internal/fakes"
-	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/pkg/archive"
 	"github.com/buildpacks/pack/pkg/buildpack"
 	"github.com/buildpacks/pack/pkg/dist"
@@ -37,7 +36,6 @@ func testBuildModuleWriter(t *testing.T, when spec.G, it spec.S) {
 		bp1v2             buildpack.BuildModule
 		bp2v1             buildpack.BuildModule
 		bp3v1             buildpack.BuildModule
-		member            void
 		tmpDir            string
 		err               error
 	)
@@ -103,62 +101,25 @@ func testBuildModuleWriter(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#NToLayerTar", func() {
-		when("there are not exclude buildpacks", func() {
-			when("there are not duplicated buildpacks", func() {
-				it("creates a tar", func() {
-					bpModules := []buildpack.BuildModule{bp1v1, bp2v1, bp3v1}
-					tarFile, bpExcluded, err := buildModuleWriter.NToLayerTar(tmpDir, "test-file-1", bpModules, nil)
+		when("there are not duplicated buildpacks", func() {
+			it("creates a tar", func() {
+				bpModules := []buildpack.BuildModule{bp1v1, bp2v1, bp3v1}
+				tarFile, err := buildModuleWriter.NToLayerTar(tmpDir, "test-file-1", bpModules)
 
-					h.AssertNil(t, err)
-					h.AssertTrue(t, len(bpExcluded) == 0)
-					h.AssertNotNil(t, tarFile)
-					assertBuildpackModuleWritten(t, tarFile, bpModules)
-				})
-			})
-
-			when("there are duplicated buildpacks", func() {
-				it("creates a tar skipping root folder from duplicated buildpacks", func() {
-					bpModules := []buildpack.BuildModule{bp1v1, bp1v2, bp2v1, bp3v1}
-					tarFile, bpExcluded, err := buildModuleWriter.NToLayerTar(tmpDir, "test-file-2", bpModules, nil)
-
-					h.AssertNil(t, err)
-					h.AssertTrue(t, len(bpExcluded) == 0)
-					h.AssertNotNil(t, tarFile)
-					assertBuildpackModuleWritten(t, tarFile, bpModules)
-					h.AssertContains(t, outBuf.String(), fmt.Sprintf("folder '%s' was already added, skipping it", "/cnb/buildpacks/buildpack-1-id"))
-				})
+				h.AssertNil(t, err)
+				h.AssertNotNil(t, tarFile)
+				assertBuildpackModuleWritten(t, tarFile, bpModules)
 			})
 		})
 
-		when("there are exclude buildpacks", func() {
-			exclude := make(map[string]struct{})
-			it.Before(func() {
-				exclude[bp2v1.Descriptor().Info().FullName()] = member
-			})
-
-			when("there are not duplicated buildpacks", func() {
-				it("creates a tar skipping excluded buildpacks", func() {
-					bpModules := []buildpack.BuildModule{bp1v1, bp2v1, bp3v1}
-					tarFile, bpExcluded, err := buildModuleWriter.NToLayerTar(tmpDir, "test-file-3", bpModules, exclude)
-					h.AssertNil(t, err)
-					h.AssertTrue(t, len(bpExcluded) == 1)
-					h.AssertNotNil(t, tarFile)
-					assertBuildpackModuleWritten(t, tarFile, []buildpack.BuildModule{bp1v1, bp3v1})
-					h.AssertContains(t, outBuf.String(), fmt.Sprintf("excluding %s from being flattened", style.Symbol(bp2v1.Descriptor().Info().FullName())))
-				})
-			})
-
-			when("there are duplicated buildpacks", func() {
-				it("creates a tar skipping excluded buildpacks and root folder from duplicated buildpacks", func() {
-					bpModules := []buildpack.BuildModule{bp1v1, bp1v2, bp2v1, bp3v1}
-					tarFile, bpExcluded, err := buildModuleWriter.NToLayerTar(tmpDir, "test-file-4", bpModules, exclude)
-					h.AssertNil(t, err)
-					h.AssertTrue(t, len(bpExcluded) == 1)
-					h.AssertNotNil(t, tarFile)
-					assertBuildpackModuleWritten(t, tarFile, []buildpack.BuildModule{bp1v1, bp1v2, bp3v1})
-					h.AssertContains(t, outBuf.String(), fmt.Sprintf("folder '%s' was already added, skipping it", "/cnb/buildpacks/buildpack-1-id"))
-					h.AssertContains(t, outBuf.String(), fmt.Sprintf("excluding %s from being flattened", style.Symbol(bp2v1.Descriptor().Info().FullName())))
-				})
+		when("there are duplicated buildpacks", func() {
+			it("creates a tar skipping root folder from duplicated buildpacks", func() {
+				bpModules := []buildpack.BuildModule{bp1v1, bp1v2, bp2v1, bp3v1}
+				tarFile, err := buildModuleWriter.NToLayerTar(tmpDir, "test-file-2", bpModules)
+				h.AssertNil(t, err)
+				h.AssertNotNil(t, tarFile)
+				assertBuildpackModuleWritten(t, tarFile, bpModules)
+				h.AssertContains(t, outBuf.String(), fmt.Sprintf("folder '%s' was already added, skipping it", "/cnb/buildpacks/buildpack-1-id"))
 			})
 		})
 	})

--- a/pkg/buildpack/buildpack_tar_writer_test.go
+++ b/pkg/buildpack/buildpack_tar_writer_test.go
@@ -112,12 +112,13 @@ func testBuildModuleWriter(t *testing.T, when spec.G, it spec.S) {
 
 		when("there are duplicated buildpacks", func() {
 			it("creates a tar skipping root folder from duplicated buildpacks", func() {
+				expectedMessage := fmt.Sprintf("folder '%s' was already added, skipping it", "/cnb/buildpacks/buildpack-1-id")
 				bpModules := []buildpack.BuildModule{bp1v1, bp1v2, bp2v1, bp3v1}
 				tarFile, err := buildModuleWriter.NToLayerTar(tmpDir, "test-file-2", bpModules)
 				h.AssertNil(t, err)
 				h.AssertNotNil(t, tarFile)
 				assertBuildpackModuleWritten(t, tarFile, bpModules)
-				h.AssertContains(t, outBuf.String(), fmt.Sprintf("folder '%s' was already added, skipping it", "/cnb/buildpacks/buildpack-1-id"))
+				h.AssertContains(t, outBuf.String(), expectedMessage)
 			})
 		})
 	})

--- a/pkg/buildpack/managed_collection.go
+++ b/pkg/buildpack/managed_collection.go
@@ -57,13 +57,13 @@ func (f *ManagedCollection) AddModules(main BuildModule, deps ...BuildModule) {
 		f.explodedModules = append(f.explodedModules, append([]BuildModule{main}, deps...)...)
 	} else {
 		if _, ok := f.excluded[main.Descriptor().Info().FullName()]; ok {
-			f.explodesModules = append(f.explodesModules, append([]BuildModule{main}, deps...)...)
+			f.explodedModules = append(f.explodedModules, append([]BuildModule{main}, deps...)...)
 			f.setExcludedModules(deps)
 			return
 		}
 		if f.maxDepth <= FlattenMaxDepth {
 			excluded, newDeps := f.calculateExcludeModules(deps...)
-			f.explodesModules = append(f.explodesModules, excluded...)
+			f.explodedModules = append(f.explodedModules, excluded...)
 			// flatten all
 			if len(f.flattenedModules) == 1 {
 				f.flattenedModules[0] = append(f.flattenedModules[0], append([]BuildModule{main}, newDeps...)...)
@@ -78,7 +78,7 @@ func (f *ManagedCollection) AddModules(main BuildModule, deps ...BuildModule) {
 					f.explodedModules = append(f.explodedModules, modules...)
 				} else {
 					excluded, newModules := f.calculateExcludeModules(modules...)
-					f.explodesModules = append(f.explodesModules, excluded...)
+					f.explodedModules = append(f.explodedModules, excluded...)
 					f.flattenedModules = append(f.flattenedModules, newModules)
 				}
 			}

--- a/pkg/buildpack/managed_collection_test.go
+++ b/pkg/buildpack/managed_collection_test.go
@@ -139,7 +139,7 @@ func testModuleManager(t *testing.T, when spec.G, it spec.S) {
 	when("manager is configured in flatten mode", func() {
 		when("flatten all", func() {
 			it.Before(func() {
-				moduleManager = buildpack.NewModuleManager(true, buildpack.FlattenMaxDepth)
+				moduleManager = buildpack.NewModuleManager(true, buildpack.FlattenMaxDepth, nil)
 				moduleManager.AddModules(compositeBP1, []buildpack.BuildModule{bp1, compositeBP2, bp21, bp22, compositeBP3, bp31}...)
 			})
 
@@ -180,7 +180,7 @@ func testModuleManager(t *testing.T, when spec.G, it spec.S) {
 
 		when("flatten with depth=1", func() {
 			it.Before(func() {
-				moduleManager = buildpack.NewModuleManager(true, 1)
+				moduleManager = buildpack.NewModuleManager(true, 1, nil)
 				moduleManager.AddModules(compositeBP1, []buildpack.BuildModule{bp1, compositeBP2, bp21, bp22, compositeBP3, bp31}...)
 			})
 
@@ -217,7 +217,7 @@ func testModuleManager(t *testing.T, when spec.G, it spec.S) {
 
 		when("flatten with depth=2", func() {
 			it.Before(func() {
-				moduleManager = buildpack.NewModuleManager(true, 2)
+				moduleManager = buildpack.NewModuleManager(true, 2, nil)
 				moduleManager.AddModules(compositeBP1, []buildpack.BuildModule{bp1, compositeBP2, bp21, bp22, compositeBP3, bp31}...)
 			})
 
@@ -255,7 +255,7 @@ func testModuleManager(t *testing.T, when spec.G, it spec.S) {
 
 	when("manager is not configured in flatten mode", func() {
 		it.Before(func() {
-			moduleManager = buildpack.NewModuleManager(false, buildpack.FlattenNone)
+			moduleManager = buildpack.NewModuleManager(false, buildpack.FlattenNone, nil)
 		})
 
 		when("#ExplodedModules", func() {


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
