### PR TITLE
Fix target validation when buildpack fails to declare field

### DIFF
--- a/pkg/dist/buildpack_descriptor.go
+++ b/pkg/dist/buildpack_descriptor.go
@@ -66,7 +66,7 @@ func (b *BuildpackDescriptor) EnsureTargetSupport(os, arch, distroName, distroVe
 	}
 	for _, target := range b.Targets() {
 		if target.OS == os {
-			if target.Arch == "*" || arch == "" || target.Arch == arch {
+			if target.Arch == "" || arch == "" || target.Arch == arch {
 				if len(target.Distributions) == 0 || distroName == "" || distroVersion == "" {
 					return nil
 				}

--- a/pkg/dist/buildpack_descriptor_test.go
+++ b/pkg/dist/buildpack_descriptor_test.go
@@ -262,6 +262,20 @@ func testBuildpackDescriptor(t *testing.T, when spec.G, it spec.S) {
 			h.AssertError(t, bp.EnsureTargetSupport("some-other-os", "fake-arch", "fake-distro", "0.0"),
 				`unable to satisfy target os/arch constraints; build image: {"os":"some-other-os","arch":"fake-arch","distribution":{"name":"fake-distro","version":"0.0"}}, buildpack 'some.buildpack.id@some.buildpack.version': [{"os":"fake-os","arch":"fake-arch","distributions":[{"name":"fake-distro","versions":["0.1"]},{"name":"another-distro","versions":["0.22"]}]}]`)
 		})
+
+		it("succeeds with missing arch", func() {
+			bp := dist.BuildpackDescriptor{
+				WithInfo: dist.ModuleInfo{
+					ID:      "some.buildpack.id",
+					Version: "some.buildpack.version",
+				},
+				WithTargets: []dist.Target{{
+					OS: "fake-os",
+				}},
+			}
+
+			h.AssertNil(t, bp.EnsureTargetSupport("fake-os", "fake-arch", "fake-distro", "0.1"))
+		})
 	})
 
 	when("#Kind", func() {


### PR DESCRIPTION
Optional fields are treated as wildcards when not specified

