### PR TITLE
Fix the rebasable flag logic in case of missing label

### DIFF
--- a/acceptance/testdata/pack_fixtures/inspect_image_local_output.json
+++ b/acceptance/testdata/pack_fixtures/inspect_image_local_output.json
@@ -3,7 +3,7 @@
   "remote_info": null,
   "local_info": {
     "stack": "pack.test.stack",
-    "rebasable": false,
+    "rebasable": {{.rebasable}},
     "base_image": {
       "top_layer": "{{.base_image_top_layer}}",
       "reference": "{{.base_image_id}}"

--- a/acceptance/testdata/pack_fixtures/inspect_image_local_output.toml
+++ b/acceptance/testdata/pack_fixtures/inspect_image_local_output.toml
@@ -2,7 +2,7 @@ image_name = "{{.image_name}}"
 
 [local_info]
 stack = "pack.test.stack"
-rebasable = false
+rebasable = {{.rebasable}}
 
   [local_info.base_image]
   top_layer = "{{.base_image_top_layer}}"

--- a/acceptance/testdata/pack_fixtures/inspect_image_local_output.yaml
+++ b/acceptance/testdata/pack_fixtures/inspect_image_local_output.yaml
@@ -3,7 +3,7 @@ image_name: "{{.image_name}}"
 remote_info:
 local_info:
   stack: pack.test.stack
-  rebasable: false
+  rebasable: {{.rebasable}}
   base_image:
     top_layer: "{{.base_image_top_layer}}"
     reference: "{{.base_image_id}}"

--- a/acceptance/testdata/pack_fixtures/inspect_image_published_output.json
+++ b/acceptance/testdata/pack_fixtures/inspect_image_published_output.json
@@ -3,7 +3,7 @@
   "local_info": null,
   "remote_info": {
     "stack": "pack.test.stack",
-    "rebasable": false,
+    "rebasable": {{.rebasable}},
     "base_image": {
       "top_layer": "{{.base_image_top_layer}}",
       "reference": "{{.base_image_ref}}"

--- a/acceptance/testdata/pack_fixtures/inspect_image_published_output.toml
+++ b/acceptance/testdata/pack_fixtures/inspect_image_published_output.toml
@@ -2,7 +2,7 @@ image_name = "{{.image_name}}"
 
 [remote_info]
 stack = "pack.test.stack"
-rebasable = false
+rebasable = {{.rebasable}}
 
   [remote_info.base_image]
   top_layer = "{{.base_image_top_layer}}"

--- a/acceptance/testdata/pack_fixtures/inspect_image_published_output.yaml
+++ b/acceptance/testdata/pack_fixtures/inspect_image_published_output.yaml
@@ -3,7 +3,7 @@ image_name: "{{.image_name}}"
 local_info: null
 remote_info:
   stack: pack.test.stack
-  rebasable: false
+  rebasable: {{.rebasable}}
   base_image:
     top_layer: "{{.base_image_top_layer}}"
     reference: "{{.base_image_ref}}"

--- a/pkg/client/inspect_image.go
+++ b/pkg/client/inspect_image.go
@@ -123,8 +123,8 @@ func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 		return nil, err
 	}
 
-	var rebasable bool
-	if _, err := dist.GetLabel(img, platform.RebasableLabel, &rebasable); err != nil {
+	rebasable, err := getRebasableLabel(img)
+	if err != nil {
 		return nil, err
 	}
 
@@ -214,4 +214,18 @@ func (c *Client) InspectImage(name string, daemon bool) (*ImageInfo, error) {
 		Processes:  processDetails,
 		Rebasable:  rebasable,
 	}, nil
+}
+
+func getRebasableLabel(labeled dist.Labeled) (bool, error) {
+	var rebasableOutput bool
+	isPresent, err := dist.GetLabel(labeled, platform.RebasableLabel, &rebasableOutput)
+	if err != nil {
+		return false, err
+	}
+
+	if !isPresent && err == nil {
+		rebasableOutput = true
+	}
+
+	return rebasableOutput, nil
 }

--- a/pkg/dist/image_test.go
+++ b/pkg/dist/image_test.go
@@ -1,1 +1,59 @@
-package dist
+package dist_test
+
+import (
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/pkg/errors"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpacks/pack/internal/builder/fakes"
+	"github.com/buildpacks/pack/pkg/dist"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestImage(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "testImage", testImage, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func testImage(t *testing.T, when spec.G, it spec.S) {
+	when("A label needs to be get", func() {
+		it("sets a label successfully", func() {
+			var outputLabel bool
+			mockInspectable := fakes.FakeInspectable{ReturnForLabel: "true", ErrorForLabel: nil}
+
+			isPresent, err := dist.GetLabel(&mockInspectable, "random-label", &outputLabel)
+
+			h.AssertNil(t, err)
+			h.AssertEq(t, isPresent, true)
+			h.AssertEq(t, outputLabel, true)
+		})
+
+		it("returns an error", func() {
+			var outputLabel bool
+			mockInspectable := fakes.FakeInspectable{ReturnForLabel: "", ErrorForLabel: errors.New("random-error")}
+
+			isPresent, err := dist.GetLabel(&mockInspectable, "random-label", &outputLabel)
+
+			h.AssertNotNil(t, err)
+			h.AssertEq(t, isPresent, false)
+			h.AssertEq(t, outputLabel, false)
+		})
+	})
+
+	when("Try to get an empty label", func() {
+		it("returns isPresent but it doesn't set the label", func() {
+			var outputLabel bool
+			mockInspectable := fakes.FakeInspectable{ReturnForLabel: "", ErrorForLabel: nil}
+
+			isPresent, err := dist.GetLabel(&mockInspectable, "random-label", &outputLabel)
+
+			h.AssertNil(t, err)
+			h.AssertEq(t, isPresent, false)
+			h.AssertEq(t, outputLabel, false)
+		})
+	})
+}

--- a/pkg/dist/image_test.go
+++ b/pkg/dist/image_test.go
@@ -1,0 +1,1 @@
+package dist


### PR DESCRIPTION
## Summary
With this PR I fixed the problem with the `rebasable` label being set as a `false` if the `io.buildpacks.rebasable` didn't exist.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

> Rebasable: false

#### After

> Rebasable: true

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
