### PR TITLE
Adding configuration to OCI Layout format when executing phases 1 by 1

### DIFF
--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -1409,6 +1409,17 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 					"-stack",
 				)
 			})
+
+			when("layout is true", func() {
+				providedLayout = true
+
+				it("configures the phase with the expected environment variables", func() {
+					layoutDir := filepath.Join(paths.RootDir, "layout-repo")
+					h.AssertSliceContains(t,
+						configProvider.ContainerConfig().Env, "CNB_USE_LAYOUT=true", fmt.Sprintf("CNB_LAYOUT_DIR=%s", layoutDir),
+					)
+				})
+			})
 		})
 
 		when("publish", func() {
@@ -1862,6 +1873,25 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 		})
+
+		when("layout is true", func() {
+			when("platform >= 0.12", func() {
+				platformAPI = api.MustParse("0.12")
+				providedLayout = true
+
+				it("it configures the phase with access to provided volumes", func() {
+					// this is required to read the /layout-repo
+					h.AssertSliceContains(t, configProvider.HostConfig().Binds, providedVolumes...)
+				})
+
+				it("configures the phase with the expected environment variables", func() {
+					layoutDir := filepath.Join(paths.RootDir, "layout-repo")
+					h.AssertSliceContains(t,
+						configProvider.ContainerConfig().Env, "CNB_USE_LAYOUT=true", fmt.Sprintf("CNB_LAYOUT_DIR=%s", layoutDir),
+					)
+				})
+			})
+		})
 	})
 
 	when("#Build", func() {
@@ -2051,6 +2081,22 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 
 						h.AssertSliceContains(t, configProvider.HostConfig().Binds, expectedBinds...)
 					})
+				})
+			})
+
+			when("layout is true", func() {
+				providedLayout = true
+
+				it("it configures the phase with access to provided volumes", func() {
+					// this is required to read the /layout-repo
+					h.AssertSliceContains(t, configProvider.HostConfig().Binds, providedVolumes...)
+				})
+
+				it("configures the phase with the expected environment variables", func() {
+					layoutDir := filepath.Join(paths.RootDir, "layout-repo")
+					h.AssertSliceContains(t,
+						configProvider.ContainerConfig().Env, "CNB_USE_LAYOUT=true", fmt.Sprintf("CNB_LAYOUT_DIR=%s", layoutDir),
+					)
 				})
 			})
 		})


### PR DESCRIPTION
## Summary

This PR adds the configuration for OCI Layout when an untrusted builder is used and pack call each phase one by one

## Output

exporting to OCI Layout format using an untrusted builder actually configure the lifecycle in `-layout` mode

#### Before

`Analyzer`, `Restorer` and `Exporter` were not configured by pack

#### After

Pack includes the correct environment variables `CNB_USE_LAYOUT=true` and `CNB_LAYOUT_DIR=/[layout repo]` to enable the feature when calling the lifecycle

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1881 