### PR TITLE
Cleanup after running acceptance tests

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -59,3 +59,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           make acceptance
+          docker network prune


### PR DESCRIPTION
While we try to cleanup after ourselves, it doesn't always work.
This will save us from having to RDP into the LCOW worker every so often

Signed-off-by: Natalie Arellano <narellano@vmware.com>
