### PR TITLE
Feature: Retrieve SBoM from Registry for Remote Images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	golang.org/x/mod v0.14.0
 	golang.org/x/oauth2 v0.15.0
 	golang.org/x/sync v0.5.0
+	golang.org/x/sys v0.15.0
 	golang.org/x/term v0.15.0
 	golang.org/x/text v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -113,7 +114,6 @@ require (
 	github.com/vbatts/tar-split v0.11.3 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/net v0.19.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/tools v0.13.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/pkg/client/download_sbom.go
+++ b/pkg/client/download_sbom.go
@@ -40,7 +40,7 @@ func (c *Client) DownloadSBOM(name string, options DownloadSBOMOptions) error {
 	img, err := c.imageFetcher.Fetch(context.Background(), name, image.FetchOptions{Daemon: options.Daemon, PullPolicy: image.PullNever})
 	if err != nil {
 		if errors.Cause(err) == image.ErrNotFound {
-			c.logger.Warnf("if image is saved on a registry run 'docker pull %s' before downloading the SBoM", name)
+			c.logger.Warnf("if the image is saved on a registry run with the flag '--remote', for example: 'pack sbom download --remote %s'", name)
 			return errors.Wrapf(image.ErrNotFound, "image '%s' cannot be found", name)
 		}
 		return err

--- a/pkg/client/download_sbom_test.go
+++ b/pkg/client/download_sbom_test.go
@@ -113,8 +113,11 @@ func testDownloadSBOM(t *testing.T, when spec.G, it spec.S) {
 			mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/non-existent-image", image.FetchOptions{Daemon: true, PullPolicy: image.PullNever}).Return(nil, image.ErrNotFound)
 
 			err := subject.DownloadSBOM("some/non-existent-image", DownloadSBOMOptions{Daemon: true, DestinationDir: ""})
-			h.AssertError(t, err, "image 'some/non-existent-image' cannot be found")
-			h.AssertContains(t, out.String(), "if image is saved on a registry run 'docker pull some/non-existent-image' before downloading the SBoM\n")
+			expectedError := fmt.Sprintf("image '%s' cannot be found", "some/non-existent-image")
+			h.AssertError(t, err, expectedError)
+
+			expectedMessage := fmt.Sprintf("Warning: if the image is saved on a registry run with the flag '--remote', for example: 'pack sbom download --remote %s'", "some/non-existent-image")
+			h.AssertContains(t, out.String(), expectedMessage)
 		})
 	})
 


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
when attempting to download a (SBoM) from a remote image that is not present in the Docker daemon, the pack tool throws an error, forcing the user to download the image to the daemon before extracting SBoM information. 

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [X] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1615 
