### PR TITLE
Excluding pre-release from `check latest pack release` workflow

### DIFF
--- a/.github/workflows/check-latest-release.yml
+++ b/.github/workflows/check-latest-release.yml
@@ -25,7 +25,7 @@ jobs:
           
           LATEST_GO_VERSION=$(go version | cut -d ' ' -f 3)
           
-          LATEST_RELEASE_VERSION=$(gh release list -L 1 | cut -d $'\t' -f 1 | cut -d ' ' -f 2)
+          LATEST_RELEASE_VERSION=$(gh release list --exclude-drafts --exclude-pre-releases -L 1 | cut -d $'\t' -f 1 | cut -d ' ' -f 2)
           
           wget https://github.com/$GITHUB_REPOSITORY/releases/download/$LATEST_RELEASE_VERSION/pack-$LATEST_RELEASE_VERSION-linux.tgz -O out.tgz
           tar xzf out.tgz


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->

This PR adds the flags ` --exclude-drafts`  and  `--exclude-pre-releases` when looking for the latest pack release to scan with grype

## Output

#### Before

```bash
> gh release list -L 1 | cut -d $'\t' -f 1 | cut -d ' ' -f 2
v0.33.0-rc1
```
After we released 0.33.0 RC1 the workflow fails not because there is CVE but because it can't find the docker image

#### After

```bash
> gh release list --exclude-drafts --exclude-pre-releases  -L 1 | cut -d $'\t' -f 1 | cut -d ' ' -f 2
v0.32.1
```

Although there is a RC1 version, it will not be analyzed when looking for CVEs

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2044 
