### PR TITLE
Separate suggested builders from default trusted builders

### DIFF
--- a/acceptance/assertions/output.go
+++ b/acceptance/assertions/output.go
@@ -182,7 +182,6 @@ func (o OutputAssertionManager) IncludesPrefixedGoogleBuilder() {
 }
 
 var herokuBuilders = []string{
-	"heroku/builder:20",
 	"heroku/builder:22",
 }
 

--- a/internal/builder/known_builder.go
+++ b/internal/builder/known_builder.go
@@ -27,7 +27,7 @@ var KnownBuilders = []KnownBuilder{
 		Vendor:             "Heroku",
 		Image:              "heroku/builder:20",
 		DefaultDescription: "Heroku-20 (Ubuntu 20.04) base image with buildpacks for Go, Java, Node.js, PHP, Python, Ruby & Scala",
-		Suggested:          true,
+		Suggested:          false,
 		Trusted:            true,
 	},
 	{

--- a/internal/builder/known_builder.go
+++ b/internal/builder/known_builder.go
@@ -1,45 +1,61 @@
 package builder
 
-type SuggestedBuilder struct {
+type KnownBuilder struct {
 	Vendor             string
 	Image              string
 	DefaultDescription string
+	Suggested          bool
+	Trusted            bool
 }
 
-var SuggestedBuilders = []SuggestedBuilder{
+var KnownBuilders = []KnownBuilder{
 	{
 		Vendor:             "Google",
 		Image:              "gcr.io/buildpacks/builder:v1",
 		DefaultDescription: "GCP Builder for all runtimes",
+		Suggested:          true,
+		Trusted:            true,
 	},
 	{
 		Vendor:             "Heroku",
 		Image:              "heroku/builder:22",
 		DefaultDescription: "Heroku-22 (Ubuntu 22.04) base image with buildpacks for Go, Java, Node.js, PHP, Python, Ruby & Scala",
+		Suggested:          true,
+		Trusted:            true,
 	},
 	{
 		Vendor:             "Heroku",
 		Image:              "heroku/builder:20",
 		DefaultDescription: "Heroku-20 (Ubuntu 20.04) base image with buildpacks for Go, Java, Node.js, PHP, Python, Ruby & Scala",
+		Suggested:          true,
+		Trusted:            true,
 	},
 	{
 		Vendor:             "Paketo Buildpacks",
 		Image:              "paketobuildpacks/builder-jammy-base",
 		DefaultDescription: "Small base image with buildpacks for Java, Node.js, Golang, .NET Core, Python & Ruby",
+		Suggested:          true,
+		Trusted:            true,
 	},
 	{
 		Vendor:             "Paketo Buildpacks",
 		Image:              "paketobuildpacks/builder-jammy-full",
 		DefaultDescription: "Larger base image with buildpacks for Java, Node.js, Golang, .NET Core, Python, Ruby, & PHP",
+		Suggested:          true,
+		Trusted:            true,
 	},
 	{
 		Vendor:             "Paketo Buildpacks",
 		Image:              "paketobuildpacks/builder-jammy-tiny",
 		DefaultDescription: "Tiny base image (jammy build image, distroless run image) with buildpacks for Golang & Java",
+		Suggested:          true,
+		Trusted:            true,
 	},
 	{
 		Vendor:             "Paketo Buildpacks",
 		Image:              "paketobuildpacks/builder-jammy-buildpackless-static",
 		DefaultDescription: "Static base image (jammy build image, distroless run image) suitable for static binaries like Go or Rust",
+		Suggested:          true,
+		Trusted:            true,
 	},
 }

--- a/internal/commands/builder_inspect_test.go
+++ b/internal/commands/builder_inspect_test.go
@@ -254,7 +254,6 @@ func testBuilderInspectCommand(t *testing.T, when spec.G, it spec.S) {
 
 				assert.Matches(outBuf.String(), regexp.MustCompile(`Paketo Buildpacks:\s+'paketobuildpacks/builder-jammy-base'`))
 				assert.Matches(outBuf.String(), regexp.MustCompile(`Paketo Buildpacks:\s+'paketobuildpacks/builder-jammy-full'`))
-				assert.Matches(outBuf.String(), regexp.MustCompile(`Heroku:\s+'heroku/builder:20'`))
 				assert.Matches(outBuf.String(), regexp.MustCompile(`Heroku:\s+'heroku/builder:22'`))
 			})
 		})

--- a/internal/commands/builder_suggest_test.go
+++ b/internal/commands/builder_suggest_test.go
@@ -47,7 +47,7 @@ func testSuggestCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("displays descriptions from metadata", func() {
-				commands.WriteSuggestedBuilder(logger, mockClient, []bldr.SuggestedBuilder{{
+				commands.WriteSuggestedBuilder(logger, mockClient, []bldr.KnownBuilder{{
 					Vendor:             "Builder",
 					Image:              "gcr.io/some/builder:latest",
 					DefaultDescription: "Default description",
@@ -65,7 +65,7 @@ func testSuggestCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("displays default descriptions", func() {
-				commands.WriteSuggestedBuilder(logger, mockClient, []bldr.SuggestedBuilder{{
+				commands.WriteSuggestedBuilder(logger, mockClient, []bldr.KnownBuilder{{
 					Vendor:             "Builder",
 					Image:              "gcr.io/some/builder:latest",
 					DefaultDescription: "Default description",
@@ -81,7 +81,7 @@ func testSuggestCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("displays default descriptions", func() {
-				commands.WriteSuggestedBuilder(logger, mockClient, []bldr.SuggestedBuilder{{
+				commands.WriteSuggestedBuilder(logger, mockClient, []bldr.KnownBuilder{{
 					Vendor:             "Builder",
 					Image:              "gcr.io/some/builder:latest",
 					DefaultDescription: "Default description",

--- a/internal/commands/config_trusted_builder.go
+++ b/internal/commands/config_trusted_builder.go
@@ -102,8 +102,10 @@ func listTrustedBuilders(args []string, logger logging.Logger, cfg config.Config
 	logger.Info("Trusted Builders:")
 
 	var trustedBuilders []string
-	for _, builder := range bldr.SuggestedBuilders {
-		trustedBuilders = append(trustedBuilders, builder.Image)
+	for _, knownBuilder := range bldr.KnownBuilders {
+		if knownBuilder.Trusted {
+			trustedBuilders = append(trustedBuilders, knownBuilder.Image)
+		}
 	}
 
 	for _, builder := range cfg.TrustedBuilders {

--- a/internal/commands/inspect_builder_test.go
+++ b/internal/commands/inspect_builder_test.go
@@ -215,7 +215,6 @@ func testInspectBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 
 				assert.Matches(outBuf.String(), regexp.MustCompile(`Paketo Buildpacks:\s+'paketobuildpacks/builder-jammy-base'`))
 				assert.Matches(outBuf.String(), regexp.MustCompile(`Paketo Buildpacks:\s+'paketobuildpacks/builder-jammy-full'`))
-				assert.Matches(outBuf.String(), regexp.MustCompile(`Heroku:\s+'heroku/builder:20'`))
 				assert.Matches(outBuf.String(), regexp.MustCompile(`Heroku:\s+'heroku/builder:22'`))
 			})
 		})

--- a/internal/commands/suggest_builders.go
+++ b/internal/commands/suggest_builders.go
@@ -39,10 +39,16 @@ func suggestSettingBuilder(logger logging.Logger, inspector BuilderInspector) {
 }
 
 func suggestBuilders(logger logging.Logger, client BuilderInspector) {
-	WriteSuggestedBuilder(logger, client, bldr.SuggestedBuilders)
+	suggestedBuilders := []bldr.KnownBuilder{}
+	for _, knownBuilder := range bldr.KnownBuilders {
+		if knownBuilder.Suggested {
+			suggestedBuilders = append(suggestedBuilders, knownBuilder)
+		}
+	}
+	WriteSuggestedBuilder(logger, client, suggestedBuilders)
 }
 
-func WriteSuggestedBuilder(logger logging.Logger, inspector BuilderInspector, builders []bldr.SuggestedBuilder) {
+func WriteSuggestedBuilder(logger logging.Logger, inspector BuilderInspector, builders []bldr.KnownBuilder) {
 	sort.Slice(builders, func(i, j int) bool {
 		if builders[i].Vendor == builders[j].Vendor {
 			return builders[i].Image < builders[j].Image
@@ -60,7 +66,7 @@ func WriteSuggestedBuilder(logger logging.Logger, inspector BuilderInspector, bu
 	wg.Add(len(builders))
 
 	for i, builder := range builders {
-		go func(w *sync.WaitGroup, i int, builder bldr.SuggestedBuilder) {
+		go func(w *sync.WaitGroup, i int, builder bldr.KnownBuilder) {
 			descriptions[i] = getBuilderDescription(builder, inspector)
 			w.Done()
 		}(&wg, i, builder)
@@ -78,7 +84,7 @@ func WriteSuggestedBuilder(logger logging.Logger, inspector BuilderInspector, bu
 	logger.Info("\tpack builder inspect <builder-image>")
 }
 
-func getBuilderDescription(builder bldr.SuggestedBuilder, inspector BuilderInspector) string {
+func getBuilderDescription(builder bldr.KnownBuilder, inspector BuilderInspector) string {
 	info, err := inspector.InspectBuilder(builder.Image, false)
 	if err == nil && info != nil && info.Description != "" {
 		return info.Description
@@ -88,8 +94,8 @@ func getBuilderDescription(builder bldr.SuggestedBuilder, inspector BuilderInspe
 }
 
 func isSuggestedBuilder(builder string) bool {
-	for _, sugBuilder := range bldr.SuggestedBuilders {
-		if builder == sugBuilder.Image {
+	for _, knownBuilder := range bldr.KnownBuilders {
+		if builder == knownBuilder.Image && knownBuilder.Suggested {
 			return true
 		}
 	}

--- a/internal/commands/suggest_builders_test.go
+++ b/internal/commands/suggest_builders_test.go
@@ -47,7 +47,7 @@ func testSuggestBuildersCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("displays descriptions from metadata", func() {
-				commands.WriteSuggestedBuilder(logger, mockClient, []bldr.SuggestedBuilder{{
+				commands.WriteSuggestedBuilder(logger, mockClient, []bldr.KnownBuilder{{
 					Vendor:             "Builder",
 					Image:              "gcr.io/some/builder:latest",
 					DefaultDescription: "Default description",
@@ -65,7 +65,7 @@ func testSuggestBuildersCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("displays default descriptions", func() {
-				commands.WriteSuggestedBuilder(logger, mockClient, []bldr.SuggestedBuilder{{
+				commands.WriteSuggestedBuilder(logger, mockClient, []bldr.KnownBuilder{{
 					Vendor:             "Builder",
 					Image:              "gcr.io/some/builder:latest",
 					DefaultDescription: "Default description",
@@ -81,7 +81,7 @@ func testSuggestBuildersCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("displays default descriptions", func() {
-				commands.WriteSuggestedBuilder(logger, mockClient, []bldr.SuggestedBuilder{{
+				commands.WriteSuggestedBuilder(logger, mockClient, []bldr.KnownBuilder{{
 					Vendor:             "Builder",
 					Image:              "gcr.io/some/builder:latest",
 					DefaultDescription: "Default description",

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -274,9 +274,9 @@ type layoutPathConfig struct {
 	targetRunImagePath      string
 }
 
-var IsSuggestedBuilderFunc = func(b string) bool {
-	for _, suggestedBuilder := range builder.SuggestedBuilders {
-		if b == suggestedBuilder.Image {
+var IsTrustedBuilderFunc = func(b string) bool {
+	for _, knownBuilder := range builder.KnownBuilders {
+		if b == knownBuilder.Image && knownBuilder.Trusted {
 			return true
 		}
 	}
@@ -384,7 +384,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 
 	// Default mode: if the TrustBuilder option is not set, trust the suggested builders.
 	if opts.TrustBuilder == nil {
-		opts.TrustBuilder = IsSuggestedBuilderFunc
+		opts.TrustBuilder = IsTrustedBuilderFunc
 	}
 
 	// Ensure the builder's platform APIs are supported


### PR DESCRIPTION
## Summary

This PR replaces the `SuggestedBuilder` struct with a `KnownBuilder` struct that contains the same details + the following boolean flags: 
- `Suggested` 
- `Trusted`

These flags can be set on a `KnownBuilder` to control if it should be displayed as a suggested builder and/or be added as a default trusted builder.

With these changes, `heroku/builder:20` has also been removed from the suggested list but remains as a default trusted builder.

## Output

`pack builder suggest`

#### Before

```
Suggested builders:
        Google:                gcr.io/buildpacks/builder:v1                            Ubuntu 18 base image with buildpacks for .NET, Go, Java, Node.js, and Python                                                                                     
        Heroku:                heroku/builder:20                                       Heroku-20 (Ubuntu 20.04) base image with buildpacks for Go, Java, Node.js, PHP, Python, Ruby & Scala.                                                            
        Heroku:                heroku/builder:22                                       Heroku-22 (Ubuntu 22.04) base image with buildpacks for Go, Java, Node.js, PHP, Python, Ruby & Scala.                                                            
        Paketo Buildpacks:     paketobuildpacks/builder-jammy-base                     Ubuntu 22.04 Jammy Jellyfish base image with buildpacks for Java, Go, .NET Core, Node.js, Python, Apache HTTPD, NGINX and Procfile                               
        Paketo Buildpacks:     paketobuildpacks/builder-jammy-buildpackless-static     Static base image (Ubuntu Jammy Jellyfish build image, distroless-like run image) with no buildpacks included. To use, specify buildpacks at build time.         
        Paketo Buildpacks:     paketobuildpacks/builder-jammy-full                     Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apache HTTPD, Go, Java, Java Native Image, .NET, NGINX, Node.js, PHP, Procfile, Python, and Ruby     
        Paketo Buildpacks:     paketobuildpacks/builder-jammy-tiny                     Tiny base image (Ubuntu Jammy Jellyfish build image, distroless-like run image) with buildpacks for Java, Java Native Image and Go                               

Tip: Learn more about a specific builder with:
        pack builder inspect <builder-image>
```

#### After

```
Suggested builders:
        Google:                gcr.io/buildpacks/builder:v1                            Ubuntu 18 base image with buildpacks for .NET, Go, Java, Node.js, and Python                                                                                     
        Heroku:                heroku/builder:22                                       Heroku-22 (Ubuntu 22.04) base image with buildpacks for Go, Java, Node.js, PHP, Python, Ruby & Scala.                                                            
        Paketo Buildpacks:     paketobuildpacks/builder-jammy-base                     Ubuntu 22.04 Jammy Jellyfish base image with buildpacks for Java, Go, .NET Core, Node.js, Python, Apache HTTPD, NGINX and Procfile                               
        Paketo Buildpacks:     paketobuildpacks/builder-jammy-buildpackless-static     Static base image (Ubuntu Jammy Jellyfish build image, distroless-like run image) with no buildpacks included. To use, specify buildpacks at build time.         
        Paketo Buildpacks:     paketobuildpacks/builder-jammy-full                     Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apache HTTPD, Go, Java, Java Native Image, .NET, NGINX, Node.js, PHP, Procfile, Python, and Ruby     
        Paketo Buildpacks:     paketobuildpacks/builder-jammy-tiny                     Tiny base image (Ubuntu Jammy Jellyfish build image, distroless-like run image) with buildpacks for Java, Java Native Image and Go                               

Tip: Learn more about a specific builder with:
        pack builder inspect <builder-image>
```

---

`pack config trusted-builders list` (no difference since the default list is still all trusted)

#### Before

```
Trusted Builders:
  gcr.io/buildpacks/builder:v1
  heroku/builder:22
  heroku/buildpacks:20
  paketobuildpacks/builder-jammy-base
  paketobuildpacks/builder-jammy-buildpackless-static
  paketobuildpacks/builder-jammy-full
  paketobuildpacks/builder-jammy-tiny
```

#### After

```
Trusted Builders:
  gcr.io/buildpacks/builder:v1
  heroku/builder:20
  heroku/builder:22
  paketobuildpacks/builder-jammy-base
  paketobuildpacks/builder-jammy-buildpackless-static
  paketobuildpacks/builder-jammy-full
  paketobuildpacks/builder-jammy-tiny
```

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related

Resolves #1500 
