### PR TITLE
handled case sensitivity

### DIFF
--- a/pkg/cache/cache_opts.go
+++ b/pkg/cache/cache_opts.go
@@ -66,7 +66,7 @@ func (c *CacheOpts) Set(value string) error {
 			return errors.Errorf("invalid field '%s' must be a key=value pair", field)
 		}
 		key := strings.ToLower(parts[0])
-		value := strings.ToLower(parts[1])
+		value := parts[1]
 		if key == "type" {
 			switch value {
 			case "build":
@@ -86,7 +86,7 @@ func (c *CacheOpts) Set(value string) error {
 			return errors.Errorf("invalid field '%s' must be a key=value pair", field)
 		}
 		key := strings.ToLower(parts[0])
-		value := strings.ToLower(parts[1])
+		value := parts[1]
 		switch key {
 		case "format":
 			switch value {

--- a/pkg/cache/cache_opts_test.go
+++ b/pkg/cache/cache_opts_test.go
@@ -235,6 +235,16 @@ func testCacheOpts(t *testing.T, when spec.G, it spec.S) {
 						input:  fmt.Sprintf("type=launch;format=bind;source=%s/test-bind-volume-cache", homeDir),
 						output: fmt.Sprintf("type=build;format=volume;type=launch;format=bind;source=%s/test-bind-volume-cache/launch-cache;", homeDir),
 					},
+					{
+						name:   "Case sensitivity test with uppercase path",
+						input:  fmt.Sprintf("type=build;format=bind;source=%s/TestBindBuildCache", homeDir),
+						output: fmt.Sprintf("type=build;format=bind;source=%s/TestBindBuildCache/build-cache;type=launch;format=volume;", homeDir),
+					},
+					{
+						name:   "Case sensitivity test with mixed case path",
+						input:  fmt.Sprintf("type=build;format=bind;source=%s/TeStBiNdBuildCaChe", homeDir),
+						output: fmt.Sprintf("type=build;format=bind;source=%s/TeStBiNdBuildCaChe/build-cache;type=launch;format=volume;", homeDir),
+					},
 				}
 			} else {
 				testcases = []CacheOptTestCase{
@@ -252,6 +262,17 @@ func testCacheOpts(t *testing.T, when spec.G, it spec.S) {
 						name:   "Launch cache as bind",
 						input:  fmt.Sprintf("type=launch;format=bind;source=%s\\test-bind-volume-cache", homeDir),
 						output: fmt.Sprintf("type=build;format=volume;type=launch;format=bind;source=%s\\test-bind-volume-cache\\launch-cache;", homeDir),
+					},
+					// Case sensitivity test cases for Windows
+					{
+						name:   "Case sensitivity test with uppercase path",
+						input:  fmt.Sprintf("type=build;format=bind;source=%s\\TestBindBuildCache", homeDir),
+						output: fmt.Sprintf("type=build;format=bind;source=%s\\TestBindBuildCache\\build-cache;type=launch;format=volume;", homeDir),
+					},
+					{
+						name:   "Case sensitivity test with mixed case path",
+						input:  fmt.Sprintf("type=build;format=bind;source=%s\\TeStBiNdBuildCaChe", homeDir),
+						output: fmt.Sprintf("type=build;format=bind;source=%s\\TeStBiNdBuildCaChe\\build-cache;type=launch;format=volume;", homeDir),
 					},
 				}
 			}


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->
When calling pack build using the --cache flag to bind a directory containing uppercase letters, pack incorrectly converts the directory to lowercase. Now this is handled. Have removed the `.toLowerCase()` function from `value.`
## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2229
