### PR TITLE
Missing test case when handling docker context - continuation of the solution to fix 1759

### DIFF
--- a/internal/docker/context.go
+++ b/internal/docker/context.go
@@ -108,6 +108,9 @@ func readConfigFile(configDir string) (*configFile, error) {
 	config := &configFile{}
 	file, err := os.Open(filename)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return &configFile{}, nil
+		}
 		return &configFile{}, err
 	}
 	defer file.Close()

--- a/internal/docker/context_test.go
+++ b/internal/docker/context_test.go
@@ -165,6 +165,30 @@ func testProcessDockerContext(t *testing.T, when spec.G, it spec.S) {
 				h.AssertContains(t, strings.TrimSpace(outBuf.String()), "docker context is default or empty, skipping it")
 			})
 		})
+
+		when("docker config folder doesn't exists", func() {
+			it.Before(func() {
+				setDockerConfig(t, errorCase, "no-docker-folder")
+			})
+
+			it("docker context process is skip", func() {
+				err := docker.ProcessDockerContext(logger)
+				h.AssertNil(t, err)
+				h.AssertContains(t, strings.TrimSpace(outBuf.String()), "docker context is default or empty, skipping it")
+			})
+		})
+
+		when("config.json config doesn't exists", func() {
+			it.Before(func() {
+				setDockerConfig(t, errorCase, "config-does-not-exist")
+			})
+
+			it("docker context process is skip", func() {
+				err := docker.ProcessDockerContext(logger)
+				h.AssertNil(t, err)
+				h.AssertContains(t, strings.TrimSpace(outBuf.String()), "docker context is default or empty, skipping it")
+			})
+		})
 	})
 }
 

--- a/internal/docker/testdata/error-cases/config-does-not-exist/README
+++ b/internal/docker/testdata/error-cases/config-does-not-exist/README
@@ -1,0 +1,1 @@
+This folder is intentionally empty to test the scenario when the docker config.json file doesn't exist


### PR DESCRIPTION
## Summary
Pack could be executed as a binary in a container that mounts the docker sock, when I did it (testing the development binary to check other ticket) I noticed I was not able to run `pack`. It throws the following error:

```bash
ERROR: reading configuration file at '/root/.docker': open /root/.docker/config.json: no such file or directory
```

In this container the `.docker` folder doesn't exists and I was not handling that error correctly. This PR fixes this problem and also handles the case where the `.docker` folder exists but the `config.json` file doesn't, In such cases, pack should keep running with its normal execution.

## Output

#### Before

```bash
ERROR: reading configuration file at '/root/.docker': open /root/.docker/config.json: no such file or directory
```
#### After

No error

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1759
