### PR TITLE
Updating to go 1.22

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Set up go env
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
       - name: Set up go env for Unix
         if: runner.os != 'Windows'
@@ -186,7 +186,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
       - name: Build
         run: |

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
       - name: Set up go env
         run: |

--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,8 @@ install-golangci-lint:
 
 ## mod-tidy: Tidy Go modules
 mod-tidy:
-	$(GOCMD) mod tidy  -compat=1.21
-	cd tools && $(GOCMD) mod tidy -compat=1.21
+	$(GOCMD) mod tidy  -compat=1.22
+	cd tools && $(GOCMD) mod tidy -compat=1.22
 
 ## tidy: Tidy modules and format the code
 tidy: mod-tidy format

--- a/go.mod
+++ b/go.mod
@@ -139,4 +139,4 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-go 1.21
+go 1.22

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildpacks/pack/tools
 
-go 1.21
+go 1.22
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
## Summary
upgrades golang version

#### Before
Pack was compiled using go 1.21 since Feb 2024 and version 0.33.0

#### After

Pack will be compiled using go 1.22 since version 0.34, lifecycle and imgutil libraries were already updated to use go 1.22 and we want to use the latest version to support multi-platform features.

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2124
