### PR TITLE
Action labeler v5.0.0 was released yesterday (12/04) and it broke the definition rules

### DIFF
--- a/.github/workflows/privileged-pr-process.yml
+++ b/.github/workflows/privileged-pr-process.yml
@@ -8,7 +8,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@main
+      - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
   add-milestone:


### PR DESCRIPTION
Action labeler [v5.0.0](https://github.com/actions/labeler/releases/tag/v5.0.0) was released yesterday and our pipelines are failing with the following error:

![Screenshot 2023-12-05 at 10 22 58 AM](https://github.com/buildpacks/pack/assets/1181799/92625614-920d-44c5-a573-20b4257af4d7)

I think the problem is related to a change on how the rules are defined.

