### PR TITLE
Disable CI failure if codecov fails due of the flakiness of the upload step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./out/tests/coverage-unit.txt
           flags: unit,os_${{ matrix.os }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
       - name: Prepare Codecov
         if: matrix.os == 'windows'


### PR DESCRIPTION
## Summary

This PR will disable a CI failure in case of codecov failures.

The codecov step is still [flaky](https://github.com/buildpacks/pack/issues/1665) despite the [fix](https://github.com/buildpacks/pack/pull/1666), here one last evidence on my PR:
* https://github.com/buildpacks/pack/actions/runs/5335523164/jobs/9668862772?pr=1806

Having flaky tests can be harmful, reason I'd like to disable CI failure:
* We still have Codecov bot comments which give us insights about the coverage and possible problems about it, it can be a helpful metric for identifying untested portions of code but I wouldn't stop the whole pipeline
* A new contributor can't re-run the GH action, it then fall into mainters/team responsibilities to do so, frequent reruns of flaky tests can also slow down the development and feedback loop, impacting productivity.
* Flaky tests can undermine the confidence in the test suite and make it difficult to rely on the reported test results especially from the community

Bonus points about code coverage:
* According to many literatures code coverage metric gives a false sense of security and in my experience I've seen teams creating low quality tests just for the sake of passing the code coverage threshold.
* The team and the maintainers review the PRs anyway, and having tests should be a standard for the project, so my take is that during the review we should stop any PR being merged if not having relevant tests covering it.

Maybe there is a specific reason to keep it activated and I'm not aware of it but I hope those points help to clarify my reasons behind this PR 🙂

## Output

#### Before
If the CodeCov fails the whole pipeline fails

#### After
if the CodeCov step fails the pipeline keeps running

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [X] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1665 
