### PR TITLE
Ensure read access when resolving run image location

### DIFF
--- a/internal/fakes/fake_access_checker.go
+++ b/internal/fakes/fake_access_checker.go
@@ -1,0 +1,19 @@
+package fakes
+
+type FakeAccessChecker struct {
+	RegistriesToFail []string
+}
+
+func NewFakeAccessChecker() *FakeAccessChecker {
+	return &FakeAccessChecker{}
+}
+
+func (f *FakeAccessChecker) Check(repo string) bool {
+	for _, toFail := range f.RegistriesToFail {
+		if toFail == repo {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -337,7 +337,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		return errors.Wrapf(err, "invalid builder %s", style.Symbol(opts.Builder))
 	}
 
-	runImageName := c.resolveRunImage(opts.RunImage, imgRegistry, builderRef.Context().RegistryStr(), bldr.DefaultRunImage(), opts.AdditionalMirrors, opts.Publish)
+	runImageName := c.resolveRunImage(opts.RunImage, imgRegistry, builderRef.Context().RegistryStr(), bldr.DefaultRunImage(), opts.AdditionalMirrors, opts.Publish, c.accessChecker)
 
 	fetchOptions := image.FetchOptions{
 		Daemon:     !opts.Publish,

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -56,6 +56,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 		subject                      *Client
 		fakeImageFetcher             *ifakes.FakeImageFetcher
 		fakeLifecycle                *ifakes.FakeLifecycle
+		fakeAccessChecker            *ifakes.FakeAccessChecker
 		defaultBuilderStackID        = "some.stack.id"
 		defaultWindowsBuilderStackID = "some.windows.stack.id"
 		defaultBuilderImage          *fakes.Image
@@ -80,6 +81,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 		var err error
 
 		fakeImageFetcher = ifakes.NewFakeImageFetcher()
+		fakeAccessChecker = ifakes.NewFakeAccessChecker()
 		fakeLifecycle = &ifakes.FakeLifecycle{}
 
 		tmpDir, err = os.MkdirTemp("", "build-test")
@@ -136,6 +138,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 			logger:              logger,
 			imageFetcher:        fakeImageFetcher,
 			downloader:          blobDownloader,
+			accessChecker:       fakeAccessChecker,
 			lifecycleExecutor:   fakeLifecycle,
 			docker:              docker,
 			buildpackDownloader: buildpackDownloader,

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
+	"github.com/buildpacks/pack/pkg/image"
 	"github.com/buildpacks/pack/pkg/logging"
 	"github.com/buildpacks/pack/pkg/testmocks"
 	h "github.com/buildpacks/pack/testhelpers"
@@ -120,6 +121,15 @@ func testClient(t *testing.T, when spec.G, it spec.S) {
 			cl, err := NewClient(WithRegistryMirrors(registryMirrors))
 			h.AssertNil(t, err)
 			h.AssertEq(t, cl.registryMirrors, registryMirrors)
+		})
+	})
+
+	when("#WithAccessChecker", func() {
+		it("uses AccessChecker provided", func() {
+			ac := &image.Checker{}
+			cl, err := NewClient(WithAccessChecker(ac))
+			h.AssertNil(t, err)
+			h.AssertSameInstance(t, cl.accessChecker, ac)
 		})
 	})
 }

--- a/pkg/client/common_test.go
+++ b/pkg/client/common_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/pack/internal/builder"
+	ifakes "github.com/buildpacks/pack/internal/fakes"
 	"github.com/buildpacks/pack/pkg/logging"
 	h "github.com/buildpacks/pack/testhelpers"
 )
@@ -31,6 +32,7 @@ func testCommon(t *testing.T, when spec.G, it spec.S) {
 			gcrRegistry     string
 			gcrRunMirror    string
 			stackInfo       builder.StackMetadata
+			accessChecker   *ifakes.FakeAccessChecker
 			assert          = h.NewAssertionManager(t)
 		)
 
@@ -54,19 +56,20 @@ func testCommon(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			}
+			accessChecker = ifakes.NewFakeAccessChecker()
 		})
 
 		when("passed specific run image", func() {
 			it("selects that run image", func() {
 				runImgFlag := "flag/passed-run-image"
-				runImageName := subject.resolveRunImage(runImgFlag, defaultRegistry, "", stackInfo.RunImage, nil, false)
+				runImageName := subject.resolveRunImage(runImgFlag, defaultRegistry, "", stackInfo.RunImage, nil, false, accessChecker)
 				assert.Equal(runImageName, runImgFlag)
 			})
 		})
 
 		when("publish is true", func() {
 			it("defaults to run-image in registry publishing to", func() {
-				runImageName := subject.resolveRunImage("", gcrRegistry, defaultRegistry, stackInfo.RunImage, nil, true)
+				runImageName := subject.resolveRunImage("", gcrRegistry, defaultRegistry, stackInfo.RunImage, nil, true, accessChecker)
 				assert.Equal(runImageName, gcrRunMirror)
 			})
 
@@ -74,7 +77,7 @@ func testCommon(t *testing.T, when spec.G, it spec.S) {
 				configMirrors := map[string][]string{
 					runImageName: {defaultRegistry + "/unique-run-img"},
 				}
-				runImageName := subject.resolveRunImage("", defaultRegistry, "", stackInfo.RunImage, configMirrors, true)
+				runImageName := subject.resolveRunImage("", defaultRegistry, "", stackInfo.RunImage, configMirrors, true, accessChecker)
 				assert.NotEqual(runImageName, defaultMirror)
 				assert.Equal(runImageName, defaultRegistry+"/unique-run-img")
 			})
@@ -83,7 +86,7 @@ func testCommon(t *testing.T, when spec.G, it spec.S) {
 				configMirrors := map[string][]string{
 					runImageName: {defaultRegistry + "/unique-run-img"},
 				}
-				runImageName := subject.resolveRunImage("", "test.registry.io", "", stackInfo.RunImage, configMirrors, true)
+				runImageName := subject.resolveRunImage("", "test.registry.io", "", stackInfo.RunImage, configMirrors, true, accessChecker)
 				assert.NotEqual(runImageName, defaultMirror)
 				assert.Equal(runImageName, defaultRegistry+"/unique-run-img")
 			})
@@ -92,7 +95,7 @@ func testCommon(t *testing.T, when spec.G, it spec.S) {
 		// If publish is false, we are using the local daemon, and want to match to the builder registry
 		when("publish is false", func() {
 			it("defaults to run-image in registry publishing to", func() {
-				runImageName := subject.resolveRunImage("", gcrRegistry, defaultRegistry, stackInfo.RunImage, nil, false)
+				runImageName := subject.resolveRunImage("", gcrRegistry, defaultRegistry, stackInfo.RunImage, nil, false, accessChecker)
 				assert.Equal(runImageName, defaultMirror)
 				assert.NotEqual(runImageName, gcrRunMirror)
 			})
@@ -101,7 +104,7 @@ func testCommon(t *testing.T, when spec.G, it spec.S) {
 				configMirrors := map[string][]string{
 					runImageName: {defaultRegistry + "/unique-run-img"},
 				}
-				runImageName := subject.resolveRunImage("", gcrRegistry, defaultRegistry, stackInfo.RunImage, configMirrors, false)
+				runImageName := subject.resolveRunImage("", gcrRegistry, defaultRegistry, stackInfo.RunImage, configMirrors, false, accessChecker)
 				assert.NotEqual(runImageName, defaultMirror)
 				assert.Equal(runImageName, defaultRegistry+"/unique-run-img")
 			})
@@ -110,9 +113,27 @@ func testCommon(t *testing.T, when spec.G, it spec.S) {
 				configMirrors := map[string][]string{
 					runImageName: {defaultRegistry + "/unique-run-img"},
 				}
-				runImageName := subject.resolveRunImage("", defaultRegistry, "test.registry.io", stackInfo.RunImage, configMirrors, false)
+				runImageName := subject.resolveRunImage("", defaultRegistry, "test.registry.io", stackInfo.RunImage, configMirrors, false, accessChecker)
 				assert.NotEqual(runImageName, defaultMirror)
 				assert.Equal(runImageName, defaultRegistry+"/unique-run-img")
+			})
+		})
+
+		when("desirable run-image is not accessible", func() {
+			it.Before(func() {
+				accessChecker.RegistriesToFail = []string{
+					gcrRunMirror,
+					stackInfo.RunImage.Image,
+				}
+			})
+
+			it.After(func() {
+				accessChecker.RegistriesToFail = nil
+			})
+
+			it("selects the first accessible run-image", func() {
+				runImageName := subject.resolveRunImage("", gcrRegistry, defaultRegistry, stackInfo.RunImage, nil, true, accessChecker)
+				assert.Equal(runImageName, defaultMirror)
 			})
 		})
 	})

--- a/pkg/client/rebase.go
+++ b/pkg/client/rebase.go
@@ -95,7 +95,9 @@ func (c *Client) Rebase(ctx context.Context, opts RebaseOptions) error {
 		"",
 		runImageMD,
 		opts.AdditionalMirrors,
-		opts.Publish)
+		opts.Publish,
+		c.accessChecker,
+	)
 
 	if runImageName == "" {
 		return errors.New("run image must be specified")

--- a/pkg/client/rebase_test.go
+++ b/pkg/client/rebase_test.go
@@ -28,6 +28,7 @@ func testRebase(t *testing.T, when spec.G, it spec.S) {
 	when("#Rebase", func() {
 		var (
 			fakeImageFetcher   *ifakes.FakeImageFetcher
+			fakeAccessChecker  *ifakes.FakeAccessChecker
 			subject            *Client
 			fakeAppImage       *fakes.Image
 			fakeRunImage       *fakes.Image
@@ -37,6 +38,7 @@ func testRebase(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			fakeImageFetcher = ifakes.NewFakeImageFetcher()
+			fakeAccessChecker = ifakes.NewFakeAccessChecker()
 
 			fakeAppImage = fakes.NewImage("some/app", "", &fakeIdentifier{name: "app-image"})
 			h.AssertNil(t, fakeAppImage.SetLabel("io.buildpacks.lifecycle.metadata",
@@ -54,8 +56,9 @@ func testRebase(t *testing.T, when spec.G, it spec.S) {
 
 			fakeLogger := logging.NewLogWithWriters(&out, &out)
 			subject = &Client{
-				logger:       fakeLogger,
-				imageFetcher: fakeImageFetcher,
+				logger:        fakeLogger,
+				imageFetcher:  fakeImageFetcher,
+				accessChecker: fakeAccessChecker,
 			}
 		})
 

--- a/pkg/image/access_checker.go
+++ b/pkg/image/access_checker.go
@@ -1,0 +1,41 @@
+package image
+
+import (
+	"github.com/buildpacks/imgutil/remote"
+	"github.com/google/go-containerregistry/pkg/authn"
+
+	"github.com/buildpacks/pack/pkg/logging"
+)
+
+type Checker struct {
+	logger   logging.Logger
+	keychain authn.Keychain
+}
+
+func NewAccessChecker(logger logging.Logger, keychain authn.Keychain) *Checker {
+	checker := &Checker{
+		logger:   logger,
+		keychain: keychain,
+	}
+
+	if checker.keychain == nil {
+		checker.keychain = authn.DefaultKeychain
+	}
+
+	return checker
+}
+
+func (c *Checker) Check(repo string) bool {
+	img, err := remote.NewImage(repo, c.keychain)
+	if err != nil {
+		return false
+	}
+
+	if ok, err := img.CheckReadAccess(); ok {
+		c.logger.Debugf("CheckReadAccess succeeded for the run image %s", repo)
+		return true
+	} else {
+		c.logger.Debugf("CheckReadAccess failed for the run image %s, error: %s", repo, err.Error())
+		return false
+	}
+}

--- a/pkg/image/access_checker_test.go
+++ b/pkg/image/access_checker_test.go
@@ -1,0 +1,34 @@
+package image_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/buildpacks/lifecycle/auth"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpacks/pack/pkg/image"
+	"github.com/buildpacks/pack/pkg/logging"
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestChecker(t *testing.T) {
+	spec.Run(t, "Checker", testChecker, spec.Report(report.Terminal{}))
+}
+
+func testChecker(t *testing.T, when spec.G, it spec.S) {
+	when("#Check", func() {
+		it("fails when checking dummy image", func() {
+			buf := &bytes.Buffer{}
+
+			keychain, err := auth.DefaultKeychain("pack.test/dummy")
+			h.AssertNil(t, err)
+
+			ic := image.NewAccessChecker(logging.NewSimpleLogger(buf), keychain)
+
+			h.AssertFalse(t, ic.Check("pack.test/dummy"))
+			h.AssertContains(t, buf.String(), "DEBUG:  CheckReadAccess failed for the run image pack.test/dummy")
+		})
+	})
+}


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->

`pack` performs it's own run-image resolution logic, and must be compliant with the platform spec, in particular with the https://github.com/buildpacks/spec/pull/357
## Output
<!-- If applicable, please provide examples of the output changes. -->

```console
$ docker logout unauthorized.registry.io
Removing login credentials for unauthorized.registry.io
$ pack build --verbose --publish private-registry.corp/my-image:latest
...
CheckReadAccess failed for the run-image unauthorized.registry.io/run:latest, error: GET ***: : Authentication is required
CheckReadAccess succeeded for the run-image authorized.registry.io/run:latest
Selected run image mirror authorized.registry.io/run:latest
...
```

#### Before

`pack` is not compliant with https://github.com/buildpacks/spec/pull/357/files and avoids the run-image resolution baked into the `lifecycle` (https://github.com/buildpacks/lifecycle/pull/1024)

#### After

`pack` will ensure read access during the run-image resolution

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes
    - [X] No

## Open Questions

Currently the `lifecycle` already has read-access and preferable registry resolution for the run-image. What would be the correct place for this? Should it be kept in both places or be left only in a single one?
