### PR TITLE
Add architecture for images created with`pack buildpack package`

### DIFF
--- a/pkg/buildpack/downloader_test.go
+++ b/pkg/buildpack/downloader_test.go
@@ -58,9 +58,11 @@ func testBuildpackDownloader(t *testing.T, when spec.G, it spec.S) {
 		return url
 	}
 
+	var linuxAmd64Platform = dist.Platform{OS: "linux", Architecture: "amd64", Platform: "linux/amd64"}
+
 	var createPackage = func(imageName string) *fakes.Image {
 		packageImage := fakes.NewImage(imageName, "", nil)
-		mockImageFactory.EXPECT().NewImage(packageImage.Name(), false, "linux").Return(packageImage, nil)
+		mockImageFactory.EXPECT().NewImage(packageImage.Name(), false, linuxAmd64Platform).Return(packageImage, nil)
 
 		pack, err := client.NewClient(
 			client.WithLogger(logger),
@@ -74,7 +76,7 @@ func testBuildpackDownloader(t *testing.T, when spec.G, it spec.S) {
 		h.AssertNil(t, pack.PackageBuildpack(context.TODO(), client.PackageBuildpackOptions{
 			Name: packageImage.Name(),
 			Config: pubbldpkg.Config{
-				Platform: dist.Platform{OS: "linux"},
+				Platform: dist.Platform{OS: "linux", Architecture: "amd64"},
 				Buildpack: dist.BuildpackURI{URI: createBuildpack(dist.BuildpackDescriptor{
 					WithAPI:    api.MustParse("0.3"),
 					WithInfo:   dist.ModuleInfo{ID: "example/foo", Version: "1.1.0"},
@@ -127,9 +129,9 @@ func testBuildpackDownloader(t *testing.T, when spec.G, it spec.S) {
 			downloadOptions = buildpack.DownloadOptions{ImageOS: "linux"}
 		)
 
-		shouldFetchPackageImageWith := func(demon bool, pull image.PullPolicy, platform string) {
+		shouldFetchPackageImageWith := func(daemon bool, pull image.PullPolicy, platform string) {
 			mockImageFetcher.EXPECT().Fetch(gomock.Any(), packageImage.Name(), image.FetchOptions{
-				Daemon:     demon,
+				Daemon:     daemon,
 				PullPolicy: pull,
 				Platform:   platform,
 			}).Return(packageImage, nil)

--- a/pkg/client/package_extension.go
+++ b/pkg/client/package_extension.go
@@ -20,7 +20,7 @@ func (c *Client) PackageExtension(ctx context.Context, opts PackageBuildpackOpti
 		return NewExperimentError("Windows extensionpackage support is currently experimental.")
 	}
 
-	err := c.validateOSPlatform(ctx, opts.Config.Platform.OS, opts.Publish, opts.Format)
+	err := c.validateAndUpdatePlatform(ctx, &opts.Config.Platform, opts.Publish, opts.Format)
 	if err != nil {
 		return err
 	}
@@ -51,9 +51,9 @@ func (c *Client) PackageExtension(ctx context.Context, opts PackageBuildpackOpti
 
 	switch opts.Format {
 	case FormatFile:
-		return packageBuilder.SaveAsFile(opts.Name, opts.Config.Platform.OS, map[string]string{})
+		return packageBuilder.SaveAsFile(opts.Name, opts.Config.Platform, map[string]string{})
 	case FormatImage:
-		_, err = packageBuilder.SaveAsImage(opts.Name, opts.Publish, opts.Config.Platform.OS, map[string]string{})
+		_, err = packageBuilder.SaveAsImage(opts.Name, opts.Publish, opts.Config.Platform, map[string]string{})
 		return errors.Wrapf(err, "saving image")
 	default:
 		return errors.Errorf("unknown format: %s", style.Symbol(opts.Format))

--- a/pkg/dist/dist.go
+++ b/pkg/dist/dist.go
@@ -35,7 +35,9 @@ func (c *ImageOrURI) DisplayString() string {
 }
 
 type Platform struct {
-	OS string `toml:"os"`
+	OS           string `toml:"os"`
+	Architecture string `toml:"architecture"`
+	Platform     string `toml:"platform,omitempty" json:"platform,omitempty" yaml:"platform,omitempty"`
 }
 
 type Order []OrderEntry

--- a/pkg/testmocks/mock_image_factory.go
+++ b/pkg/testmocks/mock_image_factory.go
@@ -9,6 +9,8 @@ import (
 
 	imgutil "github.com/buildpacks/imgutil"
 	gomock "github.com/golang/mock/gomock"
+
+	dist "github.com/buildpacks/pack/pkg/dist"
 )
 
 // MockImageFactory is a mock of ImageFactory interface.
@@ -35,7 +37,7 @@ func (m *MockImageFactory) EXPECT() *MockImageFactoryMockRecorder {
 }
 
 // NewImage mocks base method.
-func (m *MockImageFactory) NewImage(arg0 string, arg1 bool, arg2 string) (imgutil.Image, error) {
+func (m *MockImageFactory) NewImage(arg0 string, arg1 bool, arg2 dist.Platform) (imgutil.Image, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewImage", arg0, arg1, arg2)
 	ret0, _ := ret[0].(imgutil.Image)


### PR DESCRIPTION
## Summary
This changes the behavior of `pack buildpack package` to include the platform architecture when the docker daemon is available, or from `runtime.GOARCH` otherwise. It also has support for user-supplied architecture, but this is currently not supported through any pack cli arguments.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

The current behavior is described in https://github.com/buildpacks/pack/issues/2079

#### After

You can verify the change in this PR by following the steps below.

Note that docker needs to be configured to build multi-arch images for this to work as described [here](https://docs.docker.com/build/building/multi-platform/).

##### Steps

1. Create the following dockerfile in a directory.
```
FROM golang:1.21 as builder
WORKDIR /pack

RUN git clone --depth 1 --branch add-arch-in-buildpack-package https://github.com/jericop/pack.git /pack
RUN make mod-tidy build

FROM bitnami/git
USER root
WORKDIR /workspace

COPY --from=builder /pack/out/pack /usr/local/bin/pack

RUN <<RUN_EOF

image_arch=amd64
if [ $(arch) = "aarch64" ]; then
  image_arch=arm64
fi

git clone --depth 1 --branch main https://github.com/buildpacks/samples.git

pack buildpack package ttl.sh/jericop-buildpack-add-arch-in-buildpack-package:${image_arch} --publish \
  --path samples/buildpacks/hello-world

RUN_EOF

```
2. Run the following `docker buildx` command to create and publish buildpacks to ttl.sh, an ephemeral registry.
```
docker buildx build --platform linux/amd64,linux/arm64 .
```
3. Inspect the image config with crane to confirm the architecture is an empty string.
```
➜  pack-arch-issue crane ls ttl.sh/jericop-buildpack-add-arch-in-buildpack-package
amd64
arm64
➜  pack-arch-issue crane config ttl.sh/jericop-buildpack-add-arch-in-buildpack-package:amd64 | jq .architecture
"amd64"
➜  pack-arch-issue crane config ttl.sh/jericop-buildpack-add-arch-in-buildpack-package:arm64 | jq .architecture
"arm64"
➜  pack-arch-issue 
```

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

It is generally expected that when you build an image on a certain platform and architecture, the image you produce should be meant to run on that platform and architecture. As a result I don't believe this change needs to be documented.

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves https://github.com/buildpacks/pack/issues/2079
It should also resolve https://github.com/buildpacks/pack/issues/1968, which was fixed by retry logic.
