### PR TITLE
Emit a performance warning if containerd is enabled and we're exporting to the daemon

### DIFF
--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -304,6 +304,11 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 			"Re-run with '--pull-policy=always' to silence this warning.")
 	}
 
+	if !opts.Publish && usesContainerdStorage(c.docker) {
+		c.logger.Warnf("Exporting to docker daemon (building without --publish) and daemon uses containerd storage; performance may be significantly degraded.\n" +
+			"For more information, see https://github.com/buildpacks/pack/issues/2272.")
+	}
+
 	imageRef, err := c.parseReference(opts)
 	if err != nil {
 		return errors.Wrapf(err, "invalid image name '%s'", opts.Image)
@@ -801,6 +806,21 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		return fmt.Errorf("executing lifecycle: %w", err)
 	}
 	return c.logImageNameAndSha(ctx, opts.Publish, imageRef)
+}
+
+func usesContainerdStorage(docker DockerClient) bool {
+	info, err := docker.Info(context.Background())
+	if err != nil {
+		return false
+	}
+
+	for _, driverStatus := range info.DriverStatus {
+		if driverStatus[0] == "driver-type" && driverStatus[1] == "io.containerd.snapshotter.v1" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getTargetFromBuilder(builderImage imgutil.Image) (*dist.Target, error) {


### PR DESCRIPTION
Addresses https://github.com/buildpacks/pack/issues/2272#issuecomment-2426435484 `#1`

(Potentially simpler) alternative to https://github.com/buildpacks/imgutil/pull/285