### PR TITLE
Group minor/patch version Go Dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,13 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      # Group all minor/patch go dependencies into a single PR.
+      go-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "go"
@@ -15,8 +20,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "dependencies"
       - "github_actions"


### PR DESCRIPTION
Go minor/patch dependencies will now be grouped, using the new Dependabot grouping feature:
https://github.blog/changelog/2023-08-17-grouped-version-updates-by-semantic-version-level-for-dependabot/

Major updates, as well as security updates will still be opened as separate PRs. I've not grouped GitHub Actions update PRs, since the volume is typically much lower for those.

In addition, the schedule has been changed from daily to weekly.

This reduces project maintenance toil (no more having to manually create combined update PRs), plus makes it less painful for contributors to subscribe to repository notifications (currently there is a lot of noise from Dependabot PRs being opened/auto-rebased etc).