### PR TITLE
Building darwin arm64 binaries by default on CI and amd64 during releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,8 @@ jobs:
         config: [macos, linux, windows-lcow, windows-wcow]
         include:
           - config: macos
-            os: macos
+            # since macos-14 the latest runner is arm64
+            os: macos-arm64
             runner: macos-latest
             no_docker: "true"
             pack_bin: pack
@@ -170,8 +171,9 @@ jobs:
           - name: linux-arm64
             goarch: arm64
             goos: linux
-          - name: macos-arm64
-            goarch: arm64
+          - name: macos
+            # since macos-14 default runner is arm, we need to build for intel architecture later
+            goarch: amd64
             goos: darwin
           - name: linux-s390x
             goarch: s390x


### PR DESCRIPTION
## Summary

By default we will built `darwin/arm64` binaries during CI and `darwing/amd64` binaries during release, because the new macos runner is based on `arm` architecture

## Output

### Before

This is a image from our last PR before releasing `0.34.0-rc1` the `macos` binary is actually an `arm64` binary instead of `amd64`

<img width="1221" alt="Screenshot 2024-05-24 at 10 40 41 AM" src="https://github.com/buildpacks/pack/assets/1181799/63c5061d-6b04-4308-a33e-4671a589a59d">

### After

Now, we actually saved the binary as `arm64` and the `amd64` will be built later

<img width="1190" alt="Screenshot 2024-05-24 at 10 39 05 AM" src="https://github.com/buildpacks/pack/assets/1181799/a4932fc2-8592-4b37-bbd0-dec64277209d">

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2167
