### PR TITLE
Remove history for "additional buildpack"

### DIFF
--- a/dev/bench/data.js
+++ b/dev/bench/data.js
@@ -36,12 +36,6 @@ window.BENCHMARK_DATA = {
             "value": 1345662281,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 27957377533,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
           }
         ]
       },
@@ -76,12 +70,6 @@ window.BENCHMARK_DATA = {
           {
             "name": "BenchmarkBuild/with_Trusted_Builder",
             "value": 2673230163,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 41734972476,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
           }
@@ -120,12 +108,6 @@ window.BENCHMARK_DATA = {
             "value": 1818207036,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 29640697841,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
           }
         ]
       },
@@ -160,12 +142,6 @@ window.BENCHMARK_DATA = {
           {
             "name": "BenchmarkBuild/with_Trusted_Builder",
             "value": 1858477793,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 33585789339,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
           }
@@ -204,12 +180,6 @@ window.BENCHMARK_DATA = {
             "value": 1865838020,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 32321714674,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
           }
         ]
       },
@@ -244,12 +214,6 @@ window.BENCHMARK_DATA = {
           {
             "name": "BenchmarkBuild/with_Trusted_Builder",
             "value": 1748158155,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 31700057682,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
           }
@@ -288,12 +252,6 @@ window.BENCHMARK_DATA = {
             "value": 1204177127,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 29849926779,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
           }
         ]
       },
@@ -328,12 +286,6 @@ window.BENCHMARK_DATA = {
           {
             "name": "BenchmarkBuild/with_Trusted_Builder",
             "value": 2526395929,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 40889148483,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
           }
@@ -372,12 +324,6 @@ window.BENCHMARK_DATA = {
             "value": 1146795034,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 28965464342,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
           }
         ]
       },
@@ -412,12 +358,6 @@ window.BENCHMARK_DATA = {
           {
             "name": "BenchmarkBuild/with_Trusted_Builder",
             "value": 1165483858,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 27770099418,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
           }
@@ -456,12 +396,6 @@ window.BENCHMARK_DATA = {
             "value": 1247404290,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 27995589323,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
           }
         ]
       },
@@ -496,12 +430,6 @@ window.BENCHMARK_DATA = {
           {
             "name": "BenchmarkBuild/with_Trusted_Builder",
             "value": 1130959880,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 28470469361,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
           }
@@ -540,12 +468,6 @@ window.BENCHMARK_DATA = {
             "value": 2551282266,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 36865737676,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
           }
         ]
       },
@@ -580,12 +502,6 @@ window.BENCHMARK_DATA = {
           {
             "name": "BenchmarkBuild/with_Trusted_Builder",
             "value": 1107704813,
-            "unit": "ns/op",
-            "extra": "1 times\n2 procs"
-          },
-          {
-            "name": "BenchmarkBuild/with_Addtional_Buildpack",
-            "value": 27451175651,
             "unit": "ns/op",
             "extra": "1 times\n2 procs"
           }


### PR DESCRIPTION
The previous benchmarks used a buildpack that was small in size, hence any performance improvements would be hard to spot.

https://github.com/buildpacks/pack/pull/1773 will switch the buildpack to a large buildpack, thus making the benchmark more useful.

## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
