### PR TITLE
Remove legacy beta release message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,8 +280,6 @@ jobs:
           prerelease: true
           files: pack-v${{ env.PACK_VERSION }}-*
           body: |
-            > This is a **beta** pre-release of the Cloud Native Buildpack local CLI. This platform implementation should be relatively stable and reliable, but breaking changes in the underlying [specification](https://github.com/buildpack/spec) may be implemented without notice.
-
             ## Prerequisites
 
             - A container runtime such as [Docker](https://www.docker.com/get-started) or [podman](https://podman.io/getting-started/) must be available to execute builds.
@@ -350,8 +348,6 @@ jobs:
           draft: true
           files: pack-v${{ env.PACK_VERSION }}-*
           body: |
-            > This is a **beta** release of the Cloud Native Buildpack local CLI. This platform implementation should be relatively stable and reliable, but breaking changes in the underlying [specification](https://github.com/buildpack/spec) may be implemented without notice.
-
             ## Prerequisites
 
             - A container runtime such as [Docker](https://www.docker.com/get-started) or [podman](https://podman.io/getting-started/) must be available to execute builds.


### PR DESCRIPTION
## Summary
This PR remove the legacy beta warning message from the release page

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

> This is a beta release of the Cloud Native Buildpack local CLI. This platform implementation should be relatively stable and reliable, but breaking changes in the underlying [specification](https://github.com/buildpack/spec) may be implemented without notice.

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [X] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->
