### PR TITLE
Provides client keychain to lifecycle instead of the default keychain

### DIFF
--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -12,7 +12,6 @@ import (
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/auth"
 	"github.com/buildpacks/lifecycle/platform/files"
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -389,7 +388,7 @@ func (l *LifecycleExecution) Create(ctx context.Context, buildCache, launchCache
 	}
 
 	if l.opts.Publish || l.opts.Layout {
-		authConfig, err := auth.BuildEnvVar(authn.DefaultKeychain, l.opts.Image.String(), l.opts.RunImage, l.opts.CacheImage, l.opts.PreviousImage)
+		authConfig, err := auth.BuildEnvVar(l.opts.Keychain, l.opts.Image.String(), l.opts.RunImage, l.opts.CacheImage, l.opts.PreviousImage)
 		if err != nil {
 			return err
 		}
@@ -485,7 +484,7 @@ func (l *LifecycleExecution) Restore(ctx context.Context, buildCache Cache, kani
 	// for auths
 	registryOp := NullOp()
 	if len(registryImages) > 0 {
-		authConfig, err := auth.BuildEnvVar(authn.DefaultKeychain, registryImages...)
+		authConfig, err := auth.BuildEnvVar(l.opts.Keychain, registryImages...)
 		if err != nil {
 			return err
 		}
@@ -609,7 +608,7 @@ func (l *LifecycleExecution) Analyze(ctx context.Context, buildCache, launchCach
 
 	var analyze RunnerCleaner
 	if l.opts.Publish {
-		authConfig, err := auth.BuildEnvVar(authn.DefaultKeychain, l.opts.Image.String(), l.opts.RunImage, l.opts.CacheImage, l.opts.PreviousImage)
+		authConfig, err := auth.BuildEnvVar(l.opts.Keychain, l.opts.Image.String(), l.opts.RunImage, l.opts.CacheImage, l.opts.PreviousImage)
 		if err != nil {
 			return err
 		}
@@ -805,7 +804,7 @@ func (l *LifecycleExecution) Export(ctx context.Context, buildCache, launchCache
 
 	var export RunnerCleaner
 	if l.opts.Publish {
-		authConfig, err := auth.BuildEnvVar(authn.DefaultKeychain, l.opts.Image.String(), l.opts.RunImage, l.opts.CacheImage, l.opts.PreviousImage)
+		authConfig, err := auth.BuildEnvVar(l.opts.Keychain, l.opts.Image.String(), l.opts.RunImage, l.opts.CacheImage, l.opts.PreviousImage)
 		if err != nil {
 			return err
 		}

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/buildpacks/lifecycle/platform/files"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/heroku/color"
 	"github.com/sclevine/spec"
@@ -89,6 +90,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 		opts.UseCreator = providedUseCreator
 		opts.Volumes = providedVolumes
 		opts.Layout = providedLayout
+		opts.Keychain = authn.DefaultKeychain
 
 		targetImageRef, err := name.ParseReference(providedTargetImage)
 		h.AssertNil(t, err)

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/platform/files"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 
 	"github.com/buildpacks/pack/internal/builder"
@@ -98,6 +99,7 @@ type LifecycleOptions struct {
 	ReportDestinationDir string
 	SBOMDestinationDir   string
 	CreationTime         *time.Time
+	Keychain             authn.Keychain
 }
 
 func NewLifecycleExecutor(logger logging.Logger, docker DockerClient) *LifecycleExecutor {

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -538,6 +538,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		SBOMDestinationDir:   opts.SBOMDestinationDir,
 		CreationTime:         opts.CreationTime,
 		Layout:               opts.Layout(),
+		Keychain:             c.keychain,
 	}
 
 	switch {


### PR DESCRIPTION
Fixes https://github.com/buildpacks/pack/issues/1845

## Summary
Provides client keychain to lifecycle instead of the default keychain

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1845
