### PR TITLE
pack inspect <app-image> shows if the image is rebasable or not

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1153,7 +1153,7 @@ func testAcceptance(
 									"hello_args":             helloArgs,
 									"hello_args_prefix":      helloArgsPrefix,
 									"image_workdir":          imageWorkdir,
-									"rebasable":              false,
+									"rebasable":              true,
 								},
 							)
 
@@ -1827,7 +1827,7 @@ func testAcceptance(
 										"hello_args":           helloArgs,
 										"hello_args_prefix":    helloArgsPrefix,
 										"image_workdir":        imageWorkdir,
-										"rebasable":            false,
+										"rebasable":            true,
 									},
 								)
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1153,6 +1153,7 @@ func testAcceptance(
 									"hello_args":             helloArgs,
 									"hello_args_prefix":      helloArgsPrefix,
 									"image_workdir":          imageWorkdir,
+									"rebasable":              false,
 								},
 							)
 
@@ -1826,6 +1827,7 @@ func testAcceptance(
 										"hello_args":           helloArgs,
 										"hello_args_prefix":    helloArgsPrefix,
 										"image_workdir":        imageWorkdir,
+										"rebasable":            false,
 									},
 								)
 

--- a/acceptance/testdata/pack_fixtures/inspect_image_local_output.json
+++ b/acceptance/testdata/pack_fixtures/inspect_image_local_output.json
@@ -3,6 +3,7 @@
   "remote_info": null,
   "local_info": {
     "stack": "pack.test.stack",
+    "rebasable": false,
     "base_image": {
       "top_layer": "{{.base_image_top_layer}}",
       "reference": "{{.base_image_id}}"

--- a/acceptance/testdata/pack_fixtures/inspect_image_local_output.toml
+++ b/acceptance/testdata/pack_fixtures/inspect_image_local_output.toml
@@ -2,6 +2,7 @@ image_name = "{{.image_name}}"
 
 [local_info]
 stack = "pack.test.stack"
+rebasable = false
 
   [local_info.base_image]
   top_layer = "{{.base_image_top_layer}}"

--- a/acceptance/testdata/pack_fixtures/inspect_image_local_output.yaml
+++ b/acceptance/testdata/pack_fixtures/inspect_image_local_output.yaml
@@ -3,6 +3,7 @@ image_name: "{{.image_name}}"
 remote_info:
 local_info:
   stack: pack.test.stack
+  rebasable: false
   base_image:
     top_layer: "{{.base_image_top_layer}}"
     reference: "{{.base_image_id}}"

--- a/acceptance/testdata/pack_fixtures/inspect_image_published_output.json
+++ b/acceptance/testdata/pack_fixtures/inspect_image_published_output.json
@@ -3,6 +3,7 @@
   "local_info": null,
   "remote_info": {
     "stack": "pack.test.stack",
+    "rebasable": false,
     "base_image": {
       "top_layer": "{{.base_image_top_layer}}",
       "reference": "{{.base_image_ref}}"

--- a/acceptance/testdata/pack_fixtures/inspect_image_published_output.toml
+++ b/acceptance/testdata/pack_fixtures/inspect_image_published_output.toml
@@ -2,6 +2,7 @@ image_name = "{{.image_name}}"
 
 [remote_info]
 stack = "pack.test.stack"
+rebasable = false
 
   [remote_info.base_image]
   top_layer = "{{.base_image_top_layer}}"

--- a/acceptance/testdata/pack_fixtures/inspect_image_published_output.yaml
+++ b/acceptance/testdata/pack_fixtures/inspect_image_published_output.yaml
@@ -3,6 +3,7 @@ image_name: "{{.image_name}}"
 local_info: null
 remote_info:
   stack: pack.test.stack
+  rebasable: false
   base_image:
     top_layer: "{{.base_image_top_layer}}"
     reference: "{{.base_image_ref}}"

--- a/internal/inspectimage/info_display.go
+++ b/internal/inspectimage/info_display.go
@@ -67,6 +67,7 @@ func NewInfoDisplay(info *client.ImageInfo, generalInfo GeneralInfo) *InfoDispla
 			Buildpacks:      displayBuildpacks(info.Buildpacks),
 			Extensions:      displayExtensions(info.Extensions),
 			Processes:       displayProcesses(info.Processes),
+			Rebasable:       info.Rebasable,
 		}
 	}
 	return &InfoDisplay{

--- a/internal/inspectimage/info_display.go
+++ b/internal/inspectimage/info_display.go
@@ -46,6 +46,7 @@ type InfoDisplay struct {
 	Buildpacks      []dist.ModuleInfo       `json:"buildpacks" yaml:"buildpacks" toml:"buildpacks"`
 	Extensions      []dist.ModuleInfo       `json:"extensions" yaml:"extensions" toml:"extensions"`
 	Processes       []ProcessDisplay        `json:"processes" yaml:"processes" toml:"processes"`
+	Rebasable       bool                    `json:"rebasable" yaml:"rebasable" toml:"rebasable"`
 }
 
 type InspectOutput struct {
@@ -74,6 +75,7 @@ func NewInfoDisplay(info *client.ImageInfo, generalInfo GeneralInfo) *InfoDispla
 		RunImageMirrors: displayMirrors(info, generalInfo),
 		Buildpacks:      displayBuildpacks(info.Buildpacks),
 		Processes:       displayProcesses(info.Processes),
+		Rebasable:       info.Rebasable,
 	}
 }
 

--- a/internal/inspectimage/writer/human_readable.go
+++ b/internal/inspectimage/writer/human_readable.go
@@ -202,10 +202,11 @@ Processes:
 {{- end }}`
 
 var rebasableTemplate = `
-{{- if .Info.Rebasable -}}
-{{- "\n\n" -}}
-Rebasable: {{ .Info.Rebasable }}
-{{- end -}}`
+
+Rebasable: 
+{{- if or .Info.Rebasable (eq .Info.Rebasable true)  }} true 
+{{- else }} false 
+{{- end }}`
 
 var imageTemplate = `
 Stack: {{ .Info.StackID }}
@@ -230,5 +231,5 @@ Base Image:
 {{ template "runImages" . }}
 {{- template "rebasable" . }}
 {{ template "buildpacks" . }}
-{{ template "extensions" . }}
+{{ template "extensions" . -}}
 {{ template "processes" . }}`

--- a/internal/inspectimage/writer/human_readable.go
+++ b/internal/inspectimage/writer/human_readable.go
@@ -58,13 +58,15 @@ func writeImageInfo(
 		Funcs(template.FuncMap{"StringsJoin": strings.Join}).
 		Funcs(template.FuncMap{"StringsValueOrDefault": strs.ValueOrDefault}).
 		Parse(runImagesTemplate))
-	imgTpl = template.Must(imgTpl.New("buildpacks").
-		Parse(buildpacksTemplate))
+	imgTpl = template.Must(imgTpl.New("buildpacks").Parse(buildpacksTemplate))
 	if info != nil && info.Extensions != nil {
 		imgTpl = template.Must(imgTpl.New("extensions").Parse(extensionsTemplate))
 	}
 	imgTpl = template.Must(imgTpl.New("processes").
 		Parse(processesTemplate))
+
+	imgTpl = template.Must(imgTpl.New("rebasable").Parse(rebasableTemplate))
+
 	if info != nil && info.Extensions != nil {
 		imgTpl = template.Must(imgTpl.New("image").
 			Parse(imageWithExtensionTemplate))
@@ -72,6 +74,7 @@ func writeImageInfo(
 		imgTpl = template.Must(imgTpl.New("image").
 			Parse(imageTemplate))
 	}
+
 	if err != nil {
 		logger.Errorf("%s\n", err)
 		return nil
@@ -158,6 +161,12 @@ Processes:
   {{- end }}
 {{- end }}`
 
+var rebasableTemplate = `
+{{- if .Info.Rebasable -}}
+{{- "\n\n" -}}
+Rebasable: true
+{{- end -}}`
+
 var imageTemplate = `
 Stack: {{ .Info.StackID }}
 
@@ -167,6 +176,7 @@ Base Image:
 {{- end}}
   Top Layer: {{ .Info.Base.TopLayer }}
 {{ template "runImages" . }}
+{{- template "rebasable" . }}
 {{ template "buildpacks" . }}{{ template "processes" . }}`
 
 var imageWithExtensionTemplate = `

--- a/internal/inspectimage/writer/human_readable.go
+++ b/internal/inspectimage/writer/human_readable.go
@@ -228,6 +228,7 @@ Base Image:
 {{- end}}
   Top Layer: {{ .Info.Base.TopLayer }}
 {{ template "runImages" . }}
+{{- template "rebasable" . }}
 {{ template "buildpacks" . }}
 {{ template "extensions" . }}
 {{ template "processes" . }}`

--- a/internal/inspectimage/writer/human_readable.go
+++ b/internal/inspectimage/writer/human_readable.go
@@ -30,20 +30,67 @@ func (h *HumanReadable) Print(
 	if local == nil && remote == nil {
 		return fmt.Errorf("unable to find image '%s' locally or remotely", generalInfo.Name)
 	}
-	localDisplay := inspectimage.NewInfoDisplay(local, generalInfo)
-	remoteDisplay := inspectimage.NewInfoDisplay(remote, generalInfo)
 
 	logger.Infof("Inspecting image: %s\n", style.Symbol(generalInfo.Name))
 
-	logger.Info("\nREMOTE:\n")
-	err := writeImageInfo(logger, remoteDisplay, remoteErr)
-	if err != nil {
-		return fmt.Errorf("writing remote builder info: %w", err)
+	if err := writeRemoteImageInfo(logger, generalInfo, remote, remoteErr); err != nil {
+		return err
 	}
+
+	if err := writeLocalImageInfo(logger, generalInfo, local, localErr); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeLocalImageInfo(
+	logger logging.Logger,
+	generalInfo inspectimage.GeneralInfo,
+	local *client.ImageInfo,
+	localErr error) error {
 	logger.Info("\nLOCAL:\n")
-	err = writeImageInfo(logger, localDisplay, localErr)
+
+	if localErr != nil {
+		logger.Errorf("%s\n", localErr)
+		return nil
+	}
+
+	localDisplay := inspectimage.NewInfoDisplay(local, generalInfo)
+	if localDisplay == nil {
+		logger.Info("(not present)\n")
+		return nil
+	}
+
+	err := writeImageInfo(logger, localDisplay)
 	if err != nil {
 		return fmt.Errorf("writing local builder info: %w", err)
+	}
+
+	return nil
+}
+
+func writeRemoteImageInfo(
+	logger logging.Logger,
+	generalInfo inspectimage.GeneralInfo,
+	remote *client.ImageInfo,
+	remoteErr error) error {
+	logger.Info("\nREMOTE:\n")
+
+	if remoteErr != nil {
+		logger.Errorf("%s\n", remoteErr)
+		return nil
+	}
+
+	remoteDisplay := inspectimage.NewInfoDisplay(remote, generalInfo)
+	if remoteDisplay == nil {
+		logger.Info("(not present)\n")
+		return nil
+	}
+
+	err := writeImageInfo(logger, remoteDisplay)
+	if err != nil {
+		return fmt.Errorf("writing remote builder info: %w", err)
 	}
 
 	return nil
@@ -52,48 +99,41 @@ func (h *HumanReadable) Print(
 func writeImageInfo(
 	logger logging.Logger,
 	info *inspectimage.InfoDisplay,
-	err error,
 ) error {
+	imgTpl := getImageTemplate(info)
+	remoteOutput, err := getInspectImageOutput(imgTpl, info)
+	if err != nil {
+		logger.Error(err.Error())
+		return err
+	} else {
+		logger.Info(remoteOutput.String())
+		return nil
+	}
+}
+
+func getImageTemplate(info *inspectimage.InfoDisplay) *template.Template {
 	imgTpl := template.Must(template.New("runImages").
 		Funcs(template.FuncMap{"StringsJoin": strings.Join}).
 		Funcs(template.FuncMap{"StringsValueOrDefault": strs.ValueOrDefault}).
 		Parse(runImagesTemplate))
 	imgTpl = template.Must(imgTpl.New("buildpacks").Parse(buildpacksTemplate))
-	if info != nil && info.Extensions != nil {
-		imgTpl = template.Must(imgTpl.New("extensions").Parse(extensionsTemplate))
-	}
-	imgTpl = template.Must(imgTpl.New("processes").
-		Parse(processesTemplate))
+
+	imgTpl = template.Must(imgTpl.New("processes").Parse(processesTemplate))
 
 	imgTpl = template.Must(imgTpl.New("rebasable").Parse(rebasableTemplate))
 
 	if info != nil && info.Extensions != nil {
-		imgTpl = template.Must(imgTpl.New("image").
-			Parse(imageWithExtensionTemplate))
+		imgTpl = template.Must(imgTpl.New("extensions").Parse(extensionsTemplate))
+		imgTpl = template.Must(imgTpl.New("image").Parse(imageWithExtensionTemplate))
 	} else {
-		imgTpl = template.Must(imgTpl.New("image").
-			Parse(imageTemplate))
+		imgTpl = template.Must(imgTpl.New("image").Parse(imageTemplate))
 	}
-
-	if err != nil {
-		logger.Errorf("%s\n", err)
-		return nil
-	}
-
-	if info == nil {
-		logger.Info("(not present)\n")
-		return nil
-	}
-	remoteOutput, err := inspectImageOutput(info, imgTpl)
-	if err != nil {
-		logger.Error(err.Error())
-	} else {
-		logger.Info(remoteOutput.String())
-	}
-	return nil
+	return imgTpl
 }
 
-func inspectImageOutput(info *inspectimage.InfoDisplay, tpl *template.Template) (*bytes.Buffer, error) {
+func getInspectImageOutput(
+	tpl *template.Template,
+	info *inspectimage.InfoDisplay) (*bytes.Buffer, error) {
 	if info == nil {
 		return bytes.NewBuffer([]byte("(not present)")), nil
 	}

--- a/internal/inspectimage/writer/human_readable.go
+++ b/internal/inspectimage/writer/human_readable.go
@@ -204,7 +204,7 @@ Processes:
 var rebasableTemplate = `
 {{- if .Info.Rebasable -}}
 {{- "\n\n" -}}
-Rebasable: true
+Rebasable: {{ .Info.Rebasable }}
 {{- end -}}`
 
 var imageTemplate = `

--- a/internal/inspectimage/writer/human_readable_test.go
+++ b/internal/inspectimage/writer/human_readable_test.go
@@ -211,344 +211,14 @@ Processes:
 
 	when("Print", func() {
 		it.Before(func() {
-			type someData struct {
-				String string
-				Bool   bool
-				Int    int
-				Nested struct {
-					String string
-				}
-			}
 
-			remoteInfo = &client.ImageInfo{
-				StackID: "test.stack.id.remote",
-				Buildpacks: []buildpack.GroupElement{
-					{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
-					{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
-					{ID: "test.bp.three.remote", Version: "3.0.0"},
-				},
-				Base: files.RunImageForRebase{
-					TopLayer:  "some-remote-top-layer",
-					Reference: "some-remote-run-image-reference",
-				},
-				Stack: files.Stack{
-					RunImage: files.RunImageForExport{
-						Image:   "some-remote-run-image",
-						Mirrors: []string{"some-remote-mirror", "other-remote-mirror"},
-					},
-				},
-				BOM: []buildpack.BOMEntry{{
-					Require: buildpack.Require{
-						Name:    "name-1",
-						Version: "version-1",
-						Metadata: map[string]interface{}{
-							"RemoteData": someData{
-								String: "aString",
-								Bool:   true,
-								Int:    123,
-								Nested: struct {
-									String string
-								}{
-									String: "anotherString",
-								},
-							},
-						},
-					},
-					Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0"},
-				}},
-				Processes: client.ProcessDetails{
-					DefaultProcess: &launch.Process{
-						Type:             "some-remote-type",
-						Command:          launch.RawCommand{Entries: []string{"/some/remote command"}},
-						Args:             []string{"some", "remote", "args"},
-						Direct:           false,
-						WorkingDirectory: "/some-test-work-dir",
-					},
-					OtherProcesses: []launch.Process{
-						{
-							Type:             "other-remote-type",
-							Command:          launch.RawCommand{Entries: []string{"/other/remote/command"}},
-							Args:             []string{"other", "remote", "args"},
-							Direct:           true,
-							WorkingDirectory: "/other-test-work-dir",
-						},
-					},
-				},
-			}
+			remoteInfo = getRemoteBasicImageInfo()
+			remoteInfoWithRebasable = getRemoteImageInfoWithRebasable()
+			remoteWithExtensionInfo = getRemoteImageInfoWithExtension()
 
-			remoteInfoWithRebasable = &client.ImageInfo{
-				StackID: "test.stack.id.remote",
-				Buildpacks: []buildpack.GroupElement{
-					{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
-					{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
-					{ID: "test.bp.three.remote", Version: "3.0.0"},
-				},
-				Base: platform.RunImageForRebase{
-					TopLayer:  "some-remote-top-layer",
-					Reference: "some-remote-run-image-reference",
-				},
-				Stack: platform.StackMetadata{
-					RunImage: platform.RunImageForExport{
-						Image:   "some-remote-run-image",
-						Mirrors: []string{"some-remote-mirror", "other-remote-mirror"},
-					},
-				},
-				BOM: []buildpack.BOMEntry{{
-					Require: buildpack.Require{
-						Name:    "name-1",
-						Version: "version-1",
-						Metadata: map[string]interface{}{
-							"RemoteData": someData{
-								String: "aString",
-								Bool:   true,
-								Int:    123,
-								Nested: struct {
-									String string
-								}{
-									String: "anotherString",
-								},
-							},
-						},
-					},
-					Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0"},
-				}},
-				Processes: client.ProcessDetails{
-					DefaultProcess: &launch.Process{
-						Type:             "some-remote-type",
-						Command:          launch.RawCommand{Entries: []string{"/some/remote command"}},
-						Args:             []string{"some", "remote", "args"},
-						Direct:           false,
-						WorkingDirectory: "/some-test-work-dir",
-					},
-					OtherProcesses: []launch.Process{
-						{
-							Type:             "other-remote-type",
-							Command:          launch.RawCommand{Entries: []string{"/other/remote/command"}},
-							Args:             []string{"other", "remote", "args"},
-							Direct:           true,
-							WorkingDirectory: "/other-test-work-dir",
-						},
-					},
-				},
-				Rebasable: true,
-			}
-
-			localInfo = &client.ImageInfo{
-				StackID: "test.stack.id.local",
-				Buildpacks: []buildpack.GroupElement{
-					{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
-					{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
-					{ID: "test.bp.three.local", Version: "3.0.0"},
-				},
-				Base: files.RunImageForRebase{
-					TopLayer:  "some-local-top-layer",
-					Reference: "some-local-run-image-reference",
-				},
-				Stack: files.Stack{
-					RunImage: files.RunImageForExport{
-						Image:   "some-local-run-image",
-						Mirrors: []string{"some-local-mirror", "other-local-mirror"},
-					},
-				},
-				BOM: []buildpack.BOMEntry{{
-					Require: buildpack.Require{
-						Name:    "name-1",
-						Version: "version-1",
-						Metadata: map[string]interface{}{
-							"LocalData": someData{
-								Bool: false,
-								Int:  456,
-							},
-						},
-					},
-					Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0"},
-				}},
-				Processes: client.ProcessDetails{
-					DefaultProcess: &launch.Process{
-						Type:             "some-local-type",
-						Command:          launch.RawCommand{Entries: []string{"/some/local command"}},
-						Args:             []string{"some", "local", "args"},
-						Direct:           false,
-						WorkingDirectory: "/some-test-work-dir",
-					},
-					OtherProcesses: []launch.Process{
-						{
-							Type:             "other-local-type",
-							Command:          launch.RawCommand{Entries: []string{"/other/local/command"}},
-							Args:             []string{"other", "local", "args"},
-							Direct:           true,
-							WorkingDirectory: "/other-test-work-dir",
-						},
-					},
-				},
-			}
-
-			localInfoWithRebasable = &client.ImageInfo{
-				StackID: "test.stack.id.local",
-				Buildpacks: []buildpack.GroupElement{
-					{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
-					{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
-					{ID: "test.bp.three.local", Version: "3.0.0"},
-				},
-				Base: platform.RunImageForRebase{
-					TopLayer:  "some-local-top-layer",
-					Reference: "some-local-run-image-reference",
-				},
-				Stack: platform.StackMetadata{
-					RunImage: platform.RunImageForExport{
-						Image:   "some-local-run-image",
-						Mirrors: []string{"some-local-mirror", "other-local-mirror"},
-					},
-				},
-				BOM: []buildpack.BOMEntry{{
-					Require: buildpack.Require{
-						Name:    "name-1",
-						Version: "version-1",
-						Metadata: map[string]interface{}{
-							"LocalData": someData{
-								Bool: false,
-								Int:  456,
-							},
-						},
-					},
-					Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0"},
-				}},
-				Processes: client.ProcessDetails{
-					DefaultProcess: &launch.Process{
-						Type:             "some-local-type",
-						Command:          launch.RawCommand{Entries: []string{"/some/local command"}},
-						Args:             []string{"some", "local", "args"},
-						Direct:           false,
-						WorkingDirectory: "/some-test-work-dir",
-					},
-					OtherProcesses: []launch.Process{
-						{
-							Type:             "other-local-type",
-							Command:          launch.RawCommand{Entries: []string{"/other/local/command"}},
-							Args:             []string{"other", "local", "args"},
-							Direct:           true,
-							WorkingDirectory: "/other-test-work-dir",
-						},
-					},
-				},
-				Rebasable: true,
-			}
-
-			remoteWithExtensionInfo = &client.ImageInfo{
-				StackID: "test.stack.id.remote",
-				Buildpacks: []buildpack.GroupElement{
-					{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
-					{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
-					{ID: "test.bp.three.remote", Version: "3.0.0"},
-				},
-				Extensions: []buildpack.GroupElement{
-					{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
-					{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
-					{ID: "test.bp.three.remote", Version: "3.0.0"},
-				},
-				Base: files.RunImageForRebase{
-					TopLayer:  "some-remote-top-layer",
-					Reference: "some-remote-run-image-reference",
-				},
-				Stack: files.Stack{
-					RunImage: files.RunImageForExport{
-						Image:   "some-remote-run-image",
-						Mirrors: []string{"some-remote-mirror", "other-remote-mirror"},
-					},
-				},
-				BOM: []buildpack.BOMEntry{{
-					Require: buildpack.Require{
-						Name:    "name-1",
-						Version: "version-1",
-						Metadata: map[string]interface{}{
-							"RemoteData": someData{
-								String: "aString",
-								Bool:   true,
-								Int:    123,
-								Nested: struct {
-									String string
-								}{
-									String: "anotherString",
-								},
-							},
-						},
-					},
-					Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0"},
-				}},
-				Processes: client.ProcessDetails{
-					DefaultProcess: &launch.Process{
-						Type:             "some-remote-type",
-						Command:          launch.RawCommand{Entries: []string{"/some/remote command"}},
-						Args:             []string{"some", "remote", "args"},
-						Direct:           false,
-						WorkingDirectory: "/some-test-work-dir",
-					},
-					OtherProcesses: []launch.Process{
-						{
-							Type:             "other-remote-type",
-							Command:          launch.RawCommand{Entries: []string{"/other/remote/command"}},
-							Args:             []string{"other", "remote", "args"},
-							Direct:           true,
-							WorkingDirectory: "/other-test-work-dir",
-						},
-					},
-				},
-			}
-
-			localWithExtensionInfo = &client.ImageInfo{
-				StackID: "test.stack.id.local",
-				Buildpacks: []buildpack.GroupElement{
-					{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
-					{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
-					{ID: "test.bp.three.local", Version: "3.0.0"},
-				},
-				Extensions: []buildpack.GroupElement{
-					{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
-					{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
-					{ID: "test.bp.three.local", Version: "3.0.0"},
-				},
-				Base: files.RunImageForRebase{
-					TopLayer:  "some-local-top-layer",
-					Reference: "some-local-run-image-reference",
-				},
-				Stack: files.Stack{
-					RunImage: files.RunImageForExport{
-						Image:   "some-local-run-image",
-						Mirrors: []string{"some-local-mirror", "other-local-mirror"},
-					},
-				},
-				BOM: []buildpack.BOMEntry{{
-					Require: buildpack.Require{
-						Name:    "name-1",
-						Version: "version-1",
-						Metadata: map[string]interface{}{
-							"LocalData": someData{
-								Bool: false,
-								Int:  456,
-							},
-						},
-					},
-					Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0"},
-				}},
-				Processes: client.ProcessDetails{
-					DefaultProcess: &launch.Process{
-						Type:             "some-local-type",
-						Command:          launch.RawCommand{Entries: []string{"/some/local command"}},
-						Args:             []string{"some", "local", "args"},
-						Direct:           false,
-						WorkingDirectory: "/some-test-work-dir",
-					},
-					OtherProcesses: []launch.Process{
-						{
-							Type:             "other-local-type",
-							Command:          launch.RawCommand{Entries: []string{"/other/local/command"}},
-							Args:             []string{"other", "local", "args"},
-							Direct:           true,
-							WorkingDirectory: "/other-test-work-dir",
-						},
-					},
-				},
-			}
+			localInfo = getBasicLocalImageInfo()
+			localInfoWithRebasable = getLocalImageInfoWithRebasable()
+			localWithExtensionInfo = getLocalImageInfoWithExtension()
 
 			outBuf = bytes.Buffer{}
 		})
@@ -1031,4 +701,236 @@ Processes:
 			})
 		})
 	})
+}
+
+func getRemoteBasicImageInfo() *client.ImageInfo {
+	return getRemoteImageInfo(false, false)
+}
+func getRemoteImageInfoWithExtension() *client.ImageInfo {
+	return getRemoteImageInfo(true, false)
+}
+
+func getRemoteImageInfoWithRebasable() *client.ImageInfo {
+	return getRemoteImageInfo(false, true)
+}
+
+func getRemoteImageInfo(extension bool, rebasable bool) *client.ImageInfo {
+	mockedStackID := "test.stack.id.remote"
+
+	mockedBuildpacks := []buildpack.GroupElement{
+		{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+		{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
+		{ID: "test.bp.three.remote", Version: "3.0.0"},
+	}
+
+	mockedBase := files.RunImageForRebase{
+		TopLayer:  "some-remote-top-layer",
+		Reference: "some-remote-run-image-reference",
+	}
+
+	mockedStack := files.Stack{
+		RunImage: files.RunImageForExport{
+			Image:   "some-remote-run-image",
+			Mirrors: []string{"some-remote-mirror", "other-remote-mirror"},
+		},
+	}
+
+	type someData struct {
+		String string
+		Bool   bool
+		Int    int
+		Nested struct {
+			String string
+		}
+	}
+	mockedMetadata := map[string]interface{}{
+		"RemoteData": someData{
+			String: "aString",
+			Bool:   true,
+			Int:    123,
+			Nested: struct {
+				String string
+			}{
+				String: "anotherString",
+			},
+		},
+	}
+
+	mockedBOM := []buildpack.BOMEntry{{
+		Require: buildpack.Require{
+			Name:     "name-1",
+			Metadata: mockedMetadata,
+		},
+		Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0"},
+	}}
+
+	mockedProcesses := client.ProcessDetails{
+		DefaultProcess: &launch.Process{
+			Type:             "some-remote-type",
+			Command:          launch.RawCommand{Entries: []string{"/some/remote command"}},
+			Args:             []string{"some", "remote", "args"},
+			Direct:           false,
+			WorkingDirectory: "/some-test-work-dir",
+		},
+		OtherProcesses: []launch.Process{
+			{
+				Type:             "other-remote-type",
+				Command:          launch.RawCommand{Entries: []string{"/other/remote/command"}},
+				Args:             []string{"other", "remote", "args"},
+				Direct:           true,
+				WorkingDirectory: "/other-test-work-dir",
+			},
+		},
+	}
+
+	mockedExtension := []buildpack.GroupElement{
+		{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+		{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
+		{ID: "test.bp.three.remote", Version: "3.0.0"},
+	}
+
+	if extension {
+		return &client.ImageInfo{
+			StackID:    mockedStackID,
+			Buildpacks: mockedBuildpacks,
+			Base:       mockedBase,
+			Stack:      mockedStack,
+			BOM:        mockedBOM,
+			Processes:  mockedProcesses,
+			Extensions: mockedExtension,
+		}
+	} else if rebasable {
+		return &client.ImageInfo{
+			StackID:    mockedStackID,
+			Buildpacks: mockedBuildpacks,
+			Base:       mockedBase,
+			Stack:      mockedStack,
+			BOM:        mockedBOM,
+			Processes:  mockedProcesses,
+			Rebasable:  true,
+		}
+	} else {
+		return &client.ImageInfo{
+			StackID:    mockedStackID,
+			Buildpacks: mockedBuildpacks,
+			Base:       mockedBase,
+			Stack:      mockedStack,
+			BOM:        mockedBOM,
+			Processes:  mockedProcesses,
+		}
+	}
+}
+
+func getBasicLocalImageInfo() *client.ImageInfo {
+	return getLocalImageInfo(false, false)
+}
+
+func getLocalImageInfoWithExtension() *client.ImageInfo {
+	return getLocalImageInfo(true, false)
+}
+
+func getLocalImageInfoWithRebasable() *client.ImageInfo {
+	return getLocalImageInfo(false, true)
+}
+
+func getLocalImageInfo(extension bool, rebasable bool) *client.ImageInfo {
+	mockedStackID := "test.stack.id.local"
+
+	mockedBuildpacks := []buildpack.GroupElement{
+		{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+		{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
+		{ID: "test.bp.three.local", Version: "3.0.0"},
+	}
+
+	mockedBase := files.RunImageForRebase{
+		TopLayer:  "some-local-top-layer",
+		Reference: "some-local-run-image-reference",
+	}
+
+	mockedPlatform := files.Stack{
+		RunImage: files.RunImageForExport{
+			Image:   "some-local-run-image",
+			Mirrors: []string{"some-local-mirror", "other-local-mirror"},
+		},
+	}
+
+	type someData struct {
+		String string
+		Bool   bool
+		Int    int
+		Nested struct {
+			String string
+		}
+	}
+	mockedMetadata := map[string]interface{}{
+		"LocalData": someData{
+			Bool: false,
+			Int:  456,
+		},
+	}
+
+	mockedBOM := []buildpack.BOMEntry{{
+		Require: buildpack.Require{
+			Name:     "name-1",
+			Version:  "version-1",
+			Metadata: mockedMetadata,
+		},
+		Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0"},
+	}}
+
+	mockedProcesses := client.ProcessDetails{
+		DefaultProcess: &launch.Process{
+			Type:             "some-local-type",
+			Command:          launch.RawCommand{Entries: []string{"/some/local command"}},
+			Args:             []string{"some", "local", "args"},
+			Direct:           false,
+			WorkingDirectory: "/some-test-work-dir",
+		},
+		OtherProcesses: []launch.Process{
+			{
+				Type:             "other-local-type",
+				Command:          launch.RawCommand{Entries: []string{"/other/local/command"}},
+				Args:             []string{"other", "local", "args"},
+				Direct:           true,
+				WorkingDirectory: "/other-test-work-dir",
+			},
+		},
+	}
+
+	mockedExtension := []buildpack.GroupElement{
+		{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+		{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
+		{ID: "test.bp.three.local", Version: "3.0.0"},
+	}
+
+	if extension {
+		return &client.ImageInfo{
+			StackID:    mockedStackID,
+			Buildpacks: mockedBuildpacks,
+			Base:       mockedBase,
+			Stack:      mockedPlatform,
+			BOM:        mockedBOM,
+			Processes:  mockedProcesses,
+			Extensions: mockedExtension,
+		}
+	} else if rebasable {
+		return &client.ImageInfo{
+			StackID:    mockedStackID,
+			Buildpacks: mockedBuildpacks,
+			Base:       mockedBase,
+			Stack:      mockedPlatform,
+			BOM:        mockedBOM,
+			Processes:  mockedProcesses,
+			Rebasable:  true,
+		}
+	} else {
+		return &client.ImageInfo{
+			StackID:    mockedStackID,
+			Buildpacks: mockedBuildpacks,
+			Base:       mockedBase,
+			Stack:      mockedPlatform,
+			BOM:        mockedBOM,
+			Processes:  mockedProcesses,
+		}
+	}
 }

--- a/internal/inspectimage/writer/json_test.go
+++ b/internal/inspectimage/writer/json_test.go
@@ -30,12 +30,79 @@ func testJSON(t *testing.T, when spec.G, it spec.S) {
 		assert = h.NewAssertionManager(t)
 		outBuf bytes.Buffer
 
-		remoteInfo *client.ImageInfo
-		localInfo  *client.ImageInfo
+		remoteInfo              *client.ImageInfo
+		remoteInfoWithRebasable *client.ImageInfo
+		localInfo               *client.ImageInfo
+		localInfoWithRebasable  *client.ImageInfo
 
 		expectedLocalOutput = `{
   "local_info": {
     "stack": "test.stack.id.local",
+    "rebasable": false,
+    "base_image": {
+      "top_layer": "some-local-top-layer",
+      "reference": "some-local-run-image-reference"
+    },
+    "run_images": [
+      {
+        "name": "user-configured-mirror-for-local",
+        "user_configured": true
+      },
+      {
+        "name": "some-local-run-image"
+      },
+      {
+        "name": "some-local-mirror"
+      },
+      {
+        "name": "other-local-mirror"
+      }
+    ],
+    "buildpacks": [
+      {
+        "homepage": "https://some-homepage-one",
+        "id": "test.bp.one.local",
+        "version": "1.0.0"
+      },
+      {
+        "homepage": "https://some-homepage-two",
+        "id": "test.bp.two.local",
+        "version": "2.0.0"
+      }
+    ],
+	"extensions": null,
+    "processes": [
+      {
+        "type": "some-local-type",
+        "shell": "bash",
+        "command": "/some/local command",
+        "default": true,
+        "args": [
+          "some",
+          "local",
+          "args"
+        ],
+		"working-dir": "/some-test-work-dir"
+      },
+      {
+        "type": "other-local-type",
+        "shell": "",
+        "command": "/other/local/command",
+        "default": false,
+        "args": [
+          "other",
+          "local",
+          "args"
+        ],
+		"working-dir": "/other-test-work-dir"
+      }
+    ]
+  }
+}`
+		expectedLocalOutputWithRebasable = `{
+  "local_info": {
+    "stack": "test.stack.id.local",
+    "rebasable": true,
     "base_image": {
       "top_layer": "some-local-top-layer",
       "reference": "some-local-run-image-reference"
@@ -99,6 +166,71 @@ func testJSON(t *testing.T, when spec.G, it spec.S) {
 		expectedRemoteOutput = `{  
   "remote_info": {
     "stack": "test.stack.id.remote",
+    "rebasable": false,
+    "base_image": {
+      "top_layer": "some-remote-top-layer",
+      "reference": "some-remote-run-image-reference"
+    },
+    "run_images": [
+      {
+        "name": "user-configured-mirror-for-remote",
+        "user_configured": true
+      },
+      {
+        "name": "some-remote-run-image"
+      },
+      {
+        "name": "some-remote-mirror"
+      },
+      {
+        "name": "other-remote-mirror"
+      }
+    ],
+    "buildpacks": [
+      {
+        "id": "test.bp.one.remote",
+        "version": "1.0.0",
+        "homepage": "https://some-homepage-one"
+      },
+      {
+        "id": "test.bp.two.remote",
+        "version": "2.0.0",
+        "homepage": "https://some-homepage-two"
+      }
+    ],
+	"extensions": null,
+    "processes": [
+      {
+        "type": "some-remote-type",
+        "shell": "bash",
+        "command": "/some/remote command",
+        "default": true,
+        "args": [
+          "some",
+          "remote",
+          "args"
+        ],
+		"working-dir": "/some-test-work-dir"
+      },
+      {
+        "type": "other-remote-type",
+        "shell": "",
+        "command": "/other/remote/command",
+        "default": false,
+        "args": [
+          "other",
+          "remote",
+          "args"
+        ],
+		"working-dir": "/other-test-work-dir"
+      }
+    ]
+  }
+}`
+		expectedRemoteOutputWithRebasable = `{  
+  "remote_info": {
+    "stack": "test.stack.id.remote",
+    "rebasable": true,
     "base_image": {
       "top_layer": "some-remote-top-layer",
       "reference": "some-remote-run-image-reference"
@@ -227,6 +359,62 @@ func testJSON(t *testing.T, when spec.G, it spec.S) {
 				},
 			}
 
+			remoteInfoWithRebasable = &client.ImageInfo{
+				StackID: "test.stack.id.remote",
+				Buildpacks: []buildpack.GroupElement{
+					{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
+				},
+				Base: platform.RunImageForRebase{
+					TopLayer:  "some-remote-top-layer",
+					Reference: "some-remote-run-image-reference",
+				},
+				Stack: platform.StackMetadata{
+					RunImage: platform.RunImageForExport{
+						Image:   "some-remote-run-image",
+						Mirrors: []string{"some-remote-mirror", "other-remote-mirror"},
+					},
+				},
+				BOM: []buildpack.BOMEntry{{
+					Require: buildpack.Require{
+						Name:    "name-1",
+						Version: "version-1",
+						Metadata: map[string]interface{}{
+							"RemoteData": someData{
+								String: "aString",
+								Bool:   true,
+								Int:    123,
+								Nested: struct {
+									String string
+								}{
+									String: "anotherString",
+								},
+							},
+						},
+					},
+					Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+				}},
+				Processes: client.ProcessDetails{
+					DefaultProcess: &launch.Process{
+						Type:             "some-remote-type",
+						Command:          launch.RawCommand{Entries: []string{"/some/remote command"}},
+						Args:             []string{"some", "remote", "args"},
+						Direct:           false,
+						WorkingDirectory: "/some-test-work-dir",
+					},
+					OtherProcesses: []launch.Process{
+						{
+							Type:             "other-remote-type",
+							Command:          launch.RawCommand{Entries: []string{"/other/remote/command"}},
+							Args:             []string{"other", "remote", "args"},
+							Direct:           true,
+							WorkingDirectory: "/other-test-work-dir",
+						},
+					},
+				},
+				Rebasable: true,
+			}
+
 			localInfo = &client.ImageInfo{
 				StackID: "test.stack.id.local",
 				Buildpacks: []buildpack.GroupElement{
@@ -274,6 +462,56 @@ func testJSON(t *testing.T, when spec.G, it spec.S) {
 						},
 					},
 				},
+			}
+
+			localInfoWithRebasable = &client.ImageInfo{
+				StackID: "test.stack.id.local",
+				Buildpacks: []buildpack.GroupElement{
+					{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
+				},
+				Base: platform.RunImageForRebase{
+					TopLayer:  "some-local-top-layer",
+					Reference: "some-local-run-image-reference",
+				},
+				Stack: platform.StackMetadata{
+					RunImage: platform.RunImageForExport{
+						Image:   "some-local-run-image",
+						Mirrors: []string{"some-local-mirror", "other-local-mirror"},
+					},
+				},
+				BOM: []buildpack.BOMEntry{{
+					Require: buildpack.Require{
+						Name:    "name-1",
+						Version: "version-1",
+						Metadata: map[string]interface{}{
+							"LocalData": someData{
+								Bool: false,
+								Int:  456,
+							},
+						},
+					},
+					Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+				}},
+				Processes: client.ProcessDetails{
+					DefaultProcess: &launch.Process{
+						Type:             "some-local-type",
+						Command:          launch.RawCommand{Entries: []string{"/some/local command"}},
+						Args:             []string{"some", "local", "args"},
+						Direct:           false,
+						WorkingDirectory: "/some-test-work-dir",
+					},
+					OtherProcesses: []launch.Process{
+						{
+							Type:             "other-local-type",
+							Command:          launch.RawCommand{Entries: []string{"/other/local/command"}},
+							Args:             []string{"other", "local", "args"},
+							Direct:           true,
+							WorkingDirectory: "/other-test-work-dir",
+						},
+					},
+				},
+				Rebasable: true,
 			}
 
 			outBuf = bytes.Buffer{}
@@ -343,6 +581,35 @@ func testJSON(t *testing.T, when spec.G, it spec.S) {
 				assert.NotContains(outBuf.String(), "test.stack.id.remote")
 				assert.ContainsJSON(outBuf.String(), expectedLocalOutput)
 			})
+			it("prints local rebasable image info in JSON format", func() {
+				runImageMirrors := []config.RunImage{
+					{
+						Image:   "un-used-run-image",
+						Mirrors: []string{"un-used"},
+					},
+					{
+						Image:   "some-local-run-image",
+						Mirrors: []string{"user-configured-mirror-for-local"},
+					},
+					{
+						Image:   "some-remote-run-image",
+						Mirrors: []string{"user-configured-mirror-for-remote"},
+					},
+				}
+				sharedImageInfo := inspectimage.GeneralInfo{
+					Name:            "test-image",
+					RunImageMirrors: runImageMirrors,
+				}
+				jsonWriter := writer.NewJSON()
+
+				logger := logging.NewLogWithWriters(&outBuf, &outBuf)
+				err := jsonWriter.Print(logger, sharedImageInfo, localInfoWithRebasable, nil, nil, nil)
+				assert.Nil(err)
+
+				assert.ContainsJSON(outBuf.String(), `{ "image_name": "test-image" }`)
+				assert.ContainsJSON(outBuf.String(), expectedLocalOutputWithRebasable)
+				assert.NotContains(outBuf.String(), "test.stack.id.remote")
+			})
 		})
 
 		when("only remote image exists", func() {
@@ -374,6 +641,35 @@ func testJSON(t *testing.T, when spec.G, it spec.S) {
 				assert.ContainsJSON(outBuf.String(), `{ "image_name": "test-image" }`)
 				assert.NotContains(outBuf.String(), "test.stack.id.local")
 				assert.ContainsJSON(outBuf.String(), expectedRemoteOutput)
+			})
+			it("prints remote rebasable image info in JSON format", func() {
+				runImageMirrors := []config.RunImage{
+					{
+						Image:   "un-used-run-image",
+						Mirrors: []string{"un-used"},
+					},
+					{
+						Image:   "some-local-run-image",
+						Mirrors: []string{"user-configured-mirror-for-local"},
+					},
+					{
+						Image:   "some-remote-run-image",
+						Mirrors: []string{"user-configured-mirror-for-remote"},
+					},
+				}
+				sharedImageInfo := inspectimage.GeneralInfo{
+					Name:            "test-image",
+					RunImageMirrors: runImageMirrors,
+				}
+				jsonWriter := writer.NewJSON()
+
+				logger := logging.NewLogWithWriters(&outBuf, &outBuf)
+				err := jsonWriter.Print(logger, sharedImageInfo, nil, remoteInfoWithRebasable, nil, nil)
+				assert.Nil(err)
+
+				assert.ContainsJSON(outBuf.String(), `{ "image_name": "test-image" }`)
+				assert.NotContains(outBuf.String(), "test.stack.id.local")
+				assert.ContainsJSON(outBuf.String(), expectedRemoteOutputWithRebasable)
 			})
 		})
 	})

--- a/internal/inspectimage/writer/toml_test.go
+++ b/internal/inspectimage/writer/toml_test.go
@@ -30,11 +30,70 @@ func testTOML(t *testing.T, when spec.G, it spec.S) {
 		assert = h.NewAssertionManager(t)
 		outBuf bytes.Buffer
 
-		remoteInfo *client.ImageInfo
-		localInfo  *client.ImageInfo
+		remoteInfo              *client.ImageInfo
+		remoteInfoWithRebasable *client.ImageInfo
+		localInfo               *client.ImageInfo
+		localInfoWithRebasable  *client.ImageInfo
 
 		expectedLocalOutput = `[local_info]
 stack = 'test.stack.id.local'
+rebasable = false
+
+[local_info.base_image]
+top_layer = 'some-local-top-layer'
+reference = 'some-local-run-image-reference'
+
+[[local_info.run_images]]
+name = 'user-configured-mirror-for-local'
+user_configured = true
+
+[[local_info.run_images]]
+name = 'some-local-run-image'
+
+[[local_info.run_images]]
+name = 'some-local-mirror'
+
+[[local_info.run_images]]
+name = 'other-local-mirror'
+
+[[local_info.buildpacks]]
+id = 'test.bp.one.local'
+version = '1.0.0'
+homepage = 'https://some-homepage-one'
+
+[[local_info.buildpacks]]
+id = 'test.bp.two.local'
+version = '2.0.0'
+homepage = 'https://some-homepage-two'
+
+[[local_info.processes]]
+type = 'some-local-type'
+shell = 'bash'
+command = '/some/local command'
+default = true
+args = [
+    'some',
+    'local',
+    'args',
+]
+working-dir = "/some-test-work-dir"
+
+[[local_info.processes]]
+type = 'other-local-type'
+shell = ''
+command = '/other/local/command'
+default = false
+args = [
+    'other',
+    'local',
+    'args',
+]
+working-dir = "/other-test-work-dir"
+`
+
+		expectedLocalOutputWithRebasable = `[local_info]
+stack = 'test.stack.id.local'
+rebasable = true
 
 [local_info.base_image]
 top_layer = 'some-local-top-layer'
@@ -91,6 +150,64 @@ working-dir = "/other-test-work-dir"
 		expectedRemoteOutput = `
 [remote_info]
 stack = 'test.stack.id.remote'
+rebasable = false
+
+[remote_info.base_image]
+top_layer = 'some-remote-top-layer'
+reference = 'some-remote-run-image-reference'
+
+[[remote_info.run_images]]
+name = 'user-configured-mirror-for-remote'
+user_configured = true
+
+[[remote_info.run_images]]
+name = 'some-remote-run-image'
+
+[[remote_info.run_images]]
+name = 'some-remote-mirror'
+
+[[remote_info.run_images]]
+name = 'other-remote-mirror'
+
+[[remote_info.buildpacks]]
+id = 'test.bp.one.remote'
+version = '1.0.0'
+homepage = 'https://some-homepage-one'
+
+[[remote_info.buildpacks]]
+id = 'test.bp.two.remote'
+version = '2.0.0'
+homepage = 'https://some-homepage-two'
+
+[[remote_info.processes]]
+type = 'some-remote-type'
+shell = 'bash'
+command = '/some/remote command'
+default = true
+args = [
+    'some',
+    'remote',
+    'args',
+]
+working-dir = "/some-test-work-dir"
+
+[[remote_info.processes]]
+type = 'other-remote-type'
+shell = ''
+command = '/other/remote/command'
+default = false
+args = [
+    'other',
+    'remote',
+    'args',
+]
+working-dir = "/other-test-work-dir"
+`
+
+		expectedRemoteOutputWithRebasable = `
+[remote_info]
+stack = 'test.stack.id.remote'
+rebasable = true
 
 [remote_info.base_image]
 top_layer = 'some-remote-top-layer'
@@ -210,6 +327,61 @@ working-dir = "/other-test-work-dir"
 					},
 				},
 			}
+			remoteInfoWithRebasable = &client.ImageInfo{
+				StackID: "test.stack.id.remote",
+				Buildpacks: []buildpack.GroupElement{
+					{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
+				},
+				Base: platform.RunImageForRebase{
+					TopLayer:  "some-remote-top-layer",
+					Reference: "some-remote-run-image-reference",
+				},
+				Stack: platform.StackMetadata{
+					RunImage: platform.RunImageForExport{
+						Image:   "some-remote-run-image",
+						Mirrors: []string{"some-remote-mirror", "other-remote-mirror"},
+					},
+				},
+				BOM: []buildpack.BOMEntry{{
+					Require: buildpack.Require{
+						Name:    "name-1",
+						Version: "version-1",
+						Metadata: map[string]interface{}{
+							"RemoteData": someData{
+								String: "aString",
+								Bool:   true,
+								Int:    123,
+								Nested: struct {
+									String string
+								}{
+									String: "anotherString",
+								},
+							},
+						},
+					},
+					Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+				}},
+				Processes: client.ProcessDetails{
+					DefaultProcess: &launch.Process{
+						Type:             "some-remote-type",
+						Command:          launch.RawCommand{Entries: []string{"/some/remote command"}},
+						Args:             []string{"some", "remote", "args"},
+						Direct:           false,
+						WorkingDirectory: "/some-test-work-dir",
+					},
+					OtherProcesses: []launch.Process{
+						{
+							Type:             "other-remote-type",
+							Command:          launch.RawCommand{Entries: []string{"/other/remote/command"}},
+							Args:             []string{"other", "remote", "args"},
+							Direct:           true,
+							WorkingDirectory: "/other-test-work-dir",
+						},
+					},
+				},
+				Rebasable: true,
+			}
 
 			localInfo = &client.ImageInfo{
 				StackID: "test.stack.id.local",
@@ -258,6 +430,56 @@ working-dir = "/other-test-work-dir"
 						},
 					},
 				},
+			}
+
+			localInfoWithRebasable = &client.ImageInfo{
+				StackID: "test.stack.id.local",
+				Buildpacks: []buildpack.GroupElement{
+					{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
+				},
+				Base: platform.RunImageForRebase{
+					TopLayer:  "some-local-top-layer",
+					Reference: "some-local-run-image-reference",
+				},
+				Stack: platform.StackMetadata{
+					RunImage: platform.RunImageForExport{
+						Image:   "some-local-run-image",
+						Mirrors: []string{"some-local-mirror", "other-local-mirror"},
+					},
+				},
+				BOM: []buildpack.BOMEntry{{
+					Require: buildpack.Require{
+						Name:    "name-1",
+						Version: "version-1",
+						Metadata: map[string]interface{}{
+							"LocalData": someData{
+								Bool: false,
+								Int:  456,
+							},
+						},
+					},
+					Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+				}},
+				Processes: client.ProcessDetails{
+					DefaultProcess: &launch.Process{
+						Type:             "some-local-type",
+						Command:          launch.RawCommand{Entries: []string{"/some/local command"}},
+						Args:             []string{"some", "local", "args"},
+						Direct:           false,
+						WorkingDirectory: "/some-test-work-dir",
+					},
+					OtherProcesses: []launch.Process{
+						{
+							Type:             "other-local-type",
+							Command:          launch.RawCommand{Entries: []string{"/other/local/command"}},
+							Args:             []string{"other", "local", "args"},
+							Direct:           true,
+							WorkingDirectory: "/other-test-work-dir",
+						},
+					},
+				},
+				Rebasable: true,
 			}
 
 			outBuf = bytes.Buffer{}
@@ -325,6 +547,35 @@ working-dir = "/other-test-work-dir"
 				assert.NotContains(outBuf.String(), "test.stack.id.remote")
 				assert.ContainsTOML(outBuf.String(), expectedLocalOutput)
 			})
+			it("prints local rebasable image info in TOML format", func() {
+				runImageMirrors := []config.RunImage{
+					{
+						Image:   "un-used-run-image",
+						Mirrors: []string{"un-used"},
+					},
+					{
+						Image:   "some-local-run-image",
+						Mirrors: []string{"user-configured-mirror-for-local"},
+					},
+					{
+						Image:   "some-remote-run-image",
+						Mirrors: []string{"user-configured-mirror-for-remote"},
+					},
+				}
+				sharedImageInfo := inspectimage.GeneralInfo{
+					Name:            "test-image",
+					RunImageMirrors: runImageMirrors,
+				}
+				tomlWriter := writer.NewTOML()
+
+				logger := logging.NewLogWithWriters(&outBuf, &outBuf)
+				err := tomlWriter.Print(logger, sharedImageInfo, localInfoWithRebasable, nil, nil, nil)
+				assert.Nil(err)
+
+				assert.ContainsTOML(outBuf.String(), `image_name = "test-image"`)
+				assert.NotContains(outBuf.String(), "test.stack.id.remote")
+				assert.ContainsTOML(outBuf.String(), expectedLocalOutputWithRebasable)
+			})
 		})
 
 		when("only remote image exists", func() {
@@ -356,6 +607,35 @@ working-dir = "/other-test-work-dir"
 				assert.ContainsTOML(outBuf.String(), `image_name = "test-image"`)
 				assert.NotContains(outBuf.String(), "test.stack.id.local")
 				assert.ContainsTOML(outBuf.String(), expectedRemoteOutput)
+			})
+			it("prints remote rebasable image info in TOML format", func() {
+				runImageMirrors := []config.RunImage{
+					{
+						Image:   "un-used-run-image",
+						Mirrors: []string{"un-used"},
+					},
+					{
+						Image:   "some-local-run-image",
+						Mirrors: []string{"user-configured-mirror-for-local"},
+					},
+					{
+						Image:   "some-remote-run-image",
+						Mirrors: []string{"user-configured-mirror-for-remote"},
+					},
+				}
+				sharedImageInfo := inspectimage.GeneralInfo{
+					Name:            "test-image",
+					RunImageMirrors: runImageMirrors,
+				}
+				tomlWriter := writer.NewTOML()
+
+				logger := logging.NewLogWithWriters(&outBuf, &outBuf)
+				err := tomlWriter.Print(logger, sharedImageInfo, nil, remoteInfoWithRebasable, nil, nil)
+				assert.Nil(err)
+
+				assert.ContainsTOML(outBuf.String(), `image_name = "test-image"`)
+				assert.NotContains(outBuf.String(), "test.stack.id.local")
+				assert.ContainsTOML(outBuf.String(), expectedRemoteOutputWithRebasable)
 			})
 		})
 	})

--- a/internal/inspectimage/writer/yaml_test.go
+++ b/internal/inspectimage/writer/yaml_test.go
@@ -30,12 +30,56 @@ func testYAML(t *testing.T, when spec.G, it spec.S) {
 		assert = h.NewAssertionManager(t)
 		outBuf bytes.Buffer
 
-		remoteInfo *client.ImageInfo
-		localInfo  *client.ImageInfo
+		remoteInfo              *client.ImageInfo
+		remoteInfoWithRebasable *client.ImageInfo
+		localInfo               *client.ImageInfo
+		localInfoWithRebasable  *client.ImageInfo
 
 		expectedLocalOutput = `---
 local_info:
   stack: test.stack.id.local
+  rebasable: false
+  base_image:
+    top_layer: some-local-top-layer
+    reference: some-local-run-image-reference
+  run_images:
+  - name: user-configured-mirror-for-local
+    user_configured: true
+  - name: some-local-run-image
+  - name: some-local-mirror
+  - name: other-local-mirror
+  buildpacks:
+  - homepage: https://some-homepage-one
+    id: test.bp.one.local
+    version: 1.0.0
+  - homepage: https://some-homepage-two
+    id: test.bp.two.local
+    version: 2.0.0
+  extensions: []
+  processes:
+  - type: some-local-type
+    shell: bash
+    command: "/some/local command"
+    default: true
+    args:
+    - some
+    - local
+    - args
+    working-dir: /some-test-work-dir
+  - type: other-local-type
+    shell: ''
+    command: "/other/local/command"
+    default: false
+    args:
+    - other
+    - local
+    - args
+    working-dir: /other-test-work-dir
+`
+		expectedLocalOutputWithRebasable = `---
+local_info:
+  stack: test.stack.id.local
+  rebasable: true
   base_image:
     top_layer: some-local-top-layer
     reference: some-local-run-image-reference
@@ -76,6 +120,48 @@ local_info:
 		expectedRemoteOutput = `---
 remote_info:
   stack: test.stack.id.remote
+  rebasable: false
+  base_image:
+    top_layer: some-remote-top-layer
+    reference: some-remote-run-image-reference
+  run_images:
+  - name: user-configured-mirror-for-remote
+    user_configured: true
+  - name: some-remote-run-image
+  - name: some-remote-mirror
+  - name: other-remote-mirror
+  buildpacks:
+  - homepage: https://some-homepage-one
+    id: test.bp.one.remote
+    version: 1.0.0
+  - homepage: https://some-homepage-two
+    id: test.bp.two.remote
+    version: 2.0.0
+  extensions: []
+  processes:
+  - type: some-remote-type
+    shell: bash
+    command: "/some/remote command"
+    default: true
+    args:
+    - some
+    - remote
+    - args
+    working-dir: /some-test-work-dir
+  - type: other-remote-type
+    shell: ''
+    command: "/other/remote/command"
+    default: false
+    args:
+    - other
+    - remote
+    - args
+    working-dir: /other-test-work-dir
+`
+		expectedRemoteOutputWithRebasable = `---
+remote_info:
+  stack: test.stack.id.remote
+  rebasable: true
   base_image:
     top_layer: some-remote-top-layer
     reference: some-remote-run-image-reference
@@ -181,6 +267,62 @@ remote_info:
 				},
 			}
 
+			remoteInfoWithRebasable = &client.ImageInfo{
+				StackID: "test.stack.id.remote",
+				Buildpacks: []buildpack.GroupElement{
+					{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.remote", Version: "2.0.0", Homepage: "https://some-homepage-two"},
+				},
+				Base: platform.RunImageForRebase{
+					TopLayer:  "some-remote-top-layer",
+					Reference: "some-remote-run-image-reference",
+				},
+				Stack: platform.StackMetadata{
+					RunImage: platform.RunImageForExport{
+						Image:   "some-remote-run-image",
+						Mirrors: []string{"some-remote-mirror", "other-remote-mirror"},
+					},
+				},
+				BOM: []buildpack.BOMEntry{{
+					Require: buildpack.Require{
+						Name:    "name-1",
+						Version: "version-1",
+						Metadata: map[string]interface{}{
+							"RemoteData": someData{
+								String: "aString",
+								Bool:   true,
+								Int:    123,
+								Nested: struct {
+									String string
+								}{
+									String: "anotherString",
+								},
+							},
+						},
+					},
+					Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+				}},
+				Processes: client.ProcessDetails{
+					DefaultProcess: &launch.Process{
+						Type:             "some-remote-type",
+						Command:          launch.RawCommand{Entries: []string{"/some/remote command"}},
+						Args:             []string{"some", "remote", "args"},
+						Direct:           false,
+						WorkingDirectory: "/some-test-work-dir",
+					},
+					OtherProcesses: []launch.Process{
+						{
+							Type:             "other-remote-type",
+							Command:          launch.RawCommand{Entries: []string{"/other/remote/command"}},
+							Args:             []string{"other", "remote", "args"},
+							Direct:           true,
+							WorkingDirectory: "/other-test-work-dir",
+						},
+					},
+				},
+				Rebasable: true,
+			}
+
 			localInfo = &client.ImageInfo{
 				StackID: "test.stack.id.local",
 				Buildpacks: []buildpack.GroupElement{
@@ -228,6 +370,56 @@ remote_info:
 						},
 					},
 				},
+			}
+
+			localInfoWithRebasable = &client.ImageInfo{
+				StackID: "test.stack.id.local",
+				Buildpacks: []buildpack.GroupElement{
+					{ID: "test.bp.one.local", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+					{ID: "test.bp.two.local", Version: "2.0.0", Homepage: "https://some-homepage-two"},
+				},
+				Base: platform.RunImageForRebase{
+					TopLayer:  "some-local-top-layer",
+					Reference: "some-local-run-image-reference",
+				},
+				Stack: platform.StackMetadata{
+					RunImage: platform.RunImageForExport{
+						Image:   "some-local-run-image",
+						Mirrors: []string{"some-local-mirror", "other-local-mirror"},
+					},
+				},
+				BOM: []buildpack.BOMEntry{{
+					Require: buildpack.Require{
+						Name:    "name-1",
+						Version: "version-1",
+						Metadata: map[string]interface{}{
+							"LocalData": someData{
+								Bool: false,
+								Int:  456,
+							},
+						},
+					},
+					Buildpack: buildpack.GroupElement{ID: "test.bp.one.remote", Version: "1.0.0", Homepage: "https://some-homepage-one"},
+				}},
+				Processes: client.ProcessDetails{
+					DefaultProcess: &launch.Process{
+						Type:             "some-local-type",
+						Command:          launch.RawCommand{Entries: []string{"/some/local command"}},
+						Args:             []string{"some", "local", "args"},
+						Direct:           false,
+						WorkingDirectory: "/some-test-work-dir",
+					},
+					OtherProcesses: []launch.Process{
+						{
+							Type:             "other-local-type",
+							Command:          launch.RawCommand{Entries: []string{"/other/local/command"}},
+							Args:             []string{"other", "local", "args"},
+							Direct:           true,
+							WorkingDirectory: "/other-test-work-dir",
+						},
+					},
+				},
+				Rebasable: true,
 			}
 
 			outBuf = bytes.Buffer{}
@@ -293,9 +485,36 @@ remote_info:
 
 				assert.ContainsYAML(outBuf.String(), `"image_name": "test-image"`)
 				assert.ContainsYAML(outBuf.String(), expectedLocalOutput)
-
 				assert.NotContains(outBuf.String(), "test.stack.id.remote")
-				assert.ContainsYAML(outBuf.String(), expectedLocalOutput)
+			})
+			it("prints local rebasable image info in YAML format", func() {
+				runImageMirrors := []config.RunImage{
+					{
+						Image:   "un-used-run-image",
+						Mirrors: []string{"un-used"},
+					},
+					{
+						Image:   "some-local-run-image",
+						Mirrors: []string{"user-configured-mirror-for-local"},
+					},
+					{
+						Image:   "some-remote-run-image",
+						Mirrors: []string{"user-configured-mirror-for-remote"},
+					},
+				}
+				sharedImageInfo := inspectimage.GeneralInfo{
+					Name:            "test-image",
+					RunImageMirrors: runImageMirrors,
+				}
+				yamlWriter := writer.NewYAML()
+
+				logger := logging.NewLogWithWriters(&outBuf, &outBuf)
+				err := yamlWriter.Print(logger, sharedImageInfo, localInfoWithRebasable, nil, nil, nil)
+				assert.Nil(err)
+
+				assert.ContainsYAML(outBuf.String(), `"image_name": "test-image"`)
+				assert.ContainsYAML(outBuf.String(), expectedLocalOutputWithRebasable)
+				assert.NotContains(outBuf.String(), "test.stack.id.remote")
 			})
 		})
 
@@ -328,6 +547,35 @@ remote_info:
 				assert.ContainsYAML(outBuf.String(), `"image_name": "test-image"`)
 				assert.NotContains(outBuf.String(), "test.stack.id.local")
 				assert.ContainsYAML(outBuf.String(), expectedRemoteOutput)
+			})
+			it("prints remote rebasable image info in YAML format", func() {
+				runImageMirrors := []config.RunImage{
+					{
+						Image:   "un-used-run-image",
+						Mirrors: []string{"un-used"},
+					},
+					{
+						Image:   "some-local-run-image",
+						Mirrors: []string{"user-configured-mirror-for-local"},
+					},
+					{
+						Image:   "some-remote-run-image",
+						Mirrors: []string{"user-configured-mirror-for-remote"},
+					},
+				}
+				sharedImageInfo := inspectimage.GeneralInfo{
+					Name:            "test-image",
+					RunImageMirrors: runImageMirrors,
+				}
+				yamlWriter := writer.NewYAML()
+
+				logger := logging.NewLogWithWriters(&outBuf, &outBuf)
+				err := yamlWriter.Print(logger, sharedImageInfo, nil, remoteInfoWithRebasable, nil, nil)
+				assert.Nil(err)
+
+				assert.ContainsYAML(outBuf.String(), `"image_name": "test-image"`)
+				assert.ContainsYAML(outBuf.String(), expectedRemoteOutputWithRebasable)
+				assert.NotContains(outBuf.String(), "test.stack.id.local")
 			})
 		})
 	})

--- a/pkg/client/inspect_image.go
+++ b/pkg/client/inspect_image.go
@@ -124,7 +124,7 @@ func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 	}
 
 	var rebasable bool
-	if _, err := dist.GetLabel(img, platform.RebaseableLabel, &rebasable); err != nil {
+	if _, err := dist.GetLabel(img, platform.RebasableLabel, &rebasable); err != nil {
 		return nil, err
 	}
 

--- a/pkg/client/inspect_image.go
+++ b/pkg/client/inspect_image.go
@@ -123,6 +123,11 @@ func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 		return nil, err
 	}
 
+	var rebasable bool
+	if _, err := dist.GetLabel(img, platform.RebaseableLabel, &rebasable); err != nil {
+		return nil, err
+	}
+
 	platformAPI, err := img.Env(platformAPIEnv)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading platform api")
@@ -196,6 +201,7 @@ func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 			Buildpacks: buildMD.Buildpacks,
 			Extensions: buildMD.Extensions,
 			Processes:  processDetails,
+			Rebasable:  rebasable,
 		}, nil
 	}
 
@@ -206,5 +212,6 @@ func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 		BOM:        buildMD.BOM,
 		Buildpacks: buildMD.Buildpacks,
 		Processes:  processDetails,
+		Rebasable:  rebasable,
 	}, nil
 }

--- a/pkg/client/inspect_image.go
+++ b/pkg/client/inspect_image.go
@@ -55,6 +55,9 @@ type ImageInfo struct {
 
 	// Processes lists all processes contributed by buildpacks.
 	Processes ProcessDetails
+
+	// If the image can be rebased
+	Rebasable bool
 }
 
 // ProcessDetails is a collection of all start command metadata


### PR DESCRIPTION
## Summary
Now `pack inspect <image>` shows a `Rebasable` label on the inspect output based on the reabasability of the image if the label has been set or if it is `true`

`Rebasable: true` if it's rebasable, `Rebasable: false` if it's not.

It works either for local or remote images

## Output

#### Before Remote output

```
REMOTE:

Stack: test.stack.id.remote

Base Image:
  Reference: some-remote-run-image-reference
  Top Layer: some-remote-top-layer

Run Images:
  user-configured-mirror-for-remote        (user-configured)
  some-remote-run-image
  some-remote-mirror
  other-remote-mirror

Buildpacks:
  ID                          VERSION        HOMEPAGE
  test.bp.one.remote          1.0.0          https://some-homepage-one
  test.bp.two.remote          2.0.0          https://some-homepage-two
  test.bp.three.remote        3.0.0          -

Processes:
  TYPE                              SHELL        COMMAND                      ARGS                     WORK DIR
  some-remote-type (default)        bash         /some/remote command         some remote args         /some-test-work-dir
  other-remote-type                              /other/remote/command        other remote args        /other-test-work-dir
```

#### After remote output with `rebasable` label set to true

```REMOTE:

Stack: test.stack.id.remote

Base Image:
  Reference: some-remote-run-image-reference
  Top Layer: some-remote-top-layer

Run Images:
  user-configured-mirror-for-remote        (user-configured)
  some-remote-run-image
  some-remote-mirror
  other-remote-mirror

Rebasable: true

Buildpacks:
  ID                          VERSION        HOMEPAGE
  test.bp.one.remote          1.0.0          https://some-homepage-one
  test.bp.two.remote          2.0.0          https://some-homepage-two
  test.bp.three.remote        3.0.0          -

Processes:
  TYPE                              SHELL        COMMAND                      ARGS                     WORK DIR
  some-remote-type (default)        bash         /some/remote command         some remote args         /some-test-work-dir
  other-remote-type                              /other/remote/command        other remote args        /other-test-work-dir
```


## Documentation - WIP

- Should this change be documented?
    - [X] Yes, see https://github.com/buildpacks/docs/pull/592
    - [ ] No

## Related

Resolves #1799