### PR TITLE
Fetch lifecycle binaries from lifecycle image 

### DIFF
--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -239,9 +239,16 @@ func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseF
 			}
 		}
 
+		var (
+			ephemeralRunImage string
+			err               error
+		)
 		currentRunImage := l.runImageAfterExtensions()
-		if currentRunImage != "" && currentRunImage != l.opts.RunImage {
-			if err := l.opts.FetchRunImage(currentRunImage); err != nil {
+		if l.runImageChanged() || l.hasExtensionsForRun() {
+			if currentRunImage == "" { // sanity check
+				return nil
+			}
+			if ephemeralRunImage, err = l.opts.FetchRunImageWithLifecycleLayer(currentRunImage); err != nil {
 				return err
 			}
 		}
@@ -269,7 +276,7 @@ func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseF
 		if l.platformAPI.AtLeast("0.12") && l.hasExtensionsForRun() {
 			group.Go(func() error {
 				l.logger.Info(style.Step("EXTENDING (RUN)"))
-				return l.ExtendRun(ctx, kanikoCache, phaseFactory)
+				return l.ExtendRun(ctx, kanikoCache, phaseFactory, ephemeralRunImage)
 			})
 		}
 
@@ -518,8 +525,6 @@ func (l *LifecycleExecution) Restore(ctx context.Context, buildCache Cache, kani
 			l.withLogLevel()...,
 		),
 		WithNetwork(l.opts.Network),
-		If(l.hasExtensionsForRun(), WithPostContainerRunOperations(
-			CopyOutToMaybe(l.mountPaths.cnbDir(), l.tmpDir))), // FIXME: this is hacky; we should get the lifecycle binaries from the lifecycle image
 		cacheBindOp,
 		dockerOp,
 		flagsOp,
@@ -712,7 +717,7 @@ func (l *LifecycleExecution) ExtendBuild(ctx context.Context, kanikoCache Cache,
 	return extend.Run(ctx)
 }
 
-func (l *LifecycleExecution) ExtendRun(ctx context.Context, kanikoCache Cache, phaseFactory PhaseFactory) error {
+func (l *LifecycleExecution) ExtendRun(ctx context.Context, kanikoCache Cache, phaseFactory PhaseFactory, runImageName string) error {
 	flags := []string{"-app", l.mountPaths.appDir(), "-kind", "run"}
 
 	configProvider := NewPhaseConfigProvider(
@@ -725,8 +730,7 @@ func (l *LifecycleExecution) ExtendRun(ctx context.Context, kanikoCache Cache, p
 		WithFlags(flags...),
 		WithNetwork(l.opts.Network),
 		WithRoot(),
-		WithImage(l.runImageAfterExtensions()),
-		WithBinds(fmt.Sprintf("%s:%s", filepath.Join(l.tmpDir, "cnb"), l.mountPaths.cnbDir())),
+		WithImage(runImageName),
 		WithBinds(fmt.Sprintf("%s:%s", kanikoCache.Name(), l.mountPaths.kanikoCacheDir())),
 	)
 

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -66,40 +66,40 @@ type Termui interface {
 }
 
 type LifecycleOptions struct {
-	AppPath              string
-	Image                name.Reference
-	Builder              Builder
-	BuilderImage         string // differs from Builder.Name() and Builder.Image().Name() in that it includes the registry context
-	LifecycleImage       string
-	LifecycleApis        []string // optional - populated only if custom lifecycle image is downloaded, from that lifecycle's container's Labels.
-	RunImage             string
-	FetchRunImage        func(name string) error
-	ProjectMetadata      files.ProjectMetadata
-	ClearCache           bool
-	Publish              bool
-	TrustBuilder         bool
-	UseCreator           bool
-	Interactive          bool
-	Layout               bool
-	Termui               Termui
-	DockerHost           string
-	Cache                cache.CacheOpts
-	CacheImage           string
-	HTTPProxy            string
-	HTTPSProxy           string
-	NoProxy              string
-	Network              string
-	AdditionalTags       []string
-	Volumes              []string
-	DefaultProcessType   string
-	FileFilter           func(string) bool
-	Workspace            string
-	GID                  int
-	PreviousImage        string
-	ReportDestinationDir string
-	SBOMDestinationDir   string
-	CreationTime         *time.Time
-	Keychain             authn.Keychain
+	AppPath                         string
+	Image                           name.Reference
+	Builder                         Builder
+	BuilderImage                    string // differs from Builder.Name() and Builder.Image().Name() in that it includes the registry context
+	LifecycleImage                  string
+	LifecycleApis                   []string // optional - populated only if custom lifecycle image is downloaded, from that lifecycle's container's Labels.
+	RunImage                        string
+	FetchRunImageWithLifecycleLayer func(name string) (string, error)
+	ProjectMetadata                 files.ProjectMetadata
+	ClearCache                      bool
+	Publish                         bool
+	TrustBuilder                    bool
+	UseCreator                      bool
+	Interactive                     bool
+	Layout                          bool
+	Termui                          Termui
+	DockerHost                      string
+	Cache                           cache.CacheOpts
+	CacheImage                      string
+	HTTPProxy                       string
+	HTTPSProxy                      string
+	NoProxy                         string
+	Network                         string
+	AdditionalTags                  []string
+	Volumes                         []string
+	DefaultProcessType              string
+	FileFilter                      func(string) bool
+	Workspace                       string
+	GID                             int
+	PreviousImage                   string
+	ReportDestinationDir            string
+	SBOMDestinationDir              string
+	CreationTime                    *time.Time
+	Keychain                        authn.Keychain
 }
 
 func NewLifecycleExecutor(logger logging.Logger, docker DockerClient) *LifecycleExecutor {

--- a/internal/build/mount_paths.go
+++ b/internal/build/mount_paths.go
@@ -30,10 +30,6 @@ func (m mountPaths) join(parts ...string) string {
 	return strings.Join(parts, m.separator)
 }
 
-func (m mountPaths) cnbDir() string {
-	return m.join(m.volume, "cnb")
-}
-
 func (m mountPaths) layersDir() string {
 	return m.join(m.volume, "layers")
 }

--- a/internal/build/phase_config_provider.go
+++ b/internal/build/phase_config_provider.go
@@ -66,7 +66,7 @@ func NewPhaseConfigProvider(name string, lifecycleExec *LifecycleExecution, ops 
 	provider.ctrConf.Entrypoint = []string{""} // override entrypoint in case it is set
 	provider.ctrConf.Cmd = append([]string{"/cnb/lifecycle/" + name}, provider.ctrConf.Cmd...)
 
-	lifecycleExec.logger.Debugf("Running the %s on OS %s with:", style.Symbol(provider.Name()), style.Symbol(provider.os))
+	lifecycleExec.logger.Debugf("Running the %s on OS %s from image %s with:", style.Symbol(provider.Name()), style.Symbol(provider.os), style.Symbol(provider.ctrConf.Image))
 	lifecycleExec.logger.Debug("Container Settings:")
 	lifecycleExec.logger.Debugf("  Args: %s", style.Symbol(strings.Join(provider.ctrConf.Cmd, " ")))
 	lifecycleExec.logger.Debugf("  System Envs: %s", style.Symbol(strings.Join(sanitized(provider.ctrConf.Env), " ")))


### PR DESCRIPTION
## Summary

Fetch lifecycle binaries from lifecycle image instead of restorer container

Hopefully fixes missing file issues on Linux (see https://github.com/buildpacks/pack/issues/1979)

#### Before

Before, we copied the lifecycle binaries out of the restorer container and mounted them back during the extend (run) phase. 

#### After

Now, we download the lifecycle image from the daemon, fetch the lifecycle layer, and create an ephemeral run image that has the lifecycle layer added. 

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1979 (I hope)
