### PR TITLE
Adding support for reading docker context

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,6 +5,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/buildpacks/pack/internal/docker"
+
 	"github.com/buildpacks/pack/buildpackage"
 	builderwriter "github.com/buildpacks/pack/internal/builder/writer"
 	"github.com/buildpacks/pack/internal/commands"
@@ -135,6 +137,10 @@ func initConfig() (config.Config, string, error) {
 }
 
 func initClient(logger logging.Logger, cfg config.Config) (*client.Client, error) {
+	if err := docker.ProcessDockerContext(logger); err != nil {
+		return nil, err
+	}
+
 	dc, err := tryInitSSHDockerClient()
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/heroku/color v0.0.6
 	github.com/mitchellh/ioprogress v0.0.0-20180201004757-6a23b12fa88e
 	github.com/onsi/gomega v1.27.10
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc4
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
@@ -102,11 +103,11 @@ require (
 	github.com/moby/sys/sequential v0.5.0 // indirect
 	github.com/moby/term v0.5.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/runc v1.1.7 // indirect
 	github.com/opencontainers/selinux v1.11.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
+	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -280,7 +280,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.3 h1:utMvzDsuh3suAEnhH0RdHmoPbU648o6CvXxTx4SBMOw=
 github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
-github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=

--- a/internal/docker/context.go
+++ b/internal/docker/context.go
@@ -1,0 +1,143 @@
+package docker
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/opencontainers/go-digest"
+
+	"github.com/buildpacks/pack/pkg/logging"
+)
+
+const (
+	dockerHostEnvVar            = "DOCKER_HOST"
+	dockerConfigEnvVar          = "DOCKER_CONFIG"
+	defaultDockerRootConfigDir  = ".docker"
+	defaultDockerConfigFileName = "config.json"
+
+	dockerContextDirName      = "contexts"
+	dockerContextMetaDirName  = "meta"
+	dockerContextMetaFileName = "meta.json"
+	dockerContextEndpoint     = "docker"
+	defaultDockerContext      = "default"
+)
+
+type configFile struct {
+	CurrentContext string `json:"currentContext,omitempty"`
+}
+
+type endpoint struct {
+	Host string `json:",omitempty"`
+}
+
+/*
+	 Example Docker context file
+	 {
+	  "Name": "desktop-linux",
+	  "dockerConfigMetadata": {
+	    "Description": "Docker Desktop"
+	  },
+	  "Endpoints": {
+	    "docker": {
+	      "Host": "unix:///Users/jbustamante/.docker/run/docker.sock",
+	      "SkipTLSVerify": false
+	    }
+	  }
+	}
+*/
+type dockerConfigMetadata struct {
+	Name      string              `json:",omitempty"`
+	Endpoints map[string]endpoint `json:"endpoints,omitempty"`
+}
+
+func ProcessDockerContext(logger logging.Logger) error {
+	dockerHost := os.Getenv(dockerHostEnvVar)
+	if dockerHost == "" {
+		dockerConfigDir, err := configDir()
+		if err != nil {
+			return err
+		}
+
+		logger.Debugf("looking for docker configuration file at: %s", dockerConfigDir)
+		configuration, err := readConfigFile(dockerConfigDir)
+		if err != nil {
+			return errors.Wrapf(err, "reading configuration file at '%s'", dockerConfigDir)
+		}
+
+		if skip(configuration) {
+			logger.Debug("docker context is default or empty, skipping it")
+			return nil
+		}
+
+		configMetaData, err := readConfigMetadata(dockerConfigDir, configuration.CurrentContext)
+		if err != nil {
+			return errors.Wrapf(err, "reading metadata for current context '%s' at '%s'", configuration.CurrentContext, dockerConfigDir)
+		}
+
+		if dockerEndpoint, ok := configMetaData.Endpoints[dockerContextEndpoint]; ok {
+			os.Setenv(dockerHostEnvVar, dockerEndpoint.Host)
+			logger.Debugf("using docker context '%s' with endpoint = '%s'", configuration.CurrentContext, dockerEndpoint.Host)
+		} else {
+			logger.Warnf("docker endpoint doesn't exist for context '%s'", configuration.CurrentContext)
+		}
+	} else {
+		logger.Debugf("'%s=%s' environment variable is being used", dockerHostEnvVar, dockerHost)
+	}
+	return nil
+}
+
+func configDir() (string, error) {
+	dir := os.Getenv(dockerConfigEnvVar)
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", errors.Wrap(err, "determining user home directory")
+		}
+		dir = filepath.Join(home, defaultDockerRootConfigDir)
+	}
+	return dir, nil
+}
+
+func readConfigFile(configDir string) (*configFile, error) {
+	filename := filepath.Join(configDir, defaultDockerConfigFileName)
+	config := &configFile{}
+	file, err := os.Open(filename)
+	if err != nil {
+		return &configFile{}, err
+	}
+	defer file.Close()
+	if err := json.NewDecoder(file).Decode(config); err != nil && !errors.Is(err, io.EOF) {
+		return &configFile{}, err
+	}
+	return config, nil
+}
+
+func readConfigMetadata(configDir string, context string) (dockerConfigMetadata, error) {
+	dockerContextDir := filepath.Join(configDir, dockerContextDirName)
+	metaFileName := filepath.Join(dockerContextDir, dockerContextMetaDirName, digest.FromString(context).Encoded(), dockerContextMetaFileName)
+	bytes, err := os.ReadFile(metaFileName)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return dockerConfigMetadata{}, fmt.Errorf("docker context '%s' not found", context)
+		}
+		return dockerConfigMetadata{}, err
+	}
+	var meta dockerConfigMetadata
+	if err := json.Unmarshal(bytes, &meta); err != nil {
+		return dockerConfigMetadata{}, fmt.Errorf("parsing %s: %v", metaFileName, err)
+	}
+	if meta.Name != context {
+		return dockerConfigMetadata{}, fmt.Errorf("context '%s' doesn't match metadata name '%s' at '%s'", context, meta.Name, metaFileName)
+	}
+
+	return meta, nil
+}
+
+func skip(configuration *configFile) bool {
+	return configuration == nil || configuration.CurrentContext == defaultDockerContext || configuration.CurrentContext == ""
+}

--- a/internal/docker/context_test.go
+++ b/internal/docker/context_test.go
@@ -1,0 +1,177 @@
+package docker_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpacks/pack/internal/docker"
+	"github.com/buildpacks/pack/pkg/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestProcessDockerContext(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "processDockerContext", testProcessDockerContext, spec.Report(report.Terminal{}))
+}
+
+const (
+	happyCase = "happy-cases"
+	errorCase = "error-cases"
+)
+
+func testProcessDockerContext(t *testing.T, when spec.G, it spec.S) {
+	var (
+		outBuf bytes.Buffer
+		logger logging.Logger
+	)
+
+	it.Before(func() {
+		logger = logging.NewLogWithWriters(&outBuf, &outBuf, logging.WithVerbose())
+	})
+
+	when("env DOCKER_HOST is set", func() {
+		it.Before(func() {
+			os.Setenv("DOCKER_HOST", "some-value")
+		})
+
+		it("docker context process is skipped", func() {
+			err := docker.ProcessDockerContext(logger)
+			h.AssertNil(t, err)
+			h.AssertContains(t, strings.TrimSpace(outBuf.String()), "'DOCKER_HOST=some-value' environment variable is being used")
+		})
+	})
+
+	when("env DOCKER_HOST is empty", func() {
+		it.Before(func() {
+			os.Setenv("DOCKER_HOST", "")
+		})
+
+		when("config.json has currentContext", func() {
+			when("currentContext is default", func() {
+				it.Before(func() {
+					setDockerConfig(t, happyCase, "default-context")
+				})
+
+				it("docker context process is skip", func() {
+					err := docker.ProcessDockerContext(logger)
+					h.AssertNil(t, err)
+					h.AssertContains(t, strings.TrimSpace(outBuf.String()), "docker context is default or empty, skipping it")
+				})
+			})
+
+			when("currentContext is default but config doesn't exist", func() {
+				it.Before(func() {
+					setDockerConfig(t, errorCase, "empty-context")
+				})
+
+				it("throw an error", func() {
+					err := docker.ProcessDockerContext(logger)
+					h.AssertNotNil(t, err)
+					h.AssertError(t, err, "docker context 'some-bad-context' not found")
+				})
+			})
+
+			when("currentContext is not default", func() {
+				when("metadata has one endpoint", func() {
+					it.Before(func() {
+						setDockerConfig(t, happyCase, "custom-context")
+					})
+
+					it("docker endpoint host is being used", func() {
+						err := docker.ProcessDockerContext(logger)
+						h.AssertNil(t, err)
+						h.AssertContains(t, outBuf.String(), "using docker context 'desktop-linux' with endpoint = 'unix:///Users/user/.docker/run/docker.sock'")
+					})
+				})
+
+				when("metadata has more than one endpoint", func() {
+					it.Before(func() {
+						setDockerConfig(t, happyCase, "two-endpoints-context")
+					})
+
+					it("docker endpoint host is being used", func() {
+						err := docker.ProcessDockerContext(logger)
+						h.AssertNil(t, err)
+						h.AssertContains(t, outBuf.String(), "using docker context 'desktop-linux' with endpoint = 'unix:///Users/user/.docker/run/docker.sock'")
+					})
+				})
+
+				when("currentContext doesn't match metadata name", func() {
+					it.Before(func() {
+						setDockerConfig(t, errorCase, "current-context-does-not-match")
+					})
+
+					it("throw an error", func() {
+						err := docker.ProcessDockerContext(logger)
+						h.AssertNotNil(t, err)
+						h.AssertError(t, err, "context 'desktop-linux' doesn't match metadata name 'bad-name'")
+					})
+				})
+
+				when("metadata doesn't contain a docker endpoint", func() {
+					it.Before(func() {
+						setDockerConfig(t, errorCase, "docker-endpoint-does-not-exist")
+					})
+
+					it("writes a warn message into the log", func() {
+						err := docker.ProcessDockerContext(logger)
+						h.AssertNil(t, err)
+						h.AssertContains(t, outBuf.String(), "docker endpoint doesn't exist for context 'desktop-linux'")
+					})
+				})
+
+				when("metadata is invalid", func() {
+					it.Before(func() {
+						setDockerConfig(t, errorCase, "invalid-metadata")
+					})
+
+					it("throw an error", func() {
+						err := docker.ProcessDockerContext(logger)
+						h.AssertNotNil(t, err)
+						h.AssertError(t, err, "reading metadata for current context 'desktop-linux'")
+					})
+				})
+			})
+		})
+
+		when("config.json is invalid", func() {
+			it.Before(func() {
+				setDockerConfig(t, errorCase, "invalid-config")
+			})
+
+			it("throw an error", func() {
+				err := docker.ProcessDockerContext(logger)
+				h.AssertNotNil(t, err)
+				h.AssertError(t, err, "reading configuration file")
+			})
+		})
+
+		when("config.json doesn't have current context", func() {
+			it.Before(func() {
+				setDockerConfig(t, happyCase, "current-context-not-defined")
+			})
+
+			it("docker context process is skip", func() {
+				err := docker.ProcessDockerContext(logger)
+				h.AssertNil(t, err)
+				h.AssertContains(t, strings.TrimSpace(outBuf.String()), "docker context is default or empty, skipping it")
+			})
+		})
+	})
+}
+
+func setDockerConfig(t *testing.T, test, context string) {
+	t.Helper()
+	contextDir, err := filepath.Abs(filepath.Join("testdata", test, context))
+	h.AssertNil(t, err)
+	err = os.Setenv("DOCKER_CONFIG", contextDir)
+	h.AssertNil(t, err)
+}

--- a/internal/docker/testdata/error-cases/current-context-does-not-match/config.json
+++ b/internal/docker/testdata/error-cases/current-context-does-not-match/config.json
@@ -1,0 +1,3 @@
+{
+  "currentContext": "desktop-linux"
+}

--- a/internal/docker/testdata/error-cases/current-context-does-not-match/contexts/meta/fe9c6bd7a66301f49ca9b6a70b217107cd1284598bfc254700c989b916da791e/meta.json
+++ b/internal/docker/testdata/error-cases/current-context-does-not-match/contexts/meta/fe9c6bd7a66301f49ca9b6a70b217107cd1284598bfc254700c989b916da791e/meta.json
@@ -1,0 +1,8 @@
+{
+  "Name": "bad-name",
+  "Endpoints": {
+    "docker": {
+      "Host": "unix:///Users/user/.docker/run/docker.sock"
+    }
+  }
+}

--- a/internal/docker/testdata/error-cases/docker-endpoint-does-not-exist/config.json
+++ b/internal/docker/testdata/error-cases/docker-endpoint-does-not-exist/config.json
@@ -1,0 +1,3 @@
+{
+  "currentContext": "desktop-linux"
+}

--- a/internal/docker/testdata/error-cases/docker-endpoint-does-not-exist/contexts/meta/fe9c6bd7a66301f49ca9b6a70b217107cd1284598bfc254700c989b916da791e/meta.json
+++ b/internal/docker/testdata/error-cases/docker-endpoint-does-not-exist/contexts/meta/fe9c6bd7a66301f49ca9b6a70b217107cd1284598bfc254700c989b916da791e/meta.json
@@ -1,0 +1,8 @@
+{
+  "Name": "desktop-linux",
+  "Endpoints": {
+    "foo": {
+      "Host": "unix:///Users/user/.docker/run/docker.sock"
+    }
+  }
+}

--- a/internal/docker/testdata/error-cases/empty-context/config.json
+++ b/internal/docker/testdata/error-cases/empty-context/config.json
@@ -1,0 +1,3 @@
+{
+  "currentContext": "some-bad-context"
+}

--- a/internal/docker/testdata/error-cases/invalid-config/config.json
+++ b/internal/docker/testdata/error-cases/invalid-config/config.json
@@ -1,0 +1,3 @@
+{
+  "currentContext": "some-bad-context
+}

--- a/internal/docker/testdata/error-cases/invalid-metadata/config.json
+++ b/internal/docker/testdata/error-cases/invalid-metadata/config.json
@@ -1,0 +1,3 @@
+{
+  "currentContext": "desktop-linux"
+}

--- a/internal/docker/testdata/error-cases/invalid-metadata/contexts/meta/fe9c6bd7a66301f49ca9b6a70b217107cd1284598bfc254700c989b916da791e/meta.json
+++ b/internal/docker/testdata/error-cases/invalid-metadata/contexts/meta/fe9c6bd7a66301f49ca9b6a70b217107cd1284598bfc254700c989b916da791e/meta.json
@@ -1,0 +1,8 @@
+{
+  "Name": "desktop-linux",
+  "Endpoints": {
+    "docker": {
+      "Host": "unix:///Users/user/.docker/run/docker.sock
+    }
+  }
+}

--- a/internal/docker/testdata/happy-cases/current-context-not-defined/config.json
+++ b/internal/docker/testdata/happy-cases/current-context-not-defined/config.json
@@ -1,0 +1,7 @@
+{
+  "auths": {
+    "https://index.docker.io/v1/": {}
+  },
+  "credsStore": "desktop",
+  "experimental": "disabled"
+}

--- a/internal/docker/testdata/happy-cases/custom-context/config.json
+++ b/internal/docker/testdata/happy-cases/custom-context/config.json
@@ -1,0 +1,3 @@
+{
+  "currentContext": "desktop-linux"
+}

--- a/internal/docker/testdata/happy-cases/custom-context/contexts/meta/fe9c6bd7a66301f49ca9b6a70b217107cd1284598bfc254700c989b916da791e/meta.json
+++ b/internal/docker/testdata/happy-cases/custom-context/contexts/meta/fe9c6bd7a66301f49ca9b6a70b217107cd1284598bfc254700c989b916da791e/meta.json
@@ -1,0 +1,8 @@
+{
+  "Name": "desktop-linux",
+  "Endpoints": {
+    "docker": {
+      "Host": "unix:///Users/user/.docker/run/docker.sock"
+    }
+  }
+}

--- a/internal/docker/testdata/happy-cases/default-context/config.json
+++ b/internal/docker/testdata/happy-cases/default-context/config.json
@@ -1,0 +1,3 @@
+{
+  "currentContext": "default"
+}

--- a/internal/docker/testdata/happy-cases/two-endpoints-context/config.json
+++ b/internal/docker/testdata/happy-cases/two-endpoints-context/config.json
@@ -1,0 +1,3 @@
+{
+  "currentContext": "desktop-linux"
+}

--- a/internal/docker/testdata/happy-cases/two-endpoints-context/contexts/meta/fe9c6bd7a66301f49ca9b6a70b217107cd1284598bfc254700c989b916da791e/meta.json
+++ b/internal/docker/testdata/happy-cases/two-endpoints-context/contexts/meta/fe9c6bd7a66301f49ca9b6a70b217107cd1284598bfc254700c989b916da791e/meta.json
@@ -1,0 +1,11 @@
+{
+  "Name": "desktop-linux",
+  "Endpoints": {
+    "docker": {
+      "Host": "unix:///Users/user/.docker/run/docker.sock"
+    },
+    "foo": {
+      "Host": "something else"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds support to Pack for reading the `docker HOST`, to be used during the application build, from the current docker context saved at the home user directory.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

When running `pack build` on Linux with Docker desktop installed, the following error was thrown:

``` bash
ERROR: failed to build: failed to fetch builder image 'gcr.io/buildpacks/builder:latest': 
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

Initially, this error could be workaround by:

- Creating a symlink like `sudo ln -s $HOME/.docker/desktop/docker.sock /var/run/docker.sock` 
- Setting the `DOCKER_HOST=unix://$HOME/.docker/desktop/docker.sock /var/run/docker.sock` environment variable

#### After

Currently my docker context configuration is:

```bash
> docker context list
NAME                TYPE                DESCRIPTION                               DOCKER ENDPOINT                                     KUBERNETES ENDPOINT   ORCHESTRATOR
default             moby                Current DOCKER_HOST based configuration   unix:///var/run/docker.sock
desktop-linux *     moby                Docker Desktop                            unix:///Users/jbustamante/.docker/run/docker.sock
```

I used to have the symlink but I removed it, now running `pack build`, pack will read from my local docker configuration file that `desktop-liinux` context is being used and then read the endpoint host from there and use it during the build, removing the previous error

```bash
looking for docker configuration file at: /Users/jbustamante/.docker
using docker context 'desktop-linux' with endpoint = 'unix:///Users/jbustamante/.docker/run/docker.sock'
Builder paketobuildpacks/builder:base is untrusted
As a result, the phases of the lifecycle which require root access will be run in separate trusted ephemeral containers.
For more information, see https://medium.com/buildpacks/faster-more-secure-builds-with-pack-0-11-0-4d0c633ca619
Pulling image index.docker.io/paketobuildpacks/builder:base
.... 

[exporter] Saving test-image:latest...
[exporter] *** Images (71f626605c5e):
[exporter]       test-image:latest
[exporter]
[exporter] *** Image ID: 71f626605c5e6b4e6883748395c589f1cec7ce8d4fe03c0703fedef67bab2a8b
[exporter] Reading buildpack directory: /layers/paketo-buildpacks_nginx
[exporter] Reading buildpack directory item: launch.toml
[exporter] Reading buildpack directory item: nginx.sbom.cdx.json
[exporter] Reading buildpack directory item: nginx.sbom.spdx.json
[exporter] Reading buildpack directory item: nginx.sbom.syft.json
[exporter] Reading buildpack directory item: nginx.toml
Successfully built image test-image:latest
```
## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1759 
Resolves #1830 
