### PR TITLE
Fix small issue with deprecated BOM display

### DIFF
--- a/internal/inspectimage/bom_display.go
+++ b/internal/inspectimage/bom_display.go
@@ -19,7 +19,6 @@ type BOMEntryDisplay struct {
 	Version   string                 `toml:"version,omitempty" json:"version,omitempty" yaml:"version,omitempty"`
 	Metadata  map[string]interface{} `toml:"metadata" json:"metadata" yaml:"metadata"`
 	Buildpack dist.ModuleRef         `json:"buildpacks" yaml:"buildpacks" toml:"buildpacks"`
-	Extension dist.ModuleRef         `json:"extensions" yaml:"extensions" toml:"extensions"`
 }
 
 func NewBOMDisplay(info *client.ImageInfo) []BOMEntryDisplay {
@@ -62,13 +61,6 @@ func displayBOMWithExtension(bom []buildpack.BOMEntry) []BOMEntryDisplay {
 			Metadata: entry.Metadata,
 
 			Buildpack: dist.ModuleRef{
-				ModuleInfo: dist.ModuleInfo{
-					ID:      entry.Buildpack.ID,
-					Version: entry.Buildpack.Version,
-				},
-				Optional: entry.Buildpack.Optional,
-			},
-			Extension: dist.ModuleRef{
 				ModuleInfo: dist.ModuleInfo{
 					ID:      entry.Buildpack.ID,
 					Version: entry.Buildpack.Version,

--- a/internal/inspectimage/writer/bom_json_test.go
+++ b/internal/inspectimage/writer/bom_json_test.go
@@ -45,7 +45,6 @@ func testJSONBOM(t *testing.T, when spec.G, it spec.S) {
           }
         }
       },
-      "extensions": {},
       "buildpacks": {
         "id": "test.bp.one.remote",
         "version": "1.0.0"
@@ -68,7 +67,6 @@ func testJSONBOM(t *testing.T, when spec.G, it spec.S) {
           }
         }
       },
-      "extensions": {},
       "buildpacks": {
         "id": "test.bp.one.remote",
         "version": "1.0.0"

--- a/internal/inspectimage/writer/bom_yaml_test.go
+++ b/internal/inspectimage/writer/bom_yaml_test.go
@@ -41,7 +41,6 @@ local:
       int: 456
       nested:
         string: ''
-  extensions: {}
   buildpacks:
     id: test.bp.one.remote
     version: 1.0.0
@@ -57,7 +56,6 @@ remote:
       int: 123
       nested:
         string: anotherString
-  extensions: {}
   buildpacks:
     id: test.bp.one.remote
     version: 1.0.0


### PR DESCRIPTION
Extensions don't output legacy BOMs so including them in the BOM display is a bit misleading.

