### PR TITLE
Fixing error connecting to a remote daemon over ssh

### DIFF
--- a/cmd/docker_init.go
+++ b/cmd/docker_init.go
@@ -52,7 +52,7 @@ func tryInitSSHDockerClient() (dockerClient.CommonAPIClient, error) {
 	dockerClientOpts := []dockerClient.Opt{
 		dockerClient.WithVersion(client.DockerAPIVersion),
 		dockerClient.WithHTTPClient(httpClient),
-		dockerClient.WithHost("http://dummy/"),
+		dockerClient.WithHost("http://dummy"),
 		dockerClient.WithDialContext(dialContext),
 	}
 


### PR DESCRIPTION
## Summary
This PR just fixes an error connecting with a remote daemon over ssh, the only thing I did was to remove a trailing slash in at this [line](https://github.com/buildpacks/pack/blob/c38f7da1b43d5b142d1e870f3d17da93b454c64f/cmd/docker_init.go#L55) added by this [PR](https://github.com/buildpacks/pack/pull/1282) 

#### Before

I managed to reproduce the error

```bash
> DOCKER_HOST=ssh://jbustamante@34.29.52.176 /Users/jbustamante/go/src/github.com/buildpacks/pack/out/pack build -p ruby-bundler --builder cnbs/sample-builder:bionic sample-remote-app
ERROR: failed to build: failed to fetch builder image 'index.docker.io/cnbs/sample-builder:bionic': error during connect: Post "http://dummy%2F/v1.38/images/create?fromImage=cnbs%2Fsample-builder&tag=bionic": http: invalid Host header
```

#### After

I managed to connect to a remote daemon and execute the build

```bash
> DOCKER_HOST=ssh://jbustamante@34.29.52.176 /Users/jbustamante/go/src/github.com/buildpacks/pack/out/pack build -p ruby-bundler --builder cnbs/sample-builder:bionic sample-remote-app
bionic: Pulling from cnbs/sample-builder
Digest: sha256:1fbc7290c4af32a7803c084aa2e7f0b5a24a22bed6e10701791848d54fd27605
Status: Image is up to date for cnbs/sample-builder:bionic
bionic: Pulling from cnbs/sample-stack-run
Digest: sha256:22f6e78d4f4d541279069a191c27614cb3f935a5a1259e662ca5f22a85d1541a
....
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1870 
