### PR TITLE
Fix deletion of ephemeral builder

### DIFF
--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -535,6 +535,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		buildEnvs[k] = v
 	}
 
+	origBuilderName := rawBuilderImage.Name()
 	ephemeralBuilder, err := c.createEphemeralBuilder(
 		rawBuilderImage,
 		buildEnvs,
@@ -549,7 +550,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		return err
 	}
 	defer func() {
-		if ephemeralBuilder.Name() == rawBuilderImage.Name() {
+		if ephemeralBuilder.Name() == origBuilderName {
 			return
 		}
 		_, _ = c.docker.ImageRemove(context.Background(), ephemeralBuilder.Name(), types.RemoveOptions{Force: true})


### PR DESCRIPTION
`createEphemeralBuilder` mutates the provided `rawBuilderImage`, so we must save the image name before this method is called.

## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
