### PR TITLE
Disabling the progress log when downloading files on windows

### DIFF
--- a/pkg/blob/downloader.go
+++ b/pkg/blob/downloader.go
@@ -57,6 +57,10 @@ func (d *downloader) Download(ctx context.Context, pathOrURI string) (Blob, erro
 			path, err = paths.URIToFilePath(pathOrURI)
 		case "http", "https":
 			path, err = d.handleHTTP(ctx, pathOrURI)
+			if err != nil {
+				// retry
+				path, err = d.handleHTTP(ctx, pathOrURI)
+			}
 		default:
 			err = fmt.Errorf("unsupported protocol %s in URI %s", style.Symbol(parsedURL.Scheme), style.Symbol(pathOrURI))
 		}

--- a/pkg/blob/downloader.go
+++ b/pkg/blob/downloader.go
@@ -58,7 +58,7 @@ func (d *downloader) Download(ctx context.Context, pathOrURI string) (Blob, erro
 		case "http", "https":
 			path, err = d.handleHTTP(ctx, pathOrURI)
 			if err != nil {
-				// retry
+				// retry as we sometimes see `wsarecv: An existing connection was forcibly closed by the remote host.` on Windows
 				path, err = d.handleHTTP(ctx, pathOrURI)
 			}
 		default:

--- a/pkg/blob/downloader_test.go
+++ b/pkg/blob/downloader_test.go
@@ -141,6 +141,10 @@ func testDownloader(t *testing.T, when spec.G, it spec.S) {
 						server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
 							w.WriteHeader(404)
 						})
+
+						server.AppendHandlers(func(w http.ResponseWriter, r *http.Request) {
+							w.WriteHeader(404)
+						})
 					})
 
 					it("should return error", func() {


### PR DESCRIPTION
## Summary
We added a retry to logic to workaround the error when downloading some files.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

Acceptance tests on windows (LCOW) were failing 

#### After

Acceptance test are passing

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2005 
