### PR TITLE
Retrying logic when pulling an image and platform doesn't match

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1554,6 +1554,7 @@ func testAcceptance(
 
 							when("buildpackage is in a registry", func() {
 								it("adds the buildpacks to the builder and runs them", func() {
+									h.SkipIf(t, !pack.SupportsFeature(invoke.PlatformRetries), "")
 									packageImageName = registryConfig.RepoName("buildpack-" + h.RandString(8))
 
 									packageTomlPath := generatePackageTomlWithOS(t, assert, pack, tmpDir, "package_for_build_cmd.toml", imageManager.HostOS())

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -235,6 +235,7 @@ const (
 	ForceRebase
 	BuildpackFlatten
 	MetaBuildpackFolder
+	PlatformRetries
 )
 
 var featureTests = map[Feature]func(i *PackInvoker) bool{
@@ -261,6 +262,9 @@ var featureTests = map[Feature]func(i *PackInvoker) bool{
 	},
 	MetaBuildpackFolder: func(i *PackInvoker) bool {
 		return i.atLeast("v0.30.0")
+	},
+	PlatformRetries: func(i *PackInvoker) bool {
+		return i.atLeast("v0.32.1")
 	},
 }
 

--- a/pkg/image/fetcher.go
+++ b/pkg/image/fetcher.go
@@ -82,6 +82,7 @@ func NewFetcher(logger logging.Logger, docker DockerClient, opts ...FetcherOptio
 }
 
 var ErrNotFound = errors.New("not found")
+var ErrPlatformNotMatch = errors.New("platform does not match")
 
 func (f *Fetcher) Fetch(ctx context.Context, name string, options FetchOptions) (imgutil.Image, error) {
 	name, err := pname.TranslateRegistry(name, f.registryMirrors, f.logger)
@@ -110,6 +111,10 @@ func (f *Fetcher) Fetch(ctx context.Context, name string, options FetchOptions) 
 
 	f.logger.Debugf("Pulling image %s", style.Symbol(name))
 	err = f.pullImage(ctx, name, options.Platform)
+	if errors.Is(err, ErrPlatformNotMatch) {
+		f.logger.Info(err.Error())
+		err = f.pullImage(ctx, name, "")
+	}
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, err
 	}
@@ -192,6 +197,11 @@ func (f *Fetcher) pullImage(ctx context.Context, imageID string, platform string
 
 	err = jsonmessage.DisplayJSONMessagesStream(rc, &colorizedWriter{writer}, termFd, isTerm, nil)
 	if err != nil {
+		// sample error from docker engine:
+		// image with reference <image> was found but does not match the specified platform: wanted linux/amd64, actual: linux
+		if strings.Contains(err.Error(), "does not match the specified platform") {
+			return errors.Wrap(ErrPlatformNotMatch, err.Error())
+		}
 		return err
 	}
 


### PR DESCRIPTION
## Summary

The Paketo team is trying to create `arm64` builders and Buildpacks, but they are doing iteratively, because of that, they are in a situation where they need some mixed support for `arm64` and `amd64` users. With the latest pack release 0.32.0 we tried to fix an issue where users running M1 laptops and trying to build a `amd64` application image ended up with an application image having `amd64` code on the top of a `arm64` run image. see this [PR](https://github.com/buildpacks/pack/pull/1933)

The problem was, we added a `platform` configuration (os/arch) when pulling Buildpacks and unfortunately this is not valid because most of the Buildpack ecosystem doesn't specify *architecture* for their buildpacks.

As a consequence, running `pack build` or `pack builder create` or any command that is pulling Builpacks throws an error, I added a retry logic to pull again, without platform (previous behavior), when an error is found with the message `does not match the specified platform` 

## Output

#### Before

```bash
ERROR: failed to add buildpacks to builder: downloading buildpack: extracting from registry docker://gcr.io/paketo-buildpacks/dotnet-core: fetching image: image with reference gcr.io/paketo-buildpacks/dotnet-core:latest was found but does not match the specified platform: wanted linux/amd64, actual: linux
```

#### After

`pack` will silently retry

```bash
latest: Pulling from paketo-buildpacks/dotnet-core
Digest: sha256:bf28b7631c222794f01e637c2de0d097f39079c0aa6c8fbdaefeef239d404219
Status: Image is up to date for gcr.io/paketo-buildpacks/dotnet-core:latest
latest: Pulling from paketo-buildpacks/dotnet-core
Digest: sha256:bf28b7631c222794f01e637c2de0d097f39079c0aa6c8fbdaefeef239d404219
```

![Screenshot 2023-11-14 at 10 52 52 AM](https://github.com/buildpacks/pack/assets/1181799/91a87c51-8890-45e9-93c4-9aa2c5fe8a84)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1968 
