### PR TITLE
Update docker-delivery workflow to create multi-arch images

### DIFF
--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -59,15 +59,18 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Pack Build/Publish
-        uses: dfreilich/pack-action@v2.1.1
-        env:
-          BP_GO_BUILD_LDFLAGS: "-s -w -X 'github.com/buildpacks/pack.Version=${{ steps.version.outputs.result }}'"
-        with:
-          args: 'build ${{ env.IMG_NAME }}:${{ steps.version.outputs.result }} --builder ${{ env.BUILDER }} --env BP_GO_BUILD_LDFLAGS --publish'
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: buildpacks/github-actions/setup-tools@v5.3.0
+      - name: Buildx Build/Publish
+        run: |
+          docker buildx build . \
+            --tag ${{ env.IMG_NAME }}:${{ steps.version.outputs.result }} \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg pack_version=${{ steps.version.outputs.result }} \
+            --provenance=false \
+            --push
       - name: Tag Image as Latest
         if: ${{ github.event.release != '' || github.event.inputs.tag_latest }}
         run: |
-          docker pull ${{ env.IMG_NAME }}:${{ steps.version.outputs.result }}
-          docker tag ${{ env.IMG_NAME }}:${{ steps.version.outputs.result }} ${{ env.IMG_NAME }}:latest
-          docker push ${{ env.IMG_NAME }}:latest
+          crane copy ${{ env.IMG_NAME }}:${{ steps.version.outputs.result }} ${{ env.IMG_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.20-alpine as builder
+ARG pack_version
+ENV PACK_VERSION=$pack_version
+WORKDIR /app
+COPY . .
+RUN apk update && apk upgrade && apk add --no-cache make ca-certificates
+RUN update-ca-certificates
+RUN make build
+
+FROM scratch
+COPY --from=builder /app/out/pack /usr/local/bin/pack
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+ENTRYPOINT [ "/usr/local/bin/pack" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM golang:1.20-alpine as builder
+FROM golang:1.20 as builder
 ARG pack_version
 ENV PACK_VERSION=$pack_version
 WORKDIR /app
 COPY . .
-RUN apk update && apk upgrade && apk add --no-cache make ca-certificates
-RUN update-ca-certificates
 RUN make build
 
 FROM scratch


### PR DESCRIPTION
## Summary
This PR updates the delivery-docker CI workflow to publish multi-arch images that support linux/amd64 and linux/arm64. 

This change is needed in order to facilitate broader arm64 support in the buildpacks eco-system. I had to work around this limitation in [this](https://github.com/jericop/github-actions/blob/2c3dec9c7e30f9439254a61257146907f3a99b0f/buildpacks/create-multi-arch-builders/action.yaml#L62) proof-of-concept repo and it will be needed in order to add multi-arch support to paketo stacks and builders.

The current image is built using pack and only supports linux/amd64 architecture. The new approach uses a dockerfile and buildx. I added the `pack_version` build arg to the dockerfile so that you can pass the version you want to `make`. See below for manual test and verification.

If you prefer to not have a dockerfile in the repo I can embed it in a heredoc in the docker-delivery workflow. Just let me know.

## Output
Here is output of building the multi-arch image manually and pushing to an ephemeral registry (ttl.sh). You can run this locally to confirm it works as expected.

```
➜  buildpacks-pack git:(multi-arch-delivery-docker) ✗ docker buildx build . --tag ttl.sh/pack:1.2.3 --platform linux/amd64,linux/arm64 --build-arg pack_version=1.2.3 --provenance=false --push
[+] Building 538.0s (23/23) FINISHED                                                                                                                            
 => [internal] load .dockerignore                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                            0.0s
 => [internal] load build definition from Dockerfile                                                                                                       0.0s
 => => transferring dockerfile: 435B                                                                                                                       0.0s
 => [linux/arm64 internal] load metadata for docker.io/library/golang:1.20-alpine                                                                          2.0s
 => [linux/amd64 internal] load metadata for docker.io/library/golang:1.20-alpine                                                                          2.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                              0.0s
 => [linux/amd64 builder 1/6] FROM docker.io/library/golang:1.20-alpine@sha256:7efb78dac256c450d194e556e96f80936528335033a26d703ec8146cec8c2090            0.0s
 => => resolve docker.io/library/golang:1.20-alpine@sha256:7efb78dac256c450d194e556e96f80936528335033a26d703ec8146cec8c2090                                0.0s
 => [internal] load build context                                                                                                                          0.1s
 => => transferring context: 64.44kB                                                                                                                       0.1s
 => [linux/arm64 builder 1/6] FROM docker.io/library/golang:1.20-alpine@sha256:7efb78dac256c450d194e556e96f80936528335033a26d703ec8146cec8c2090            0.0s
 => => resolve docker.io/library/golang:1.20-alpine@sha256:7efb78dac256c450d194e556e96f80936528335033a26d703ec8146cec8c2090                                0.0s
 => CACHED [linux/amd64 builder 2/6] WORKDIR /app                                                                                                          0.0s
 => [linux/amd64 builder 3/6] COPY . .                                                                                                                     2.4s
 => CACHED [linux/arm64 builder 2/6] WORKDIR /app                                                                                                          0.0s
 => [linux/arm64 builder 3/6] COPY . .                                                                                                                     2.4s
 => [linux/arm64 builder 4/6] RUN apk update && apk upgrade && apk add --no-cache make ca-certificates                                                    12.4s
 => [linux/amd64 builder 4/6] RUN apk update && apk upgrade && apk add --no-cache make ca-certificates                                                     3.9s
 => [linux/amd64 builder 5/6] RUN update-ca-certificates                                                                                                   0.1s
 => [linux/amd64 builder 6/6] RUN make build                                                                                                             102.4s
 => [linux/arm64 builder 5/6] RUN update-ca-certificates                                                                                                   0.6s
 => [linux/arm64 builder 6/6] RUN make build                                                                                                             499.0s
 => [linux/amd64 stage-1 1/2] COPY --from=builder /app/out/pack /usr/local/bin/pack                                                                        0.1s
 => [linux/amd64 stage-1 2/2] COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/                                                       0.1s
 => [linux/arm64 stage-1 1/2] COPY --from=builder /app/out/pack /usr/local/bin/pack                                                                        0.0s
 => [linux/arm64 stage-1 2/2] COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/                                                       0.1s
 => exporting to image                                                                                                                                    21.1s
 => => exporting layers                                                                                                                                    1.6s
 => => exporting manifest sha256:37a5124a5de557d93a28a125323fbcdb51b1193321d2005c3dbbdc84b011627a                                                          0.0s
 => => exporting config sha256:78b140f407a20ad2602f20b82344238f4ca4f8d92667056e0121c595eefaee66                                                            0.0s
 => => exporting manifest sha256:4cbcb02b41dc8bda9143666ed1dc168d847120b7b7b15b959284c4fd27236855                                                          0.0s
 => => exporting config sha256:85565f3a49af5ce561d3e5e5ebeceea37af59479dea14bafbefbdd12569746a8                                                            0.0s
 => => exporting manifest list sha256:4fbd3f1cd64853730b56201d3a9672023af70359bebc90f95f437ed5c5087a6b                                                     0.0s
 => => pushing layers                                                                                                                                     16.6s
 => => pushing manifest for ttl.sh/pack:1.2.3@sha256:4fbd3f1cd64853730b56201d3a9672023af70359bebc90f95f437ed5c5087a6b                                      2.9s
➜  buildpacks-pack git:(multi-arch-delivery-docker) ✗ 
➜  buildpacks-pack git:(multi-arch-delivery-docker) ✗ docker pull ttl.sh/pack:1.2.3
1.2.3: Pulling from pack
7dde045fcad8: Pull complete 
7b689b0f2bfa: Pull complete 
Digest: sha256:4fbd3f1cd64853730b56201d3a9672023af70359bebc90f95f437ed5c5087a6b
Status: Downloaded newer image for ttl.sh/pack:1.2.3
ttl.sh/pack:1.2.3
➜  buildpacks-pack git:(multi-arch-delivery-docker) ✗ docker run --rm ttl.sh/pack:1.2.3 version
1.2.3
➜  buildpacks-pack git:(multi-arch-delivery-docker) ✗ 
```

#### Before

Today the buildpacksio/pack image can only be pulled on the linux/amd64 platform.

#### After

Afterwards the buildpacksio/pack image can be pulled on linux/amd64 and linux/arm64 platforms.

## Documentation

I don't think documentation is needed for this CI change, but I'm happy to add any if requested.
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
