### PR TITLE
Add .grype.yaml file to ignore known false positives from scans

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,3 @@
+ignore:
+  - vulnerability: CVE-2015-5237 # false positive, see https://github.com/anchore/grype/issues/558
+  - vulnerability: CVE-2021-22570 # false positive, see https://github.com/anchore/grype/issues/558


### PR DESCRIPTION
We do this for the lifecycle: https://github.com/buildpacks/lifecycle/blob/main/.grype.yaml