### PR TITLE
When additional buildpack is missing version, try to use the latest one

### DIFF
--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -566,6 +566,7 @@ version = "1.0"
 					h.AssertNil(t, command.Execute())
 				})
 			})
+
 			when("file has a builder specified", func() {
 				var projectTomlPath string
 
@@ -608,6 +609,7 @@ builder = "my-builder"
 					})
 				})
 			})
+
 			when("file is invalid", func() {
 				var projectTomlPath string
 

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -1099,8 +1099,10 @@ func getBuildpackLocator(bp projectTypes.Buildpack, stackID string) (string, err
 		return bp.URI, nil
 	case bp.ID != "" && bp.Version != "":
 		return fmt.Sprintf("%s@%s", bp.ID, bp.Version), nil
+	case bp.ID != "" && bp.Version == "":
+		return bp.ID, nil
 	default:
-		return "", errors.New("Invalid buildpack defined in project descriptor")
+		return "", errors.New("Invalid buildpack definition")
 	}
 }
 

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -1284,6 +1284,29 @@ api = "0.2"
 				)
 			})
 
+			when("from project descriptor", func() {
+				when("id - no version is provided", func() {
+					it("resolves version", func() {
+						h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+							Image:      "some/app",
+							Builder:    defaultBuilderName,
+							ClearCache: true,
+							ProjectDescriptor: projectTypes.Descriptor{
+								Build: projectTypes.Build{Buildpacks: []projectTypes.Buildpack{{ID: "buildpack.1.id"}}},
+							},
+						}))
+						h.AssertEq(t, fakeLifecycle.Opts.Builder.Name(), defaultBuilderImage.Name())
+
+						assertOrderEquals(`[[order]]
+
+  [[order.group]]
+    id = "buildpack.1.id"
+    version = "buildpack.1.version"
+`)
+					})
+				})
+			})
+
 			when("buildpacks include URIs", func() {
 				var buildpackTgz string
 
@@ -1405,6 +1428,7 @@ api = "0.2"
 							{ID: "some-other-buildpack-id", Version: "some-other-buildpack-version"},
 						})
 					})
+
 					it("adds the pre buildpack from the project descriptor", func() {
 						err := subject.Build(context.TODO(), BuildOptions{
 							Image:      "some/app",
@@ -1519,6 +1543,7 @@ api = "0.2"
 							{ID: "buildpack.2.id", Version: "buildpack.2.version"},
 						})
 					})
+
 					it("not added from the project descriptor", func() {
 						err := subject.Build(context.TODO(), BuildOptions{
 							Image:      "some/app",
@@ -1716,7 +1741,7 @@ api = "0.2"
 							ProjectDescriptorBaseDir: tmpDir,
 						})
 
-						h.AssertEq(t, "Invalid buildpack defined in project descriptor", err.Error())
+						h.AssertEq(t, "Invalid buildpack definition", err.Error())
 					})
 
 					it("ignores script if there is a URI", func() {


### PR DESCRIPTION
Fixes https://github.com/buildpacks/pack/issues/1862

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1862
