### PR TITLE
use latest version of go minor when building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: "1.19"
+          check-latest: true
       - name: Set up go env for Unix
         if: runner.os != 'Windows'
         run: |
@@ -180,6 +181,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: "1.19"
+          check-latest: true
       - name: Build
         run: |
           [[ $GITHUB_REF =~ ^refs\/heads\/release/(.*)$ ]] && version=${BASH_REMATCH[1]} || version=0.0.0

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: "1.19"
+          check-latest: true
       - name: Set up go env
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV


### PR DESCRIPTION
This should get us go 1.19.10

https://github.com/actions/setup-go#check-latest-version