### PR TITLE
When running `choco install pack --source <package>` we need to point to a folder instead of a nupkg package

### DIFF
--- a/.github/workflows/delivery-chocolatey.yml
+++ b/.github/workflows/delivery-chocolatey.yml
@@ -40,7 +40,7 @@ jobs:
             return updatedTag;
       - name: Setup working dir
         run: |
-          mkdir ${{ env.CHOCO_PATH }}
+          mkdir -p ${{ env.CHOCO_PATH }}/source
           cp -r .github/workflows/delivery/chocolatey/. ${{ env.CHOCO_PATH }}/
           ls -R ${{ env.CHOCO_PATH }}
       - name: Download and unzip Pack (Windows)
@@ -69,7 +69,7 @@ jobs:
       - name: build-release
         uses: crazy-max/ghaction-chocolatey@v3
         with:
-          args: pack ${{ env.CHOCO_PATH }}/pack.nuspec --outputdirectory ${{ env.CHOCO_PATH}}
+          args: pack ${{ env.CHOCO_PATH }}/pack.nuspec --outputdirectory ${{ env.CHOCO_PATH}}/source
       - name: list files
         run: |
           ls ${{ env.CHOCO_PATH }}
@@ -77,10 +77,10 @@ jobs:
       - name: Test Release
         uses: crazy-max/ghaction-chocolatey@v3
         with:
-          args: install pack -s ${{ env.CHOCO_PATH }}/pack.${{ env.PACK_VERSION }}.nupkg
+          args: install pack -s ${{ env.CHOCO_PATH }}/source
       - name: Ensure Pack Installed
         run: pack help
       - name: Upload Release
         uses: crazy-max/ghaction-chocolatey@v3
         with:
-          args: push ${{ env.CHOCO_PATH }}/pack.${{ env.PACK_VERSION }}.nupkg -s https://push.chocolatey.org/ -k ${{ secrets.CHOCO_KEY }}
+          args: push ${{ env.CHOCO_PATH }}/source/pack.${{ env.PACK_VERSION }}.nupkg -s https://push.chocolatey.org/ -k ${{ secrets.CHOCO_KEY }}


### PR DESCRIPTION
This should fix the issue:

The path 'D:\a\pack\pack\chocolatey\pack.0.32.1.nupkg' for the selected source could not be resolved.
 pack not installed. The package was not found with the source(s) listed.

## Summary
I am not an expert on `choco`, but I did some try and error approach. I [found](https://docs.chocolatey.org/en-us/features/host-packages#local-folder-or-share-structure) that when using `pack install pack --source <package>` is better to point to a folder rather than a *.nupkg. Doing that change in our pipeline fixes the issue to deploy pack `0.32.1`. 

## Output

This is the [log](https://github.com/buildpacks/pack/actions/runs/6906054533) when I ran manually the pipeline using my branch. I enabled `debug` but basically I move the *.nupkg to a `repo` folder

```bash
  Resolving resource ListResource for source D:\a\pack\pack\chocolatey\repo
  Resolving resource DependencyInfoResource for source D:\a\pack\pack\chocolatey\repo
  [NuGet] Resolving dependency information took 0 ms
  Resolving resource DownloadResource for source D:\a\pack\pack\chocolatey\repo
  Attempting to delete file "".
  [NuGet] Adding package 'pack.0.32.1' to folder 'C:\ProgramData\chocolatey\lib'
  [NuGet] Added package 'pack.0.32.1' to folder 'C:\ProgramData\chocolatey\lib'
  [NuGet] Added package 'pack.0.32.1' to folder 'C:\ProgramData\chocolatey\lib' from source 'D:\a\pack\pack\chocolatey\repo'
  
  pack v0.32.1
  pack package files install completed. Performing other installation steps.
  Capturing package files in 'C:\ProgramData\chocolatey\lib\pack'
   Found 'C:\ProgramData\chocolatey\lib\pack\pack.nupkg'
    with checksum '78BCC84B3E687AFB1996F614F174120E'
   Found 'C:\ProgramData\chocolatey\lib\pack\pack.nuspec'
    with checksum '4B57434C1024B455133E491278E1F874'
   Found 'C:\ProgramData\chocolatey\lib\pack\tools\LICENSE.txt'
    with checksum '9A62EB9DFB57055E1E956532E1A1B703'
   Found 'C:\ProgramData\chocolatey\lib\pack\tools\pack.exe'
    with checksum '1542F62987B1A2A06401FFE60215210E'
   Found 'C:\ProgramData\chocolatey\lib\pack\tools\VERIFICATION.txt'
    with checksum '56C31BE8575FD95BAE8CFA6E58B1FC01'
  Calling command ['"C:\ProgramData\chocolatey\tools\shimgen.exe" --path="..\\lib\pack\tools\pack.exe" --output="C:\ProgramData\chocolatey\bin\pack.exe"  --iconpath="C:\ProgramData\chocolatey\lib\pack\tools\pack.exe"']
   [ShimGen] [WARN ] Could not extract icon from associated program. Using default. Error:
   [ShimGen]   Selected Icon is invalid
   [ShimGen] Microsoft (R) Visual C# Compiler version 4.8.9037.0
   [ShimGen] for C# 5
   [ShimGen] Copyright (C) Microsoft Corporation. All rights reserved.
   [ShimGen] This compiler is provided as part of the Microsoft (R) .NET Framework, but only supports language versions up to C# 5, which is no longer the latest version. For compilers that support newer versions of the C# programming language, see http://go.microsoft.com/fwlink/?LinkID=533240
   [ShimGen] ShimGen has successfully created 'C:\ProgramData\chocolatey\bin\pack.exe'
  Command ['"C:\ProgramData\chocolatey\tools\shimgen.exe" --path="..\\lib\pack\tools\pack.exe" --output="C:\ProgramData\chocolatey\bin\pack.exe"  --iconpath="C:\ProgramData\chocolatey\lib\pack\tools\pack.exe"'] exited with '0'
   ShimGen has successfully created a shim for pack.exe
    Created: C:\ProgramData\chocolatey\bin\pack.exe
    Targeting: C:\ProgramData\chocolatey\lib\pack\tools\pack.exe
    IsGui:False
  
  Attempting to create directory "C:\ProgramData\chocolatey\.chocolatey\pack.0.32.1".
  There was no original file at 'C:\ProgramData\chocolatey\.chocolatey\pack.0.32.1\.files'
  Attempting to delete file "C:\ProgramData\chocolatey\.chocolatey\pack.0.32.1\.extra".
  Attempting to delete file "C:\ProgramData\chocolatey\.chocolatey\pack.0.32.1\.version".
  Attempting to delete file "C:\ProgramData\chocolatey\.chocolatey\pack.0.32.1\.sxs".
  Attempting to delete file "C:\ProgramData\chocolatey\.chocolatey\pack.0.32.1\.pin".
  Sending message 'HandlePackageResultCompletedMessage' out if there are subscribers...
  Attempting to delete file "C:\ProgramData\chocolatey\lib\pack\.chocolateyPending".
   The install of pack was successful.
    Software installed to 'C:\ProgramData\chocolatey\lib\pack'
  
  Chocolatey installed 1/1 packages. 
   See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
  Sending message 'PostRunMessage' out if there are subscribers...
  Exiting with 0

```
#### Before

Errors were shown

#### After

Pack was deployed to chocolatey repo

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1981
