### PR TITLE
Allow trusted builders by repo or tag

### DIFF
--- a/internal/builder/trusted_builder_test.go
+++ b/internal/builder/trusted_builder_test.go
@@ -1,0 +1,102 @@
+package builder_test
+
+import (
+	"testing"
+
+	"github.com/heroku/color"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	bldr "github.com/buildpacks/pack/internal/builder"
+	"github.com/buildpacks/pack/internal/config"
+
+	h "github.com/buildpacks/pack/testhelpers"
+)
+
+func TestTrustedBuilder(t *testing.T) {
+	color.Disable(true)
+	defer color.Disable(false)
+	spec.Run(t, "Trusted Builder", trustedBuilder, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+func trustedBuilder(t *testing.T, when spec.G, it spec.S) {
+	when("IsKnownTrustedBuilder", func() {
+		it("matches exactly", func() {
+			h.AssertTrue(t, bldr.IsKnownTrustedBuilder("paketobuildpacks/builder-jammy-base"))
+			h.AssertFalse(t, bldr.IsKnownTrustedBuilder("paketobuildpacks/builder-jammy-base:latest"))
+			h.AssertFalse(t, bldr.IsKnownTrustedBuilder("paketobuildpacks/builder-jammy-base:1.2.3"))
+			h.AssertFalse(t, bldr.IsKnownTrustedBuilder("my/private/builder"))
+		})
+	})
+
+	when("IsTrustedBuilder", func() {
+		it("trust image without tag", func() {
+			cfg := config.Config{
+				TrustedBuilders: []config.TrustedBuilder{
+					{
+						Name: "my/trusted/builder-jammy",
+					},
+				},
+			}
+
+			trustedBuilders := []string{
+				"my/trusted/builder-jammy",
+				"my/trusted/builder-jammy:latest",
+				"my/trusted/builder-jammy:1.2.3",
+			}
+
+			untrustedBuilders := []string{
+				"my/private/builder",            // random builder
+				"my/trusted/builder-jammy-base", // shared prefix
+			}
+
+			for _, builder := range trustedBuilders {
+				isTrusted, err := bldr.IsTrustedBuilder(cfg, builder)
+				h.AssertNil(t, err)
+				h.AssertTrue(t, isTrusted)
+			}
+
+			for _, builder := range untrustedBuilders {
+				isTrusted, err := bldr.IsTrustedBuilder(cfg, builder)
+				h.AssertNil(t, err)
+				h.AssertFalse(t, isTrusted)
+			}
+		})
+		it("trust image with tag", func() {
+			cfg := config.Config{
+				TrustedBuilders: []config.TrustedBuilder{
+					{
+						Name: "my/trusted/builder-jammy:1.2.3",
+					},
+					{
+						Name: "my/trusted/builder-jammy:latest",
+					},
+				},
+			}
+
+			trustedBuilders := []string{
+				"my/trusted/builder-jammy:1.2.3",
+				"my/trusted/builder-jammy:latest",
+			}
+
+			untrustedBuilders := []string{
+				"my/private/builder",
+				"my/trusted/builder-jammy",
+				"my/trusted/builder-jammy:2.0.0",
+				"my/trusted/builder-jammy-base",
+			}
+
+			for _, builder := range trustedBuilders {
+				isTrusted, err := bldr.IsTrustedBuilder(cfg, builder)
+				h.AssertNil(t, err)
+				h.AssertTrue(t, isTrusted)
+			}
+
+			for _, builder := range untrustedBuilders {
+				isTrusted, err := bldr.IsTrustedBuilder(cfg, builder)
+				h.AssertNil(t, err)
+				h.AssertFalse(t, isTrusted)
+			}
+		})
+	})
+}

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -12,6 +12,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	bldr "github.com/buildpacks/pack/internal/builder"
+
 	"github.com/buildpacks/pack/internal/config"
 	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/pkg/cache"
@@ -110,7 +112,11 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				return err
 			}
 
-			trustBuilder := isTrustedBuilder(cfg, builder) || flags.TrustBuilder
+			isTrusted, err := bldr.IsTrustedBuilder(cfg, builder)
+			if err != nil {
+				return err
+			}
+			trustBuilder := isTrusted || bldr.IsKnownTrustedBuilder(builder) || flags.TrustBuilder
 			if trustBuilder {
 				logger.Debugf("Builder %s is trusted", style.Symbol(builder))
 				if flags.LifecycleImage != "" {

--- a/internal/commands/builder_inspect.go
+++ b/internal/commands/builder_inspect.go
@@ -8,6 +8,8 @@ import (
 	"github.com/buildpacks/pack/internal/config"
 	"github.com/buildpacks/pack/pkg/client"
 	"github.com/buildpacks/pack/pkg/logging"
+
+	bldr "github.com/buildpacks/pack/internal/builder"
 )
 
 type BuilderInspector interface {
@@ -61,10 +63,15 @@ func inspectBuilder(
 	inspector BuilderInspector,
 	writerFactory writer.BuilderWriterFactory,
 ) error {
+	isTrusted, err := bldr.IsTrustedBuilder(cfg, imageName)
+	if err != nil {
+		return err
+	}
+
 	builderInfo := writer.SharedBuilderInfo{
 		Name:      imageName,
 		IsDefault: imageName == cfg.DefaultBuilder,
-		Trusted:   isTrustedBuilder(cfg, imageName),
+		Trusted:   isTrusted,
 	}
 
 	localInfo, localErr := inspector.InspectBuilder(imageName, true, client.WithDetectionOrderDepth(flags.Depth))

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -7,8 +7,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/buildpacks/pack/internal/builder"
-
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -105,16 +103,6 @@ func getMirrors(config config.Config) map[string][]string {
 		mirrors[ri.Image] = ri.Mirrors
 	}
 	return mirrors
-}
-
-func isTrustedBuilder(cfg config.Config, builderName string) bool {
-	for _, trustedBuilder := range cfg.TrustedBuilders {
-		if builderName == trustedBuilder.Name {
-			return true
-		}
-	}
-
-	return builder.IsKnownTrustedBuilder(builderName)
 }
 
 func deprecationWarning(logger logging.Logger, oldCmd, replacementCmd string) {

--- a/internal/commands/config_trusted_builder.go
+++ b/internal/commands/config_trusted_builder.go
@@ -51,7 +51,11 @@ func addTrustedBuilder(args []string, logger logging.Logger, cfg config.Config, 
 	imageName := args[0]
 	builderToTrust := config.TrustedBuilder{Name: imageName}
 
-	if isTrustedBuilder(cfg, imageName) {
+	isTrusted, err := bldr.IsTrustedBuilder(cfg, imageName)
+	if err != nil {
+		return err
+	}
+	if isTrusted || bldr.IsKnownTrustedBuilder(imageName) {
 		logger.Infof("Builder %s is already trusted", style.Symbol(imageName))
 		return nil
 	}


### PR DESCRIPTION
## Summary

With this change, the tag part of a trusted builder is ignored. Trusting a builder `my/registry/builder` at the moment does not also trust `my/registry/builder:latest`, which should be the same image. Following up on a Slack [discussion](https://cloud-native.slack.com/archives/C0331B61A1Y/p1726214408262059), it might be more intuitive for users to trust an image regardless of any tag.

I took the opportunity to extract trusted/known builder handling into a common location.

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

