### PR TITLE
Add buildpacksio/pack:<version>-base images to delivery

### DIFF
--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -16,12 +16,21 @@ on:
         default: false
 
 env:
-  BUILDER: "paketobuildpacks/builder-jammy-tiny"
   IMG_NAME: 'pack'
   USERNAME: 'buildpacksio'
 
 jobs:
   deliver-docker:
+    strategy:
+      matrix:
+        config: [tiny, base]
+        include:
+          - config: tiny
+            base_image: gcr.io/distroless/static
+            suffix:
+          - config: base
+            base_image: ubuntu:jammy
+            suffix: -base
     runs-on: ubuntu-latest
     steps:
       - name: Determine version
@@ -42,16 +51,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: v${{ steps.version.outputs.result }}
-      # This has to come after the first checkout, so it isn't clobbered
-      - name: Checkout delivery configuration
-        uses: actions/checkout@v4
-        with:
-          path: ./head
-      - name: Setup Working Dir
-        shell: bash
-        run: |
-          rm project.toml || true
-          cp head/.github/workflows/delivery/docker/project.toml project.toml
       - name: Determine App Name
         run: 'echo "IMG_NAME=${{ env.USERNAME }}/${{ env.IMG_NAME }}" >> $GITHUB_ENV'
       - name: Login to Dockerhub
@@ -65,12 +64,13 @@ jobs:
       - name: Buildx Build/Publish
         run: |
           docker buildx build . \
-            --tag ${{ env.IMG_NAME }}:${{ steps.version.outputs.result }} \
+            --tag ${{ env.IMG_NAME }}:${{ steps.version.outputs.result }}${{ matrix.suffix }} \
             --platform linux/amd64,linux/arm64 \
             --build-arg pack_version=${{ steps.version.outputs.result }} \
+            --build-arg base_image=${{ matrix.base_image }} \
             --provenance=false \
             --push
       - name: Tag Image as Latest
-        if: ${{ github.event.release != '' || github.event.inputs.tag_latest }}
+        if: ${{ (github.event.release != '' || github.event.inputs.tag_latest) && matrix.config != 'base' }}
         run: |
           crane copy ${{ env.IMG_NAME }}:${{ steps.version.outputs.result }} ${{ env.IMG_NAME }}:latest

--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -70,6 +70,10 @@ jobs:
             --build-arg base_image=${{ matrix.base_image }} \
             --provenance=false \
             --push
+      - name: Tag Image as Base
+        if: ${{ (github.event.release != '' || github.event.inputs.tag_latest) && matrix.config == 'base' }}
+        run: |
+          crane copy ${{ env.IMG_NAME }}:${{ steps.version.outputs.result }} ${{ env.IMG_NAME }}:base
       - name: Tag Image as Latest
         if: ${{ (github.event.release != '' || github.event.inputs.tag_latest) && matrix.config != 'base' }}
         run: |

--- a/.github/workflows/delivery/docker/project.toml
+++ b/.github/workflows/delivery/docker/project.toml
@@ -1,7 +1,0 @@
-[project]
-version = "1.0.2"
-source-url = "https://github.com/buildpacks/pack"
-
-[[build.env]]
-name = "BP_GO_TARGETS"
-value = "./cmd/pack"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG base_image=gcr.io/distroless/static
+
 FROM golang:1.20 as builder
 ARG pack_version
 ENV PACK_VERSION=$pack_version
@@ -5,8 +7,6 @@ WORKDIR /app
 COPY . .
 RUN make build
 
-FROM scratch
+FROM ${base_image}
 COPY --from=builder /app/out/pack /usr/local/bin/pack
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /tmp /tmp
 ENTRYPOINT [ "/usr/local/bin/pack" ]


### PR DESCRIPTION
## Summary
I still need to test this out end-to-end but I think this should resolve https://github.com/buildpacks/pack/issues/1554 by adding a pack image based on ubuntu:jammy to our delivery pipeline.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

We publish:
* buildpacksio/pack:0.X.Y (version such as 0.31.0)
* buildpacksio/pack:latest

#### After

We publish:
* buildpacksio/pack:0.X.Y (version such as 0.31.0) <- still a tiny image
* buildpacksio/pack:latest <- still a tiny image
* buildpacksio/pack:0.X.Y-base <- based on jammy

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1554 
