### PR TITLE
Fix: deriving stack.toml from the new run image information

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -1083,7 +1083,7 @@ func (b *Builder) stackLayer(dest string) (string, error) {
 	if b.metadata.Stack.RunImage.Image != "" {
 		err = toml.NewEncoder(buf).Encode(b.metadata.Stack)
 	} else if len(b.metadata.RunImages) > 0 {
-		err = toml.NewEncoder(buf).Encode(b.metadata.RunImages[0])
+		err = toml.NewEncoder(buf).Encode(StackMetadata{RunImage: b.metadata.RunImages[0]})
 	}
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to marshal stack.toml")

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -1583,6 +1583,18 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 				)
 			})
 
+			it("adds the stack.toml to the image", func() {
+				layerTar, err := baseImage.FindLayerWithPath("/cnb/stack.toml")
+				h.AssertNil(t, err)
+				h.AssertOnTarEntry(t, layerTar, "/cnb/stack.toml",
+					h.ContentEquals(`[run-image]
+  image = "some/run"
+  mirrors = ["some/mirror", "other/mirror"]
+`),
+					h.HasModTime(archive.NormalizedDateTime),
+				)
+			})
+
 			it("adds the run image to the metadata", func() {
 				label, err := baseImage.Label("io.buildpacks.builder.metadata")
 				h.AssertNil(t, err)


### PR DESCRIPTION
...we should write the file with the correct schema

Fixes bug identified during Working Group demo