### PR TITLE
only add the stack arg to lifecycle for older platform APIs

### DIFF
--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -572,8 +572,10 @@ func (l *LifecycleExecution) Analyze(ctx context.Context, buildCache, launchCach
 		if l.platformAPI.LessThan("0.12") {
 			args = append([]string{"-stack", l.mountPaths.stackPath()}, args...)
 			stackOp = WithContainerOperations(WriteStackToml(l.mountPaths.stackPath(), l.opts.Builder.Stack(), l.os))
+		} else {
+			args = append([]string{"-run", l.mountPaths.runPath()}, args...)
+			runOp = WithContainerOperations(WriteRunToml(l.mountPaths.runPath(), l.opts.Builder.RunImages(), l.os))
 		}
-		runOp = WithContainerOperations(WriteRunToml(l.mountPaths.runPath(), l.opts.Builder.RunImages(), l.os))
 	}
 
 	flagsOp := WithFlags(flags...)

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -569,8 +569,10 @@ func (l *LifecycleExecution) Analyze(ctx context.Context, buildCache, launchCach
 		if l.opts.RunImage != "" {
 			args = append([]string{"-run-image", l.opts.RunImage}, args...)
 		}
-		args = append([]string{"-stack", l.mountPaths.stackPath()}, args...)
-		stackOp = WithContainerOperations(WriteStackToml(l.mountPaths.stackPath(), l.opts.Builder.Stack(), l.os))
+		if l.platformAPI.LessThan("0.12") {
+			args = append([]string{"-stack", l.mountPaths.stackPath()}, args...)
+			stackOp = WithContainerOperations(WriteStackToml(l.mountPaths.stackPath(), l.opts.Builder.Stack(), l.os))
+		}
 		runOp = WithContainerOperations(WriteRunToml(l.mountPaths.runPath(), l.opts.Builder.RunImages(), l.os))
 	}
 


### PR DESCRIPTION

## Summary
only adds the stack arg to lifecycle for older platform APIs

## Output
hard to say but it sure doesn't add the stack arg when invoking lifecyle if the platform API is older

#### Before

it would add the stack arg to lifecycle indiscriminately 

#### After
only adds the stack arg to lifecycle for older platform APIs


## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ x ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
