### PR TITLE
Add validation support for empty/nil `[[stacks]]`

### DIFF
--- a/pkg/buildpack/builder.go
+++ b/pkg/buildpack/builder.go
@@ -339,7 +339,7 @@ func (b *PackageBuilder) resolvedStacks() []dist.Stack {
 		bpdStacks := bp.Descriptor().Stacks()
 		if len(bpdStacks) == 0 && len(bpd.Order()) == 0 {
 			// For non-meta-buildpacks using targets, not stacks: assume any stack
-			bpdStacks = append(stacks, dist.Stack{ID: "*"})
+			bpdStacks = append(bpdStacks, dist.Stack{ID: "*"})
 		}
 
 		if len(stacks) == 0 {

--- a/pkg/buildpack/builder.go
+++ b/pkg/buildpack/builder.go
@@ -330,13 +330,22 @@ func (b *PackageBuilder) validate() error {
 
 func (b *PackageBuilder) resolvedStacks() []dist.Stack {
 	stacks := b.buildpack.Descriptor().Stacks()
+	if len(stacks) == 0 && len(b.buildpack.Descriptor().Order()) == 0 {
+		// For non-meta-buildpacks using targets, not stacks: assume any stack
+		stacks = append(stacks, dist.Stack{ID: "*"})
+	}
 	for _, bp := range b.AllModules() {
 		bpd := bp.Descriptor()
+		bpdStacks := bp.Descriptor().Stacks()
+		if len(bpdStacks) == 0 && len(bpd.Order()) == 0 {
+			// For non-meta-buildpacks using targets, not stacks: assume any stack
+			bpdStacks = append(stacks, dist.Stack{ID: "*"})
+		}
 
 		if len(stacks) == 0 {
-			stacks = bpd.Stacks()
-		} else if len(bpd.Stacks()) > 0 { // skip over "meta-buildpacks"
-			stacks = stack.MergeCompatible(stacks, bpd.Stacks())
+			stacks = bpdStacks
+		} else if len(bpdStacks) > 0 { // skip over "meta-buildpacks"
+			stacks = stack.MergeCompatible(stacks, bpdStacks)
 		}
 	}
 

--- a/pkg/buildpack/builder_test.go
+++ b/pkg/buildpack/builder_test.go
@@ -244,6 +244,25 @@ func testPackageBuilder(t *testing.T, when spec.G, it spec.S) {
 					})
 
 					when("validate stacks", func() {
+						when("buildpack does not define stacks", func() {
+							it("should succeed", func() {
+								bp, err := ifakes.NewFakeBuildpack(dist.BuildpackDescriptor{
+									WithAPI: api.MustParse("0.10"),
+									WithInfo: dist.ModuleInfo{
+										ID:      "bp.1.id",
+										Version: "bp.1.version",
+									},
+									WithStacks: nil,
+									WithOrder:  nil,
+								}, 0644)
+								h.AssertNil(t, err)
+								builder := buildpack.NewBuilder(mockImageFactory(expectedImageOS))
+								builder.SetBuildpack(bp)
+								err = testFn(builder)
+								h.AssertNil(t, err)
+							})
+						})
+
 						when("buildpack is meta-buildpack", func() {
 							it("should succeed", func() {
 								bp, err := ifakes.NewFakeBuildpack(dist.BuildpackDescriptor{


### PR DESCRIPTION
## Summary

A `buildpack.toml` without `[[order]]` and `[[stacks]]` tables fails to pass validation during `pack buildpack package` as mentioned in #2047.

`[[stacks]]` was [deprecated in API `0.10`](https://github.com/buildpacks/spec/blob/buildpack/v0.10/buildpack.md#buildpacktoml-toml-stacks-array). Based on my experience with many other software deprecations, deprecations are usually hints to stop using that feature. It's surprising to me that pack would ask to specify `[[stacks]]` while supporting a Buildpack API that marks `[[stacks]]` as deprecated.

This PR adds a new test (which fails on the main branch) that illustrates the problem. It also changes the validation a bit so that `pack` supports non-meta buildpacks without this table.

This change will add support for empty stacks for Buildpack API versions prior to `0.10`. I believe this makes sense. Previous versions of the Buildpack API did not mark `[[stacks]]` as mandatory, though it looks like this validation may have been accidentally doing so for `pack`.

## Output

#### Before

```bash
pack buildpack package procfile-test --config ../procfile-cnb/packaged/x86_64-unknown-linux-musl/debug/heroku_procfile/package.toml
ERROR: saving image: no compatible stacks among provided buildpacks
```

#### After

```bash
go run cmd/pack/main.go buildpack package procfile-test --config ../procfile-cnb/packaged/x86_64-unknown-linux-musl/debug/heroku_procfile/package.toml
Successfully created package procfile-test and saved to docker daemon
```
## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No
    - [x] Maybe. Should we be clearer about what deprecated means here? https://github.com/buildpacks/spec/blob/buildpack/v0.10/buildpack.md#buildpacktoml-toml-stacks-array

## Related

Resolves #2047