### PR TITLE
tiny cleanup

### DIFF
--- a/pkg/buildpack/buildpack.go
+++ b/pkg/buildpack/buildpack.go
@@ -593,9 +593,8 @@ func (m *moduleTarCollection) get(id, version string) (moduleTar, error) {
 func (m *moduleTarCollection) moduleTars() []ModuleTar {
 	var modulesTar []ModuleTar
 	for _, v := range m.modules {
-		v := v
-		vv := &v
-		modulesTar = append(modulesTar, vv)
+		vcopy := v
+		modulesTar = append(modulesTar, &vcopy)
 	}
 	return modulesTar
 }


### PR DESCRIPTION
the line `vv := &v` seems to be unnecessary,  and imo it's more clear not to re-use the same variable name so i called it `vcopy` 