### PR TITLE
Avoid writing duplicate tar files for flattened buildpacks

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -612,6 +612,13 @@ func (b *Builder) addExplodedModules(kind string, logger logging.Logger, tmpDir 
 		}
 		info, diffID, layerTar := mi.info, mi.diffID, mi.layerTar
 
+		// skip if empty
+		if diffID.String() == "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
+			// tar is empty
+			logger.Debugf("%s %s is a component of a flattened buildpack that will be added elsewhere, skipping...", istrings.Title(kind), style.Symbol(info.FullName()))
+			continue
+		}
+
 		// check against builder layers
 		if existingInfo, ok := layers[info.ID][info.Version]; ok {
 			if existingInfo.LayerDiffID == diffID.String() {


### PR DESCRIPTION
When `pack build --buildpack <flattened buildpack>` is invoked, `pack` doesn't know the buildpack is flattened, so it treats it like `pack build --buildpack bp/1 --buildpack bp2`,
resulting in unnecessary tar files being created
and duplicate layers being added to the ephemeral builder, which can exhaust disk space depending on the environment.

This optimization avoids writing the tar file more than once by returning a no-op read closer
when the diffID has already been queued for downloading.

## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
