### PR TITLE
Don't warn about clear-env key while parsing buildpack.toml as this is actually expected.

### DIFF
--- a/pkg/buildpack/buildpack_test.go
+++ b/pkg/buildpack/buildpack_test.go
@@ -514,6 +514,7 @@ id = "bp.one"
 version = "1.2.3"
 homepage = "http://geocities.com/cool-bp"
 sbom-formats = ["this should not warn"]
+clear-env = true
 
 [[targets]]
 os = "some-os"

--- a/pkg/dist/buildmodule.go
+++ b/pkg/dist/buildmodule.go
@@ -21,6 +21,7 @@ type ModuleInfo struct {
 	Homepage    string    `toml:"homepage,omitempty" json:"homepage,omitempty" yaml:"homepage,omitempty"`
 	Keywords    []string  `toml:"keywords,omitempty" json:"keywords,omitempty" yaml:"keywords,omitempty"`
 	Licenses    []License `toml:"licenses,omitempty" json:"licenses,omitempty" yaml:"licenses,omitempty"`
+	ClearEnv    bool      `toml:"clear-env,omitempty" json:"clear-env,omitempty" yaml:"clear-env,omitempty"`
 }
 
 func (b ModuleInfo) FullName() string {


### PR DESCRIPTION
Fixes https://github.com/buildpacks/pack/issues/2253

## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
```
24: Pulling from heroku/builder
Digest: sha256:28390a2f5e326a0e32f041e934c0d509757d2aab0c33bb9476569557e29b8c99
Status: Image is up to date for heroku/builder:24
24: Pulling from heroku/heroku
Digest: sha256:2363090f27c848b67a06a3a269dac13f042ffeed61af27432bd3bad360ed1d0e
Status: Image is up to date for heroku/heroku:24
Warning: Ignoring unexpected key(s) in descriptor for buildpack testing-buildpack: buildpack.clear-env
Warning: Builder is trusted but additional modules were added; using the untrusted (5 phases) build flow
===> ANALYZING
[analyzer] Image with name "test-image" not found
===> DETECTING
[detector] ========
```
#### After
```
24: Pulling from heroku/builder
Digest: sha256:28390a2f5e326a0e32f041e934c0d509757d2aab0c33bb9476569557e29b8c99
Status: Image is up to date for heroku/builder:24
24: Pulling from heroku/heroku
Digest: sha256:2363090f27c848b67a06a3a269dac13f042ffeed61af27432bd3bad360ed1d0e
Status: Image is up to date for heroku/heroku:24
Warning: Builder is trusted but additional modules were added; using the untrusted (5 phases) build flow
===> ANALYZING
[analyzer] Image with name "test-image" not found
===> DETECTING
[detector] ======== 
```
## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2253
