### PR TITLE
chore: updating docker base image to use go 1.22

### DIFF
--- a/.github/workflows/delivery-ubuntu.yml
+++ b/.github/workflows/delivery-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          target: [bionic, focal, jammy, lunar, noble]
+          target: [bionic, focal, jammy, noble]
       runs-on: ubuntu-20.04
       steps:
           - name: Checkout code
@@ -94,18 +94,6 @@ jobs:
           - name: Deliver jammy
             if: matrix.target == 'jammy'
             uses: docker://ubuntu:jammy
-            with:
-              entrypoint: .github/workflows/delivery/ubuntu/deliver.sh
-            env:
-              DEBIAN_FRONTEND: "noninteractive"
-              GO_DEP_PACKAGE_NAME: golang
-              GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-              GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
-              PACKAGE_VERSION: ${{ steps.version.outputs.result }}
-
-          - name: Deliver lunar
-            if: matrix.target == 'lunar'
-            uses: docker://ubuntu:lunar
             with:
               entrypoint: .github/workflows/delivery/ubuntu/deliver.sh
             env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG base_image=gcr.io/distroless/static
 
-FROM golang:1.20 as builder
+FROM golang:1.22 as builder
 ARG pack_version
 ENV PACK_VERSION=$pack_version
 WORKDIR /app


### PR DESCRIPTION
## Summary

After releasing pack [0.34.0](https://github.com/buildpacks/pack/releases/tag/v0.34.0) our CI/CD workflow failed  to publish in docker [registry](https://hub.docker.com/r/buildpacksio/pack/) because our base image is using docker 1.20, this PR fixes that. Also, the CI/CD failed deploying to ubuntu lunar, but this version reached its end of life in January 25 2024, I am removing it because we don't need to support it anymore.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before


Error:

```bash
> [linux/amd64 builder 4/4] RUN make build:
14.04 go: downloading github.com/beorn7/perks v1.0.1
14.05 go: downloading github.com/cespare/xxhash/v2 v2.2.0
14.06 go: downloading github.com/prometheus/client_model v0.5.0
14.09 go: downloading github.com/prometheus/common v0.48.0
14.10 go: downloading github.com/prometheus/procfs v0.12.0
30.24 /go/pkg/mod/go.opentelemetry.io/otel@v1.25.0/attribute/set.go:7:2: package cmp is not in GOROOT (/usr/local/go/src/cmp)
30.24 note: imported by a module that requires go 1.21
30.24 /go/pkg/mod/go.opentelemetry.io/otel@v1.25.0/attribute/set.go:10:2: package slices is not in GOROOT (/usr/local/go/src/slices)
30.24 note: imported by a module that requires go 1.21
30.24 make: *** [Makefile:61: build] Error 1
------
Dockerfile:8
--------------------
   6 |     WORKDIR /app
   7 |     COPY . .
   8 | >>> RUN make build
   9 |     
  10 |     FROM ${base_image}
--------------------
ERROR: failed to solve: process "/bin/sh -c make build" did not complete successfully: exit code: 2
Error: Process completed with exit code 1.

```

#### After

Running docker build works

Resolves #2172 
Resoves #2156