### PR TITLE
Bump default lifecycle binary version from 0.19.6 to 0.20.0

### DIFF
--- a/acceptance/testdata/pack_fixtures/report_output.txt
+++ b/acceptance/testdata/pack_fixtures/report_output.txt
@@ -2,7 +2,7 @@ Pack:
   Version:  {{ .Version }}
   OS/Arch:  {{ .OS }}/{{ .Arch }}
 
-Default Lifecycle Version:  0.19.6
+Default Lifecycle Version:  0.20.0
 
 Supported Platform APIs:  0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13
 

--- a/internal/builder/lifecycle.go
+++ b/internal/builder/lifecycle.go
@@ -14,7 +14,7 @@ import (
 
 // A snapshot of the latest tested lifecycle version values
 const (
-	DefaultLifecycleVersion    = "0.19.6"
+	DefaultLifecycleVersion    = "0.20.0"
 	DefaultBuildpackAPIVersion = "0.2"
 )
 


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->

This doesn't bump the library version (no urgent need) but it does bump the default version that gets pulled in for builder creation. Since we just released some security fixes (and told folks to upgrade) having it be the default makes sense.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
