### PR TITLE
Adding `--label` flag to `pack builder create` command

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -103,6 +103,7 @@ type BuilderOption func(*options) error
 
 type options struct {
 	toFlatten buildpack.FlattenModuleInfos
+	labels    map[string]string
 }
 
 // FromImage constructs a builder from a builder image
@@ -139,6 +140,13 @@ func constructBuilder(img imgutil.Image, newName string, errOnMissingLabel bool,
 		return nil, err
 	}
 
+	for labelKey, labelValue := range opts.labels {
+		err = img.SetLabel(labelKey, labelValue)
+		if err != nil {
+			return nil, errors.Wrapf(err, "adding label %s=%s", labelKey, labelValue)
+		}
+	}
+
 	bldr := &Builder{
 		baseImageName:        img.Name(),
 		image:                img,
@@ -166,6 +174,13 @@ func constructBuilder(img imgutil.Image, newName string, errOnMissingLabel bool,
 func WithFlattened(modules buildpack.FlattenModuleInfos) BuilderOption {
 	return func(o *options) error {
 		o.toFlatten = modules
+		return nil
+	}
+}
+
+func WithLabels(labels map[string]string) BuilderOption {
+	return func(o *options) error {
+		o.labels = labels
 		return nil
 	}
 }

--- a/internal/commands/builder_create.go
+++ b/internal/commands/builder_create.go
@@ -23,6 +23,7 @@ type BuilderCreateFlags struct {
 	Registry        string
 	Policy          string
 	Flatten         []string
+	Label           map[string]string
 }
 
 // CreateBuilder creates a builder image, based on a builder config
@@ -96,6 +97,7 @@ Creating a custom builder allows you to control what buildpacks are used and wha
 				Registry:        flags.Registry,
 				PullPolicy:      pullPolicy,
 				Flatten:         toFlatten,
+				Labels:          flags.Label,
 			}); err != nil {
 				return err
 			}
@@ -113,6 +115,7 @@ Creating a custom builder allows you to control what buildpacks are used and wha
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, "Publish the builder directly to the container registry specified in <image-name>, instead of the daemon.")
 	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
 	cmd.Flags().StringSliceVar(&flags.Flatten, "flatten", nil, "List of buildpacks to flatten together into a single layer (format: '<buildpack-id>@<buildpack-version>,<buildpack-id>@<buildpack-version>'")
+	cmd.Flags().StringToStringVarP(&flags.Label, "label", "l", nil, "Labels to add to the builder image, in the form of '<name>=<value>'")
 
 	AddHelpFlag(cmd, "create")
 	return cmd

--- a/internal/commands/builder_create_test.go
+++ b/internal/commands/builder_create_test.go
@@ -424,5 +424,22 @@ func testCreateCommand(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 		})
+
+		when("--label", func() {
+			when("can not be parsed", func() {
+				it("errors with a descriptive message", func() {
+					cmd := packageCommand()
+					cmd.SetArgs([]string{
+						"some/builder",
+						"--config", builderConfigPath,
+						"--label", "name+value",
+					})
+
+					err := cmd.Execute()
+					h.AssertNotNil(t, err)
+					h.AssertError(t, err, "invalid argument \"name+value\" for \"-l, --label\" flag: name+value must be formatted as key=value")
+				})
+			})
+		})
 	})
 }

--- a/pkg/client/create_builder.go
+++ b/pkg/client/create_builder.go
@@ -32,6 +32,9 @@ type CreateBuilderOptions struct {
 	// BuildConfigEnv for Builder
 	BuildConfigEnv map[string]string
 
+	// Map of labels to add to the Buildpack
+	Labels map[string]string
+
 	// Configuration that defines the functionality a builder provides.
 	Config pubbldr.Config
 
@@ -154,6 +157,10 @@ func (c *Client) createBaseBuilder(ctx context.Context, opts CreateBuilderOption
 	if opts.Flatten != nil && len(opts.Flatten.FlattenModules()) > 0 {
 		builderOpts = append(builderOpts, builder.WithFlattened(opts.Flatten))
 	}
+	if opts.Labels != nil && len(opts.Labels) > 0 {
+		builderOpts = append(builderOpts, builder.WithLabels(opts.Labels))
+	}
+
 	bldr, err := builder.New(baseImage, opts.BuilderName, builderOpts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid build-image")

--- a/pkg/client/create_builder_test.go
+++ b/pkg/client/create_builder_test.go
@@ -791,6 +791,20 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNotContains(t, out.String(), "is using deprecated Buildpacks API version")
 			})
 
+			it("should set labels", func() {
+				opts.Labels = map[string]string{"test.label.one": "1", "test.label.two": "2"}
+				prepareFetcherWithBuildImage()
+				prepareFetcherWithRunImages()
+
+				err := subject.CreateBuilder(context.TODO(), opts)
+				h.AssertNil(t, err)
+
+				imageLabels, err := fakeBuildImage.Labels()
+				h.AssertNil(t, err)
+				h.AssertEq(t, imageLabels["test.label.one"], "1")
+				h.AssertEq(t, imageLabels["test.label.two"], "2")
+			})
+
 			when("Buildpack dependencies are provided", func() {
 				var (
 					bp1v1          buildpack.BuildModule


### PR DESCRIPTION
## Summary
This PR adds a new `--label` flag to the `pack builder create` command 

## Output

#### Before

The flag didn't exist before

#### After

New flag will look like this, when running `pack builder create --help`

```bash
Flags:
  -l, --label stringToString        Labels to add to the builder image, in the form of '<name>=<value>' (default [])
```

Running a local builder creation like 

```bash
> out/pack builder create cnbs/local-builder:jammy --config builder.toml --label "foo=bar"
# then we inspect the labels
>  docker inspect cnbs/local-builder:jammy | jq '.[] | .Config.Labels' | jq .
```

output

```json
{
  "foo": "bar",
  "io.buildpacks.base.distro.name": "ubuntu",
  "io.buildpacks.base.distro.version": "\"22.04\"",
  "io.buildpacks.builder.metadata": "...."
}
```

As we can see the label "foo=bar" was set to the builder image

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see #__
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2033 
