### PR TITLE
Make the docker Image `pack:base` built on the same base image as `pack:x.x.x-base`

### DIFF
--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Tag Image as Base
         if: ${{ (github.event.release != '' || github.event.inputs.tag_latest) && matrix.config == 'base' }}
         run: |
-          crane copy ${{ env.IMG_NAME }}:${{ steps.version.outputs.result }} ${{ env.IMG_NAME }}:base
+          crane copy ${{ env.IMG_NAME }}:${{ steps.version.outputs.result }}${{ matrix.suffix }} ${{ env.IMG_NAME }}:base
       - name: Tag Image as Latest
         if: ${{ (github.event.release != '' || github.event.inputs.tag_latest) && matrix.config != 'base' }}
         run: |
-          crane copy ${{ env.IMG_NAME }}:${{ steps.version.outputs.result }} ${{ env.IMG_NAME }}:latest
+          crane copy ${{ env.IMG_NAME }}:${{ steps.version.outputs.result }}${{ matrix.suffix }} ${{ env.IMG_NAME }}:latest

--- a/tools/test-fork.sh
+++ b/tools/test-fork.sh
@@ -53,7 +53,7 @@ sed -i '' "/- config: windows-lcow/,+4d" $wfdir/build.yml
 
 echo "Replacing the registry account with owned one (assumes DOCKER_PASSWORD and DOCKER_USERNAME have been added to GitHub secrets, if not using ghcr.io)"
 sed -i '' "s/buildpacksio\/pack/$registry\/$username\/$reponame/g" $wfdir/check-latest-release.yml
-sed -i '' "/REPO_NAME: 'index.docker.io'/ s/index.docker.io/$registry/g" $wfdir/delivery-docker.yml
+sed -i '' "/REGISTRY_NAME: 'index.docker.io'/ s/index.docker.io/$registry/g" $wfdir/delivery-docker.yml
 sed -i '' "/USER_NAME: 'buildpacksio'/ s/buildpacksio/$username/g" $wfdir/delivery-docker.yml
 
 if [[ $registry != "index.docker.io" ]]; then


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
Currently, the docker image `pack:base` is built on the same base image as tiny. But it is considered that the image should be based on the same image as `pack:x.x.x-base`, so this PR corrects it.

This PR make changes below:
- Add `${{ matrix.suffix }}` to the source tag for retagging in the `delivery-docker.yml`, making the `pack:base` image.
- Make a small fix to the helper script for testing the GitHub Action workflows on forked repositories.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
- The `pack:x.x.x-base` doesn't have `sh`

```
$ docker run --rm -it --entrypoint sh buildpacksio/pack:base
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "sh": executable file not found in $PATH: unknown.
```


#### After
Tested using images build with my fork repository.

- The `pack:x.x.x-base` and `pack:base` has the `sh` and `echo`

```
$ docker run --rm -it --entrypoint sh ghcr.io/hhiroshell/pack:0.2.0-base
Unable to find image 'ghcr.io/hhiroshell/pack:0.2.0-base' locally
0.2.0-base: Pulling from hhiroshell/pack
3713021b0277: Already exists
b8d22795b29f: Pull complete
Digest: sha256:e914b59c36cd8dd90fdd05a98233219b2518d29629be775cbd058747fea8af63
Status: Downloaded newer image for ghcr.io/hhiroshell/pack:0.2.0-base
# echo aaaa
aaaa

$ docker run --rm -it --entrypoint sh ghcr.io/hhiroshell/pack:base
Unable to find image 'ghcr.io/hhiroshell/pack:base' locally
base: Pulling from hhiroshell/pack
Digest: sha256:e914b59c36cd8dd90fdd05a98233219b2518d29629be775cbd058747fea8af63
Status: Downloaded newer image for ghcr.io/hhiroshell/pack:base
# echo aaaa
aaaa
```

- The `pack:latest` and `pack:xxx` doesn't have `sh`, because based on the distroless

```
$ docker run --rm -it --entrypoint sh ghcr.io/hhiroshell/pack:latest
Unable to find image 'ghcr.io/hhiroshell/pack:latest' locally
latest: Pulling from hhiroshell/pack
f531499c6b73: Pull complete
...
Digest: sha256:5ff2af78112489da719204239161dc98d32927f5c40b72cc8bab5ab726467c77
Status: Downloaded newer image for ghcr.io/hhiroshell/pack:latest
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "sh": executable file not found in $PATH: unknown.

$ docker run --rm -it --entrypoint sh ghcr.io/hhiroshell/pack:0.2.0
Unable to find image 'ghcr.io/hhiroshell/pack:0.2.0' locally
0.2.0: Pulling from hhiroshell/pack
Digest: sha256:5ff2af78112489da719204239161dc98d32927f5c40b72cc8bab5ab726467c77
Status: Downloaded newer image for ghcr.io/hhiroshell/pack:0.2.0
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "sh": executable file not found in $PATH: unknown.
```


## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2111 
