### PR TITLE
Release Noble Numbat

### DIFF
--- a/.github/workflows/delivery-ubuntu.yml
+++ b/.github/workflows/delivery-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          target: [bionic, focal, jammy, lunar]
+          target: [bionic, focal, jammy, lunar, noble]
       runs-on: ubuntu-20.04
       steps:
           - name: Checkout code
@@ -106,6 +106,18 @@ jobs:
           - name: Deliver lunar
             if: matrix.target == 'lunar'
             uses: docker://ubuntu:lunar
+            with:
+              entrypoint: .github/workflows/delivery/ubuntu/deliver.sh
+            env:
+              DEBIAN_FRONTEND: "noninteractive"
+              GO_DEP_PACKAGE_NAME: golang
+              GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+              GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+              PACKAGE_VERSION: ${{ steps.version.outputs.result }}
+
+          - name: Deliver noble
+            if: matrix.target == 'noble'
+            uses: docker://ubuntu:noble
             with:
               entrypoint: .github/workflows/delivery/ubuntu/deliver.sh
             env:


### PR DESCRIPTION
Ubunut has pushed out a docker image for [Noble](https://hub.docker.com/_/ubuntu).  There is not a pack cli in [buildpacks launchpad](https://ppa.launchpadcontent.net/cncf-buildpacks/pack-cli/ubuntu/dists/) for Noble

## Summary

- Update Github workflows to release a package for Ubuntu 22.04 (Noble Numbat)

## Output

Upload pack to the buildpacks PPA launchpad for Noble

#### Before

- No package existed for Noble

#### After

- Package exists for Noble

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
