### PR TITLE
If includeRoot by default the permission value is always set to 0777

### DIFF
--- a/internal/build/container_ops_test.go
+++ b/internal/build/container_ops_test.go
@@ -169,17 +169,9 @@ lrwxrwxrwx    1 123      456 (.*) fake-app-symlink -> fake-app-file
 (.*)    <DIR>          ...                    some-vol
 `)
 				} else {
-					if runtime.GOOS == "windows" {
-						// Expected LCOW results
-						h.AssertContainsMatch(t, outBuf.String(), `
+					h.AssertContainsMatch(t, outBuf.String(), `
 drwxrwxrwx    2 123      456 (.*) some-vol
 `)
-					} else {
-						// Expected results
-						h.AssertContainsMatch(t, outBuf.String(), `
-drwxr-xr-x    2 123      456 (.*) some-vol
-`)
-					}
 				}
 			})
 		})

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -174,10 +174,13 @@ func WriteDirToTar(tw TarWriter, srcDir, basePath string, uid, gid int, mode int
 			Name:     basePath,
 			Mode:     mode,
 		}
-		if rootHeader.Mode == -1 {
-			rootHeader.Mode = int64(fs.ModePerm &^ Umask)
+
+		if mode == -1 {
+			mode = int64(fs.ModePerm)
 		}
+
 		finalizeHeader(rootHeader, uid, gid, mode, normalizeModTime)
+
 		if err := tw.WriteHeader(rootHeader); err != nil {
 			return err
 		}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -169,19 +169,9 @@ func ReadTarEntry(rc io.Reader, entryPath string) (*tar.Header, []byte, error) {
 // contents will be placed. The includeRoot param sets the permissions and metadata on the root file.
 func WriteDirToTar(tw TarWriter, srcDir, basePath string, uid, gid int, mode int64, normalizeModTime, includeRoot bool, fileFilter func(string) bool) error {
 	if includeRoot {
-		rootHeader := &tar.Header{
-			Typeflag: tar.TypeDir,
-			Name:     basePath,
-			Mode:     mode,
-		}
-
-		if mode == -1 {
-			mode = int64(fs.ModePerm)
-		}
-
-		finalizeHeader(rootHeader, uid, gid, mode, normalizeModTime)
-
-		if err := tw.WriteHeader(rootHeader); err != nil {
+		mode = modePermIfNegativeMode(mode)
+		err := writeRootHeader(tw, basePath, mode, uid, gid, normalizeModTime)
+		if err != nil {
 			return err
 		}
 	}
@@ -197,31 +187,9 @@ func WriteDirToTar(tw TarWriter, srcDir, basePath string, uid, gid int, mode int
 				return nil
 			}
 		}
+
 		if err != nil {
 			return err
-		}
-
-		if fi.Mode()&os.ModeSocket != 0 {
-			return nil
-		}
-
-		var header *tar.Header
-		if fi.Mode()&os.ModeSymlink != 0 {
-			target, err := os.Readlink(file)
-			if err != nil {
-				return err
-			}
-
-			// Ensure that symlinks have Linux link names, independent of source OS
-			header, err = tar.FileInfoHeader(fi, filepath.ToSlash(target))
-			if err != nil {
-				return err
-			}
-		} else {
-			header, err = tar.FileInfoHeader(fi, fi.Name())
-			if err != nil {
-				return err
-			}
 		}
 
 		if relPath == "" {
@@ -234,14 +202,28 @@ func WriteDirToTar(tw TarWriter, srcDir, basePath string, uid, gid int, mode int
 			return nil
 		}
 
-		header.Name = filepath.ToSlash(filepath.Join(basePath, relPath))
-		finalizeHeader(header, uid, gid, mode, normalizeModTime)
+		if hasModeSocket(fi) != 0 {
+			return nil
+		}
 
-		if err := tw.WriteHeader(header); err != nil {
+		var header *tar.Header
+		if hasModeSymLink(fi) {
+			if header, err = getHeaderFromSymLink(file, fi); err != nil {
+				return err
+			}
+		} else {
+			if header, err = tar.FileInfoHeader(fi, fi.Name()); err != nil {
+				return err
+			}
+		}
+
+		header.Name = getHeaderNameFromBaseAndRelPath(basePath, relPath)
+		err = writeHeader(header, uid, gid, mode, normalizeModTime, tw)
+		if err != nil {
 			return err
 		}
 
-		if fi.Mode().IsRegular() {
+		if hasRegularMode(fi) {
 			f, err := os.Open(filepath.Clean(file))
 			if err != nil {
 				return err
@@ -337,26 +319,6 @@ func WriteZipToTar(tw TarWriter, srcZip, basePath string, uid, gid int, mode int
 	return nil
 }
 
-func isFatFile(header zip.FileHeader) bool {
-	var (
-		creatorFAT  uint16 = 0 // nolint:revive
-		creatorVFAT uint16 = 14
-	)
-
-	// This identifies FAT files, based on the `zip` source: https://golang.org/src/archive/zip/struct.go
-	firstByte := header.CreatorVersion >> 8
-	return firstByte == creatorFAT || firstByte == creatorVFAT
-}
-
-func finalizeHeader(header *tar.Header, uid, gid int, mode int64, normalizeModTime bool) {
-	NormalizeHeader(header, normalizeModTime)
-	if mode != -1 {
-		header.Mode = mode
-	}
-	header.Uid = uid
-	header.Gid = gid
-}
-
 // NormalizeHeader normalizes a tar.Header
 //
 // Normalizes the following:
@@ -388,4 +350,87 @@ func IsZip(path string) (bool, error) {
 	default:
 		return false, err
 	}
+}
+
+func isFatFile(header zip.FileHeader) bool {
+	var (
+		creatorFAT  uint16 = 0 // nolint:revive
+		creatorVFAT uint16 = 14
+	)
+
+	// This identifies FAT files, based on the `zip` source: https://golang.org/src/archive/zip/struct.go
+	firstByte := header.CreatorVersion >> 8
+	return firstByte == creatorFAT || firstByte == creatorVFAT
+}
+
+func finalizeHeader(header *tar.Header, uid, gid int, mode int64, normalizeModTime bool) {
+	NormalizeHeader(header, normalizeModTime)
+	if mode != -1 {
+		header.Mode = mode
+	}
+	header.Uid = uid
+	header.Gid = gid
+}
+
+func hasRegularMode(fi os.FileInfo) bool {
+	return fi.Mode().IsRegular()
+}
+
+func getHeaderNameFromBaseAndRelPath(basePath string, relPath string) string {
+	return filepath.ToSlash(filepath.Join(basePath, relPath))
+}
+
+func writeHeader(header *tar.Header, uid int, gid int, mode int64, normalizeModTime bool, tw TarWriter) error {
+	finalizeHeader(header, uid, gid, mode, normalizeModTime)
+
+	if err := tw.WriteHeader(header); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getHeaderFromSymLink(file string, fi os.FileInfo) (*tar.Header, error) {
+	target, err := os.Readlink(file)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure that symlinks have Linux link names, independent of source OS
+	header, err := tar.FileInfoHeader(fi, filepath.ToSlash(target))
+	if err != nil {
+		return nil, err
+	}
+	return header, nil
+}
+
+func hasModeSymLink(fi os.FileInfo) bool {
+	return fi.Mode()&os.ModeSymlink != 0
+}
+
+func hasModeSocket(fi os.FileInfo) fs.FileMode {
+	return fi.Mode() & os.ModeSocket
+}
+
+func writeRootHeader(tw TarWriter, basePath string, mode int64, uid int, gid int, normalizeModTime bool) error {
+	rootHeader := &tar.Header{
+		Typeflag: tar.TypeDir,
+		Name:     basePath,
+		Mode:     mode,
+	}
+
+	finalizeHeader(rootHeader, uid, gid, mode, normalizeModTime)
+
+	if err := tw.WriteHeader(rootHeader); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func modePermIfNegativeMode(mode int64) int64 {
+	if mode == -1 {
+		mode = int64(fs.ModePerm)
+	}
+	return mode
 }

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -169,7 +169,7 @@ func ReadTarEntry(rc io.Reader, entryPath string) (*tar.Header, []byte, error) {
 // contents will be placed. The includeRoot param sets the permissions and metadata on the root file.
 func WriteDirToTar(tw TarWriter, srcDir, basePath string, uid, gid int, mode int64, normalizeModTime, includeRoot bool, fileFilter func(string) bool) error {
 	if includeRoot {
-		mode = modePermIfNegativeMode(mode)
+		mode := modePermIfNegativeMode(mode)
 		err := writeRootHeader(tw, basePath, mode, uid, gid, normalizeModTime)
 		if err != nil {
 			return err
@@ -430,7 +430,7 @@ func writeRootHeader(tw TarWriter, basePath string, mode int64, uid int, gid int
 
 func modePermIfNegativeMode(mode int64) int64 {
 	if mode == -1 {
-		mode = int64(fs.ModePerm)
+		return int64(fs.ModePerm)
 	}
 	return mode
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -2,7 +2,6 @@ package archive_test
 
 import (
 	"archive/tar"
-	"io/fs"
 	"net"
 	"os"
 	"path/filepath"
@@ -214,6 +213,33 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("mode is set to 0755", func() {
+			it("writes a tar to the dest dir with 0755", func() {
+				fh, err := os.Create(filepath.Join(tmpDir, "some.tar"))
+				h.AssertNil(t, err)
+
+				tw := tar.NewWriter(fh)
+
+				err = archive.WriteDirToTar(tw, src, "/nested/dir/dir-in-archive", 1234, 2345, 0755, true, false, nil)
+				h.AssertNil(t, err)
+				h.AssertNil(t, tw.Close())
+				h.AssertNil(t, fh.Close())
+
+				file, err := os.Open(filepath.Join(tmpDir, "some.tar"))
+				h.AssertNil(t, err)
+				defer file.Close()
+
+				tr := tar.NewReader(file)
+
+				verify := h.NewTarVerifier(t, tr, 1234, 2345)
+				verify.NextFile("/nested/dir/dir-in-archive/some-file.txt", "some-content", 0755)
+				verify.NextDirectory("/nested/dir/dir-in-archive/sub-dir", 0755)
+				if runtime.GOOS != "windows" {
+					verify.NextSymLink("/nested/dir/dir-in-archive/sub-dir/link-file", "../some-file.txt")
+				}
+			})
+		})
+
 		when("includeRoot is true", func() {
 			it("sets metadata on base dest file", func() {
 				fh, err := os.Create(filepath.Join(tmpDir, "some.tar"))
@@ -235,33 +261,32 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 				verify := h.NewTarVerifier(t, tr, 1234, 2345)
 				verify.NextDirectory("/nested/dir/dir-in-archive", int64(os.ModePerm))
 			})
-		})
+			when("mode is set to -1", func() {
+				it("writes a tar to the dest dir with default (0777) dir mode", func() {
+					fh, err := os.Create(filepath.Join(tmpDir, "some.tar"))
+					h.AssertNil(t, err)
 
-		when("mode is set to -1", func() {
-			it("writes a tar to the dest dir with preexisting file mode", func() {
-				fh, err := os.Create(filepath.Join(tmpDir, "some.tar"))
-				h.AssertNil(t, err)
+					tw := tar.NewWriter(fh)
 
-				tw := tar.NewWriter(fh)
+					err = archive.WriteDirToTar(tw, src, "/nested/dir/dir-in-archive", 1234, 2345, -1, true, true, nil)
+					h.AssertNil(t, err)
+					h.AssertNil(t, tw.Close())
+					h.AssertNil(t, fh.Close())
 
-				err = archive.WriteDirToTar(tw, src, "/nested/dir/dir-in-archive", 1234, 2345, -1, true, true, nil)
-				h.AssertNil(t, err)
-				h.AssertNil(t, tw.Close())
-				h.AssertNil(t, fh.Close())
+					file, err := os.Open(filepath.Join(tmpDir, "some.tar"))
+					h.AssertNil(t, err)
+					defer file.Close()
 
-				file, err := os.Open(filepath.Join(tmpDir, "some.tar"))
-				h.AssertNil(t, err)
-				defer file.Close()
+					tr := tar.NewReader(file)
 
-				tr := tar.NewReader(file)
-
-				verify := h.NewTarVerifier(t, tr, 1234, 2345)
-				verify.NextDirectory("/nested/dir/dir-in-archive", int64(fs.ModePerm&^archive.Umask))
-				verify.NextFile("/nested/dir/dir-in-archive/some-file.txt", "some-content", fileMode(t, filepath.Join(src, "some-file.txt")))
-				verify.NextDirectory("/nested/dir/dir-in-archive/sub-dir", fileMode(t, filepath.Join(src, "sub-dir")))
-				if runtime.GOOS != "windows" {
-					verify.NextSymLink("/nested/dir/dir-in-archive/sub-dir/link-file", "../some-file.txt")
-				}
+					verify := h.NewTarVerifier(t, tr, 1234, 2345)
+					verify.NextDirectory("/nested/dir/dir-in-archive", 0777)
+					verify.NextFile("/nested/dir/dir-in-archive/some-file.txt", "some-content", 0777)
+					verify.NextDirectory("/nested/dir/dir-in-archive/sub-dir", 0777)
+					if runtime.GOOS != "windows" {
+						verify.NextSymLink("/nested/dir/dir-in-archive/sub-dir/link-file", "../some-file.txt")
+					}
+				})
 			})
 		})
 
@@ -616,14 +641,4 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 	})
-}
-
-func fileMode(t *testing.T, path string) int64 {
-	t.Helper()
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("failed to stat %s", path)
-	}
-	mode := int64(info.Mode() & os.ModePerm)
-	return mode
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -262,7 +262,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 				verify.NextDirectory("/nested/dir/dir-in-archive", int64(os.ModePerm))
 			})
 			when("mode is set to -1", func() {
-				it("writes a tar to the dest dir with default (0777) dir mode", func() {
+				it("writes a tar to the root dir with default (0777) dir mode", func() {
 					fh, err := os.Create(filepath.Join(tmpDir, "some.tar"))
 					h.AssertNil(t, err)
 
@@ -281,8 +281,8 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 
 					verify := h.NewTarVerifier(t, tr, 1234, 2345)
 					verify.NextDirectory("/nested/dir/dir-in-archive", 0777)
-					verify.NextFile("/nested/dir/dir-in-archive/some-file.txt", "some-content", 0777)
-					verify.NextDirectory("/nested/dir/dir-in-archive/sub-dir", 0777)
+					verify.NextFile("/nested/dir/dir-in-archive/some-file.txt", "some-content", fileMode(t, filepath.Join(src, "some-file.txt")))
+					verify.NextDirectory("/nested/dir/dir-in-archive/sub-dir", fileMode(t, filepath.Join(src, "sub-dir")))
 					if runtime.GOOS != "windows" {
 						verify.NextSymLink("/nested/dir/dir-in-archive/sub-dir/link-file", "../some-file.txt")
 					}
@@ -641,4 +641,14 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 	})
+}
+
+func fileMode(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("failed to stat %s", path)
+	}
+	mode := int64(info.Mode() & os.ModePerm)
+	return mode
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -241,7 +241,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("includeRoot is true", func() {
-			it("sets metadata on base dest file", func() {
+			it("writes a tar to the root dir with the provided mode", func() {
 				fh, err := os.Create(filepath.Join(tmpDir, "some.tar"))
 				h.AssertNil(t, err)
 


### PR DESCRIPTION
## Summary
This PR solves the issue https://github.com/buildpacks/pack/issues/1800
The logic behind it is:
Whenever we pass `mode = -1` and `includeRoot = true` to the method `archive.WriteDirToTar` it sets the permissions to `0777`.
One thing that is worth noticing is that we *ALWAYS* pass `mode=-1` and `includeRoot=true` which implies we always set `0777` for the rootDir
Codebase reference:
*  `container_ops.createReader`
* `lifecycle_execution.Create:370`
* `lifecycle_execution.Detect:430`

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

```
drwxr-xr-x    2 123      456 (.*) some-vol
```

#### After

```
drwxrwxrwx    2 123      456 (.*) some-vol
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [X] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1800
