### PR TITLE
Removing validation of deprecated io.buildpacks.stack.id

### DIFF
--- a/acceptance/assertions/output.go
+++ b/acceptance/assertions/output.go
@@ -76,10 +76,7 @@ func (o OutputAssertionManager) ReportsSkippingRestore() {
 func (o OutputAssertionManager) ReportsRunImageStackNotMatchingBuilder(runImageStack, builderStack string) {
 	o.testObject.Helper()
 
-	o.assert.Contains(
-		o.output,
-		fmt.Sprintf("run-image stack id '%s' does not match builder stack '%s'", runImageStack, builderStack),
-	)
+	o.assert.Contains(o.output, "Warning: deprecated usage of stack")
 }
 
 func (o OutputAssertionManager) WithoutColors() {

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -362,9 +362,12 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		pathsConfig.targetRunImagePath = targetRunImagePath
 		pathsConfig.hostRunImagePath = hostRunImagePath
 	}
-	runImage, err := c.validateRunImage(ctx, runImageName, fetchOptions, bldr.StackID)
+	runImage, warnings, err := c.validateRunImage(ctx, runImageName, fetchOptions, bldr.StackID)
 	if err != nil {
 		return errors.Wrapf(err, "invalid run-image '%s'", runImageName)
+	}
+	for _, warning := range warnings {
+		c.logger.Warn(warning)
 	}
 
 	var runMixins []string
@@ -799,22 +802,22 @@ func (c *Client) getBuilder(img imgutil.Image) (*builder.Builder, error) {
 	return bldr, nil
 }
 
-func (c *Client) validateRunImage(context context.Context, name string, opts image.FetchOptions, expectedStack string) (imgutil.Image, error) {
+func (c *Client) validateRunImage(context context.Context, name string, opts image.FetchOptions, expectedStack string) (builderImage imgutil.Image, warnings []string, err error) {
 	if name == "" {
-		return nil, errors.New("run image must be specified")
+		return nil, nil, errors.New("run image must be specified")
 	}
 	img, err := c.imageFetcher.Fetch(context, name, opts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	stackID, err := img.Label("io.buildpacks.stack.id")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if stackID != expectedStack {
-		return nil, fmt.Errorf("run-image stack id '%s' does not match builder stack '%s'", stackID, expectedStack)
+		warnings = append(warnings, "deprecated usage of stack")
 	}
-	return img, nil
+	return builderImage, warnings, nil
 }
 
 func (c *Client) validateMixins(additionalBuildpacks []buildpack.BuildModule, bldr *builder.Builder, runImageName string, runMixins []string) error {

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -802,22 +802,22 @@ func (c *Client) getBuilder(img imgutil.Image) (*builder.Builder, error) {
 	return bldr, nil
 }
 
-func (c *Client) validateRunImage(context context.Context, name string, opts image.FetchOptions, expectedStack string) (builderImage imgutil.Image, warnings []string, err error) {
+func (c *Client) validateRunImage(context context.Context, name string, opts image.FetchOptions, expectedStack string) (runImage imgutil.Image, warnings []string, err error) {
 	if name == "" {
 		return nil, nil, errors.New("run image must be specified")
 	}
-	img, err := c.imageFetcher.Fetch(context, name, opts)
+	runImage, err = c.imageFetcher.Fetch(context, name, opts)
 	if err != nil {
 		return nil, nil, err
 	}
-	stackID, err := img.Label("io.buildpacks.stack.id")
+	stackID, err := runImage.Label("io.buildpacks.stack.id")
 	if err != nil {
 		return nil, nil, err
 	}
 	if stackID != expectedStack {
 		warnings = append(warnings, "deprecated usage of stack")
 	}
-	return builderImage, warnings, nil
+	return runImage, warnings, nil
 }
 
 func (c *Client) validateMixins(additionalBuildpacks []buildpack.BuildModule, bldr *builder.Builder, runImageName string, runMixins []string) error {

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -524,14 +524,14 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, fakeRunImage.SetLabel("io.buildpacks.stack.id", "other.stack"))
 				})
 
-				it("errors", func() {
-					h.AssertError(t, subject.Build(context.TODO(), BuildOptions{
+				it("warning", func() {
+					err := subject.Build(context.TODO(), BuildOptions{
 						Image:    "some/app",
 						Builder:  defaultBuilderName,
 						RunImage: "custom/run",
-					}),
-						"invalid run-image 'custom/run': run-image stack id 'other.stack' does not match builder stack 'some.stack.id'",
-					)
+					})
+					h.AssertNil(t, err)
+					h.AssertContains(t, outBuf.String(), "Warning: deprecated usage of stack")
 				})
 			})
 


### PR DESCRIPTION
## Summary
Replaces the error with a warning.

## Output
Warning: No schema version declared in project.toml, defaulting to schema version 0.1
latest: Pulling from paketobuildpacks/builder-jammy-base
Digest: sha256:9bb4d01f8d42ccb9aa3b6b10a5876c8913e3ba9709882f18c9bd8c54f46d862b
Status: Image is up to date for paketobuildpacks/builder-jammy-base:latest
latest: Pulling from buildpacks/builder/php
Digest: sha256:91065e07a53b1c048fcaf8e49936a9d19c388b2dfdf2e7e589885aab2f5aae79
Status: Image is up to date for gcr.io/buildpacks/builder/php:latest
Warning: deprecated usage of stack

#### Before
Error message that interrupted build process
#### After
Warning message, build continues

## Documentation
https://buildpacks.io/docs/for-app-developers/concepts/base-images/stack/

- Should this change be documented?
    - [ ] Yes, see #___
    - [ x] No, already documented in  [docs](https://buildpacks.io/docs/for-app-developers/concepts/base-images/stack/) 

## Related
#2104

Resolves #2104
