### PR TITLE
Fix ephemeral bridge network name for podman

### DIFF
--- a/internal/build/lifecycle_execution.go
+++ b/internal/build/lifecycle_execution.go
@@ -211,7 +211,7 @@ func (l *LifecycleExecution) Run(ctx context.Context, phaseFactoryCreator PhaseF
 		if l.os == "windows" {
 			driver = "nat"
 		}
-		networkName := fmt.Sprintf("pack.local/network/%x", randString(10))
+		networkName := fmt.Sprintf("pack.local-network-%x", randString(10))
 		resp, err := l.docker.NetworkCreate(ctx, networkName, types.NetworkCreate{
 			Driver: driver,
 		})

--- a/internal/build/lifecycle_execution_test.go
+++ b/internal/build/lifecycle_execution_test.go
@@ -804,7 +804,7 @@ func testLifecycleExecution(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 
 				for _, entry := range fakePhaseFactory.NewCalledWithProvider {
-					h.AssertContains(t, string(entry.HostConfig().NetworkMode), "pack.local/network/")
+					h.AssertContains(t, string(entry.HostConfig().NetworkMode), "pack.local-network-")
 					h.AssertEq(t, entry.HostConfig().NetworkMode.IsDefault(), false)
 					h.AssertEq(t, entry.HostConfig().NetworkMode.IsHost(), false)
 					h.AssertEq(t, entry.HostConfig().NetworkMode.IsNone(), false)


### PR DESCRIPTION
See https://github.com/buildpacks/pack/issues/2219#issuecomment-2260923340

