### PR TITLE
Improvements to --cache help

### DIFF
--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -226,9 +226,9 @@ func buildCommandFlags(cmd *cobra.Command, buildFlags *BuildFlags, cfg config.Co
 	cmd.Flags().StringVarP(&buildFlags.Builder, "builder", "B", cfg.DefaultBuilder, "Builder image")
 	cmd.Flags().Var(&buildFlags.Cache, "cache",
 		`Cache options used to define cache techniques for build process.
-- Cache as bind: type=<build/launch>;format=bind;source=<path to directory>;
-- Cache as image: type=<build/launch>;format=image;name=<registry image name>;
-- Cache as volume: type=<build/launch>;format=volume;[name=<volume name>;]
+- Cache as bind: 'type=<build/launch>;format=bind;source=<path to directory>'
+- Cache as image (requires --publish): 'type=<build/launch>;format=image;name=<registry image name>'
+- Cache as volume: 'type=<build/launch>;format=volume;[name=<volume name>]'
     - If no name is provided, a random name will be generated.
 `)
 	cmd.Flags().StringVar(&buildFlags.CacheImage, "cache-image", "", `Cache build layers in remote registry. Requires --publish`)


### PR DESCRIPTION
- Add quotes, otherwise the option will be ignored
- Remove trailing ; which causes `invalid field '' must be a key=value pair` error
- Clarify that cache as image requires --publish