### PR TITLE
Flatten buildpack package is move to be experimental

### DIFF
--- a/internal/commands/buildpack_package.go
+++ b/internal/commands/buildpack_package.go
@@ -54,7 +54,7 @@ func BuildpackPackage(logger logging.Logger, cfg config.Config, packager Buildpa
 			"and they can be included in the configs used in `pack builder create` and `pack buildpack package`. For more " +
 			"on how to package a buildpack, see: https://buildpacks.io/docs/buildpack-author-guide/package-a-buildpack/.",
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
-			if err := validateBuildpackPackageFlags(&flags); err != nil {
+			if err := validateBuildpackPackageFlags(cfg, &flags); err != nil {
 				return err
 			}
 
@@ -96,6 +96,10 @@ func BuildpackPackage(logger logging.Logger, cfg config.Config, packager Buildpa
 					logger.Warnf("%s is not a valid extension for a packaged buildpack. Packaged buildpacks must have a %s extension", style.Symbol(ext), style.Symbol(client.CNBExtension))
 				}
 			}
+			if flags.Flatten {
+				logger.Warn("Creating a flattened Buildpack package could break the distribution specification. Please use it with caution.")
+			}
+
 			if err := packager.PackageBuildpack(cmd.Context(), client.PackageBuildpackOptions{
 				RelativeBaseDir: relativeBaseDir,
 				Name:            name,
@@ -134,11 +138,16 @@ func BuildpackPackage(logger logging.Logger, cfg config.Config, packager Buildpa
 	cmd.Flags().BoolVar(&flags.Flatten, "flatten", false, "Flatten the buildpack into a single layer")
 	cmd.Flags().StringSliceVarP(&flags.FlattenExclude, "flatten-exclude", "e", nil, "Buildpacks to exclude from flattening, in the form of '<buildpack-id>@<buildpack-version>'")
 	cmd.Flags().IntVar(&flags.Depth, "depth", -1, "Max depth to flatten.\nOmission of this flag or values < 0 will flatten the entire tree.")
+	if !cfg.Experimental {
+		cmd.Flags().MarkHidden("flatten")
+		cmd.Flags().MarkHidden("depth")
+		cmd.Flags().MarkHidden("flatten-exclude")
+	}
 	AddHelpFlag(cmd, "package")
 	return cmd
 }
 
-func validateBuildpackPackageFlags(p *BuildpackPackageFlags) error {
+func validateBuildpackPackageFlags(cfg config.Config, p *BuildpackPackageFlags) error {
 	if p.Publish && p.Policy == image.PullNever.String() {
 		return errors.Errorf("--publish and --pull-policy never cannot be used together. The --publish flag requires the use of remote images.")
 	}
@@ -146,10 +155,16 @@ func validateBuildpackPackageFlags(p *BuildpackPackageFlags) error {
 		return errors.Errorf("--config and --path cannot be used together. Please specify the relative path to the Buildpack directory in the package config file.")
 	}
 
-	if p.Flatten && len(p.FlattenExclude) > 0 {
-		for _, exclude := range p.FlattenExclude {
-			if strings.Count(exclude, "@") != 1 {
-				return errors.Errorf("invalid format %s; please use '<buildpack-id>@<buildpack-version>' to exclude buildpack from flattening", exclude)
+	if p.Flatten {
+		if !cfg.Experimental {
+			return client.NewExperimentError("Flattening a buildpack package currently experimental.")
+		}
+
+		if len(p.FlattenExclude) > 0 {
+			for _, exclude := range p.FlattenExclude {
+				if strings.Count(exclude, "@") != 1 {
+					return errors.Errorf("invalid format %s; please use '<buildpack-id>@<buildpack-version>' to exclude buildpack from flattening", exclude)
+				}
 			}
 		}
 	}

--- a/internal/commands/buildpack_package_test.go
+++ b/internal/commands/buildpack_package_test.go
@@ -121,13 +121,25 @@ func testPackageCommand(t *testing.T, when spec.G, it spec.S) {
 					})
 				})
 				when("flatten is set to true", func() {
-					when("flatten exclude doesn't have format <buildpack>@<version>", func() {
+					when("experimental is true", func() {
+						when("flatten exclude doesn't have format <buildpack>@<version>", func() {
+							it("errors with a descriptive message", func() {
+								cmd := packageCommand(withClientConfig(config.Config{Experimental: true}), withBuildpackPackager(fakeBuildpackPackager))
+								cmd.SetArgs([]string{"test", "-f", "file", "--flatten", "--flatten-exclude", "some-buildpack"})
+
+								err := cmd.Execute()
+								h.AssertError(t, err, fmt.Sprintf("invalid format %s; please use '<buildpack-id>@<buildpack-version>' to exclude buildpack from flattening", "some-buildpack"))
+							})
+						})
+					})
+
+					when("experimental is false", func() {
 						it("errors with a descriptive message", func() {
-							cmd := packageCommand(withBuildpackPackager(fakeBuildpackPackager))
-							cmd.SetArgs([]string{"test", "-f", "file", "--flatten", "--flatten-exclude", "some-buildpack"})
+							cmd := packageCommand(withClientConfig(config.Config{Experimental: false}), withBuildpackPackager(fakeBuildpackPackager))
+							cmd.SetArgs([]string{"test", "-f", "file", "--flatten"})
 
 							err := cmd.Execute()
-							h.AssertError(t, err, fmt.Sprintf("invalid format %s; please use '<buildpack-id>@<buildpack-version>' to exclude buildpack from flattening", "some-buildpack"))
+							h.AssertError(t, err, "Flattening a buildpack package currently experimental.")
 						})
 					})
 				})

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -33,7 +33,7 @@ func PackageBuildpack(logger logging.Logger, cfg config.Config, packager Buildpa
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {
 			deprecationWarning(logger, "package-buildpack", "buildpack package")
 
-			if err := validateBuildpackPackageFlags(&flags); err != nil {
+			if err := validateBuildpackPackageFlags(cfg, &flags); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
## Summary
After our working group meeting today (05/25/2023) some concerns were raised with breaking the [distribution spec ](https://github.com/buildpacks/spec/blob/distribution/0.2/distribution.md#buildpackage) flattening a buildpack package. This pull request is wrapping the functionality to be under the *experimetal* mode, it means, users will need to enable the experimental mode in order to see the new flags. Also, a warning message is display to end users. The idea is to do not block the feature for being released but still have the open conversation with the community in how the spec is being broke.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

`--flatten`, `--depth` and `flatten-exclude` flags were added to be available with the `pack buildpack package` command.

#### After
The flags were hidden if experimental mode is not enabled

![Screenshot 2023-05-25 at 5 32 35 PM](https://github.com/buildpacks/pack/assets/1181799/cda8da7f-4d50-48c4-99d8-c3d6a4041a4b)

They will be only available when experimental mode is enabled
![Screenshot 2023-05-25 at 5 32 44 PM](https://github.com/buildpacks/pack/assets/1181799/b7b79d80-c5a0-4b1b-92bb-8d52704ffff8)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1595 
