### PR TITLE
Reverting the MAC - Address flag code (for now)

### DIFF
--- a/internal/build/fakes/fake_builder.go
+++ b/internal/build/fakes/fake_builder.go
@@ -122,9 +122,3 @@ func WithBuilder(builder *FakeBuilder) func(*build.LifecycleOptions) {
 		opts.Builder = builder
 	}
 }
-
-func WithMacAddresss(macAddresss string) func(*build.LifecycleOptions) {
-	return func(opts *build.LifecycleOptions) {
-		opts.MacAddress = macAddresss
-	}
-}

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -97,7 +97,6 @@ type LifecycleOptions struct {
 	Workspace                       string
 	GID                             int
 	UID                             int
-	MacAddress                      string
 	PreviousImage                   string
 	ReportDestinationDir            string
 	SBOMDestinationDir              string

--- a/internal/build/phase_config_provider.go
+++ b/internal/build/phase_config_provider.go
@@ -46,13 +46,6 @@ func NewPhaseConfigProvider(name string, lifecycleExec *LifecycleExecution, ops 
 	provider.ctrConf.Image = lifecycleExec.opts.Builder.Name()
 	provider.ctrConf.Labels = map[string]string{"author": "pack"}
 
-	if lifecycleExec.opts.MacAddress != "" {
-		// TODO fix this
-		//nolint:staticcheck
-		provider.ctrConf.MacAddress = lifecycleExec.opts.MacAddress
-		lifecycleExec.logger.Debugf("MAC Address: %s", style.Symbol(lifecycleExec.opts.MacAddress))
-	}
-
 	if lifecycleExec.os == "windows" {
 		provider.hostConf.Isolation = container.IsolationProcess
 	}

--- a/internal/build/phase_config_provider_test.go
+++ b/internal/build/phase_config_provider_test.go
@@ -75,19 +75,6 @@ func testPhaseConfigProvider(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("mac address is set", func() {
-			it("should set MacAddress in LifecycleOptions", func() {
-				expectedMacAddress := "01:23:45:67:89:ab"
-				lifecycle := newTestLifecycleExec(t, false, "some-temp-dir", fakes.WithMacAddresss(expectedMacAddress))
-
-				phaseConfigProvider := build.NewPhaseConfigProvider("some-name", lifecycle)
-
-				// TODO fix this
-				//nolint:staticcheck
-				h.AssertEq(t, phaseConfigProvider.ContainerConfig().MacAddress, expectedMacAddress)
-			})
-		})
-
 		when("building with interactive mode", func() {
 			it("returns a phase config provider with interactive args", func() {
 				handler := func(bodyChan <-chan container.WaitResponse, errChan <-chan error, reader io.Reader) error {

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -763,37 +763,6 @@ builder = "my-builder"
 			})
 		})
 
-		when("mac-address flag is provided", func() {
-			when("mac-address is a valid value", func() {
-				it("should set MacAddress in BuildOptions", func() {
-					mockClient.EXPECT().
-						Build(gomock.Any(), EqBuildOptionsWithMacAddress("01:23:45:67:89:ab")).
-						Return(nil)
-
-					command.SetArgs([]string{"--builder", "my-builder", "image", "--mac-address", "01:23:45:67:89:ab"})
-					h.AssertNil(t, command.Execute())
-				})
-			})
-			when("mac-address is an invalid value", func() {
-				it("should throw an error", func() {
-					command.SetArgs([]string{"--builder", "my-builder", "image", "--mac-address", "invalid-mac"})
-					err := command.Execute()
-					h.AssertError(t, err, "invalid MAC address")
-				})
-			})
-		})
-
-		when("mac-address flag is not provided", func() {
-			it("should not set MacAddress in BuildOptions", func() {
-				mockClient.EXPECT().
-					Build(gomock.Any(), EqBuildOptionsWithMacAddress("")).
-					Return(nil)
-
-				command.SetArgs([]string{"--builder", "my-builder", "image"})
-				h.AssertNil(t, command.Execute())
-			})
-		})
-
 		when("previous-image flag is provided", func() {
 			when("image is invalid", func() {
 				it("error must be thrown", func() {
@@ -1103,15 +1072,6 @@ func EqBuildOptionsWithOverrideGroupID(gid int) gomock.Matcher {
 		description: fmt.Sprintf("GID=%d", gid),
 		equals: func(o client.BuildOptions) bool {
 			return o.GroupID == gid
-		},
-	}
-}
-
-func EqBuildOptionsWithMacAddress(macAddress string) gomock.Matcher {
-	return buildOptionsMatcher{
-		description: fmt.Sprintf("MacAddress=%s", macAddress),
-		equals: func(o client.BuildOptions) bool {
-			return o.MacAddress == macAddress
 		},
 	}
 }

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -204,9 +204,6 @@ type BuildOptions struct {
 	// Directory to output the report.toml metadata artifact
 	ReportDestinationDir string
 
-	// For storing the mac-address to later pass on docker config structure
-	MacAddress string
-
 	// Desired create time in the output image config
 	CreationTime *time.Time
 
@@ -546,7 +543,6 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		Workspace:                opts.Workspace,
 		GID:                      opts.GroupID,
 		UID:                      opts.UserID,
-		MacAddress:               opts.MacAddress,
 		PreviousImage:            opts.PreviousImage,
 		Interactive:              opts.Interactive,
 		Termui:                   termui.NewTermui(imageName, ephemeralBuilder, runImageName),


### PR DESCRIPTION
## Summary
Currently we can't verify in our CI tooling that the `MAC address` is configured correctly when running the docker container, the reason for that is because the ubuntu [latest]([runner](https://github.com/actions/runner-images/blob/ubuntu22/20240324.2/images/ubuntu/Ubuntu2204-Readme.md#tools)) runner only supports Docker version 1.43 and we need version 1.44 for this feature. Also, we need to update our Windows runner, currently they support Docker version 1.41.

Once our runners are running the expected Docker version, then we can merge this code again, plus the acceptance tests developed in this [PR](https://github.com/buildpacks/pack/pull/2063)

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->


