### PR TITLE
Warn misconfiguration keys in project.toml only for tables we own

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -80,7 +80,7 @@ func warnIfTomlContainsKeysNotSupportedBySchema(schemaVersion string, tomlMetaDa
 		for _, unsupportedKey := range unsupportedKeys {
 			logger.Warnf("- %s\n", unsupportedKey)
 		}
-		logger.Warn("The above keys will be ignored. If this is not intentional, maybe try updating your schema version.\n")
+		logger.Warn("The above keys will be ignored. If this is not intentional, try updating your schema version.\n")
 	}
 }
 

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -401,13 +401,24 @@ name = "licenses should have either a type or uri defined"
 			h.AssertContains(t, readStdout(), "Warning: No schema version declared in project.toml, defaulting to schema version 0.1\n")
 		})
 
-		it("should warn when unsupported keys are declared with schema v0.1", func() {
+		it("should warn when unsupported keys, on tables the project owns, are declared with schema v0.1", func() {
 			projectToml := `
-[_]
-schema-version = "0.1"
+# try to use some schema 0.2 configuration with 0.1 version - warning message expected
+[project]
+authors = ["foo", "bar"]
 
-[unsupported-table]
-unsupported-key = "some value"
+# try to use buildpack.io table with version 0.1 - warning message expected
+[[io.buildpacks.build.env]]
+name = "JAVA_OPTS"
+value = "-Xmx1g"
+
+# something else defined by end-users - no warning message expected
+[io.docker]
+file = "./Dockerfile"
+
+# some metadata - no warning message expected
+[metadata]
+foo = "bar"
 `
 			tmpProjectToml, err := createTmpProjectTomlFile(projectToml)
 			if err != nil {
@@ -416,17 +427,36 @@ unsupported-key = "some value"
 
 			_, err = ReadProjectDescriptor(tmpProjectToml.Name(), logger)
 			h.AssertNil(t, err)
-
-			h.AssertContains(t, readStdout(), "Warning: The following keys declared in project.toml are not supported in schema version 0.1:\nWarning: - unsupported-table\nWarning: - unsupported-table.unsupported-key\nWarning: The above keys will be ignored. If this is not intentional, maybe try updating your schema version.\n")
+			h.AssertContains(t, readStdout(), "Warning: The following keys declared in project.toml are not supported in schema version 0.1:\nWarning: - project.authors\nWarning: - io.buildpacks.build.env\nWarning: - io.buildpacks.build.env.name\nWarning: - io.buildpacks.build.env.value\nWarning: The above keys will be ignored. If this is not intentional, maybe try updating your schema version.\n")
 		})
 
-		it("should warn when unsupported keys are declared with schema v0.2", func() {
+		it("should warn when unsupported keys, on tables the project owns, are declared with schema v0.2", func() {
 			projectToml := `
 [_]
 schema-version = "0.2"
+# typo in a key under valid table - warning message expected
+versions = "0.1"
 
-[unsupported-table]
-unsupported-key = "some value"
+[[_.licenses]]
+type = "foo"
+# invalid key under a valid table - warning message expected
+foo = "bar"
+
+# try to use an invalid key under io.buildpacks - warning message expected
+[[io.buildpacks.build.foo]]
+name = "something"
+
+# something else defined by end-users - no warning message expected
+[io.docker]
+file = "./Dockerfile"
+
+# some metadata defined the end-user - no warning message expected
+[_.metadata]
+foo = "bar"
+
+# more metadata defined the end-user - no warning message expected
+[_.metadata.fizz]
+buzz = ["a", "b", "c"]
 `
 			tmpProjectToml, err := createTmpProjectTomlFile(projectToml)
 			if err != nil {
@@ -436,7 +466,8 @@ unsupported-key = "some value"
 			_, err = ReadProjectDescriptor(tmpProjectToml.Name(), logger)
 			h.AssertNil(t, err)
 
-			h.AssertContains(t, readStdout(), "Warning: The following keys declared in project.toml are not supported in schema version 0.2:\nWarning: - unsupported-table\nWarning: - unsupported-table.unsupported-key\nWarning: The above keys will be ignored. If this is not intentional, maybe try updating your schema version.\n")
+			// Assert we only warn
+			h.AssertContains(t, readStdout(), "Warning: The following keys declared in project.toml are not supported in schema version 0.2:\nWarning: - _.versions\nWarning: - _.licenses.foo\nWarning: - io.buildpacks.build.foo\nWarning: - io.buildpacks.build.foo.name\nWarning: The above keys will be ignored. If this is not intentional, maybe try updating your schema version.\n")
 		})
 	})
 }

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -427,7 +427,7 @@ foo = "bar"
 
 			_, err = ReadProjectDescriptor(tmpProjectToml.Name(), logger)
 			h.AssertNil(t, err)
-			h.AssertContains(t, readStdout(), "Warning: The following keys declared in project.toml are not supported in schema version 0.1:\nWarning: - project.authors\nWarning: - io.buildpacks.build.env\nWarning: - io.buildpacks.build.env.name\nWarning: - io.buildpacks.build.env.value\nWarning: The above keys will be ignored. If this is not intentional, maybe try updating your schema version.\n")
+			h.AssertContains(t, readStdout(), "Warning: The following keys declared in project.toml are not supported in schema version 0.1:\nWarning: - project.authors\nWarning: - io.buildpacks.build.env\nWarning: - io.buildpacks.build.env.name\nWarning: - io.buildpacks.build.env.value\nWarning: The above keys will be ignored. If this is not intentional, try updating your schema version.\n")
 		})
 
 		it("should warn when unsupported keys, on tables the project owns, are declared with schema v0.2", func() {
@@ -467,7 +467,7 @@ buzz = ["a", "b", "c"]
 			h.AssertNil(t, err)
 
 			// Assert we only warn
-			h.AssertContains(t, readStdout(), "Warning: The following keys declared in project.toml are not supported in schema version 0.2:\nWarning: - _.versions\nWarning: - _.licenses.foo\nWarning: - io.buildpacks.build.foo\nWarning: - io.buildpacks.build.foo.name\nWarning: The above keys will be ignored. If this is not intentional, maybe try updating your schema version.\n")
+			h.AssertContains(t, readStdout(), "Warning: The following keys declared in project.toml are not supported in schema version 0.2:\nWarning: - _.versions\nWarning: - _.licenses.foo\nWarning: - io.buildpacks.build.foo\nWarning: - io.buildpacks.build.foo.name\nWarning: The above keys will be ignored. If this is not intentional, try updating your schema version.\n")
 		})
 	})
 }


### PR DESCRIPTION
## Summary

With pack [PR 2042](https://github.com/buildpacks/pack/pull/2042) we added a warning message when unsupported keys are declared in `project.toml`, the problem was that our [spec](https://buildpacks.io/docs/reference/config/project-descriptor/) allow the end-users to extend the file outside all `non-_` table and this shouldn't print a warning 

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

Any `project.toml` version 0.1 or 0.2 with something like declared

```toml
[unsupported-table]
unsupported-key = "some value"
``` 

Will print a warning message

#### After

We will only print a warning message for keys under `_.*` that are not supported or if `buildpack.io` is being used and not valid, everything else will be ignore

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #1922 
