### PR TITLE
add support to override UID for container

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	golang.org/x/mod v0.14.0
 	golang.org/x/oauth2 v0.15.0
 	golang.org/x/sync v0.5.0
+	golang.org/x/sys v0.15.0
 	golang.org/x/term v0.15.0
 	golang.org/x/text v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -113,7 +114,6 @@ require (
 	github.com/vbatts/tar-split v0.11.3 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/net v0.19.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/tools v0.13.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -26,6 +26,7 @@ import (
 const (
 	defaultProcessType = "web"
 	overrideGID        = 0
+	overrideUID        = 0
 	sourceDateEpochEnv = "SOURCE_DATE_EPOCH"
 )
 
@@ -323,6 +324,10 @@ func (l *LifecycleExecution) Create(ctx context.Context, buildCache, launchCache
 		flags = append(flags, "-gid", strconv.Itoa(l.opts.GID))
 	}
 
+	if l.opts.UID >= overrideUID {
+		flags = append(flags, "-uid", strconv.Itoa(l.opts.UID))
+	}
+
 	if l.opts.PreviousImage != "" {
 		if l.opts.Image == nil {
 			return errors.New("image can't be nil")
@@ -472,6 +477,10 @@ func (l *LifecycleExecution) Restore(ctx context.Context, buildCache Cache, kani
 		flags = append(flags, "-gid", strconv.Itoa(l.opts.GID))
 	}
 
+	if l.opts.UID >= overrideUID {
+		flags = append(flags, "-uid", strconv.Itoa(l.opts.UID))
+	}
+
 	// for kaniko
 	kanikoCacheBindOp := NullOp()
 	if (l.platformAPI.AtLeast("0.10") && l.hasExtensionsForBuild()) ||
@@ -571,6 +580,10 @@ func (l *LifecycleExecution) Analyze(ctx context.Context, buildCache, launchCach
 
 	if l.opts.GID >= overrideGID {
 		flags = append(flags, "-gid", strconv.Itoa(l.opts.GID))
+	}
+
+	if l.opts.UID >= overrideUID {
+		flags = append(flags, "-uid", strconv.Itoa(l.opts.UID))
 	}
 
 	if l.opts.PreviousImage != "" {
@@ -776,6 +789,10 @@ func (l *LifecycleExecution) Export(ctx context.Context, buildCache, launchCache
 	}
 	if l.opts.GID >= overrideGID {
 		flags = append(flags, "-gid", strconv.Itoa(l.opts.GID))
+	}
+
+	if l.opts.UID >= overrideUID {
+		flags = append(flags, "-uid", strconv.Itoa(l.opts.UID))
 	}
 
 	cacheBindOp := NullOp()

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -1076,6 +1076,31 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("override UID", func() {
+			when("override UID is provided", func() {
+				lifecycleOps = append(lifecycleOps, func(options *build.LifecycleOptions) {
+					options.UID = 1001
+				})
+
+				it("configures the phase with the expected arguments", func() {
+					h.AssertIncludeAllExpectedPatterns(t,
+						configProvider.ContainerConfig().Cmd,
+						[]string{"-uid", "1001"},
+					)
+				})
+			})
+
+			when("override UID is not provided", func() {
+				lifecycleOps = append(lifecycleOps, func(options *build.LifecycleOptions) {
+					options.UID = -1
+				})
+
+				it("uid is not added to the expected arguments", func() {
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-uid")
+				})
+			})
+		})
+
 		when("-previous-image is used and builder is trusted", func() {
 			when("image is invalid", func() {
 				it("errors", func() {
@@ -1590,6 +1615,31 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 						})
 					})
 				})
+
+				when("override UID", func() {
+					when("override UID is provided", func() {
+						lifecycleOps = append(lifecycleOps, func(options *build.LifecycleOptions) {
+							options.UID = 1001
+						})
+
+						it("configures the phase with the expected arguments", func() {
+							h.AssertIncludeAllExpectedPatterns(t,
+								configProvider.ContainerConfig().Cmd,
+								[]string{"-uid", "1001"},
+							)
+						})
+					})
+
+					when("override UID is not provided", func() {
+						lifecycleOps = append(lifecycleOps, func(options *build.LifecycleOptions) {
+							options.UID = -1
+						})
+
+						it("uid is not added to the expected arguments", func() {
+							h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-uid")
+						})
+					})
+				})
 			})
 		})
 
@@ -1795,6 +1845,31 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 
 				it("gid is not added to the expected arguments", func() {
 					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-gid")
+				})
+			})
+		})
+
+		when("override UID", func() {
+			when("override UID is provided", func() {
+				lifecycleOps = append(lifecycleOps, func(options *build.LifecycleOptions) {
+					options.UID = 1001
+				})
+
+				it("configures the phase with the expected arguments", func() {
+					h.AssertIncludeAllExpectedPatterns(t,
+						configProvider.ContainerConfig().Cmd,
+						[]string{"-uid", "1001"},
+					)
+				})
+			})
+
+			when("override UID is not provided", func() {
+				lifecycleOps = append(lifecycleOps, func(options *build.LifecycleOptions) {
+					options.UID = -1
+				})
+
+				it("uid is not added to the expected arguments", func() {
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-uid")
 				})
 			})
 		})
@@ -2366,6 +2441,31 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 
 				it("gid is not added to the expected arguments", func() {
 					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-gid")
+				})
+			})
+		})
+
+		when("override UID", func() {
+			when("override UID is provided", func() {
+				lifecycleOps = append(lifecycleOps, func(options *build.LifecycleOptions) {
+					options.UID = 1001
+				})
+
+				it("configures the phase with the expected arguments", func() {
+					h.AssertIncludeAllExpectedPatterns(t,
+						configProvider.ContainerConfig().Cmd,
+						[]string{"-uid", "1001"},
+					)
+				})
+			})
+
+			when("override UID is not provided", func() {
+				lifecycleOps = append(lifecycleOps, func(options *build.LifecycleOptions) {
+					options.UID = -1
+				})
+
+				it("uid is not added to the expected arguments", func() {
+					h.AssertSliceNotContains(t, configProvider.ContainerConfig().Cmd, "-uid")
 				})
 			})
 		})

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -96,6 +96,7 @@ type LifecycleOptions struct {
 	FileFilter                      func(string) bool
 	Workspace                       string
 	GID                             int
+	UID                             int
 	PreviousImage                   string
 	ReportDestinationDir            string
 	SBOMDestinationDir              string

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -48,6 +48,7 @@ type BuildFlags struct {
 	AdditionalTags       []string
 	Workspace            string
 	GID                  int
+	UID                  int
 	PreviousImage        string
 	SBOMDestinationDir   string
 	ReportDestinationDir string
@@ -143,6 +144,12 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 			if cmd.Flags().Changed("gid") {
 				gid = flags.GID
 			}
+
+			var uid = -1
+			if cmd.Flags().Changed("uid") {
+				uid = flags.UID
+			}
+
 			dateTime, err := parseTime(flags.DateTime)
 			if err != nil {
 				return errors.Wrapf(err, "parsing creation time %s", flags.DateTime)
@@ -177,6 +184,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				Workspace:                flags.Workspace,
 				LifecycleImage:           lifecycleImage,
 				GroupID:                  gid,
+				UserID:                   uid,
 				PreviousImage:            inputPreviousImage.Name(),
 				Interactive:              flags.Interactive,
 				SBOMDestinationDir:       flags.SBOMDestinationDir,
@@ -257,6 +265,7 @@ This option may set DOCKER_HOST environment variable for the build container if 
 	cmd.Flags().StringArrayVar(&buildFlags.Volumes, "volume", nil, "Mount host volume into the build container, in the form '<host path>:<target path>[:<options>]'.\n- 'host path': Name of the volume or absolute directory path to mount.\n- 'target path': The path where the file or directory is available in the container.\n- 'options' (default \"ro\"): An optional comma separated list of mount options.\n    - \"ro\", volume contents are read-only.\n    - \"rw\", volume contents are readable and writeable.\n    - \"volume-opt=<key>=<value>\", can be specified more than once, takes a key-value pair consisting of the option name and its value."+stringArrayHelp("volume"))
 	cmd.Flags().StringVar(&buildFlags.Workspace, "workspace", "", "Location at which to mount the app dir in the build image")
 	cmd.Flags().IntVar(&buildFlags.GID, "gid", 0, `Override GID of user's group in the stack's build and run images. The provided value must be a positive number`)
+	cmd.Flags().IntVar(&buildFlags.UID, "uid", 0, `Override UID of user in the stack's build and run images. The provided value must be a positive number`)
 	cmd.Flags().StringVar(&buildFlags.PreviousImage, "previous-image", "", "Set previous image to a particular tag reference, digest reference, or (when performing a daemon build) image ID")
 	cmd.Flags().StringVar(&buildFlags.SBOMDestinationDir, "sbom-output-dir", "", "Path to export SBoM contents.\nOmitting the flag will yield no SBoM content.")
 	cmd.Flags().StringVar(&buildFlags.ReportDestinationDir, "report-output-dir", "", "Path to export build report.toml.\nOmitting the flag yield no report file.")
@@ -291,6 +300,10 @@ func validateBuildFlags(flags *BuildFlags, cfg config.Config, inputImageRef clie
 
 	if flags.GID < 0 {
 		return errors.New("gid flag must be in the range of 0-2147483647")
+	}
+
+	if flags.UID < 0 {
+		return errors.New("uid flag must be in the range of 0-2147483647")
 	}
 
 	if flags.Interactive && !cfg.Experimental {

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -186,6 +186,9 @@ type BuildOptions struct {
 	// User's group id used to build the image
 	GroupID int
 
+	// User's user id used to build the image
+	UserID int
+
 	// A previous image to set to a particular tag reference, digest reference, or (when performing a daemon build) image ID;
 	PreviousImage string
 
@@ -539,6 +542,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		FileFilter:               fileFilter,
 		Workspace:                opts.Workspace,
 		GID:                      opts.GroupID,
+		UID:                      opts.UserID,
 		PreviousImage:            opts.PreviousImage,
 		Interactive:              opts.Interactive,
 		Termui:                   termui.NewTermui(imageName, ephemeralBuilder, runImageName),


### PR DESCRIPTION
Here in the pr I simply add a flag --uid to override uid for container and keep the implementation same as gid, as a new contributor to buildpack project I might be missing some points .. A swift review or guidance would greatly assist me in diving into this project.

Resolves #1347
