### PR TITLE
Remove deprecated stack validation

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -2181,13 +2181,13 @@ func testAcceptance(
 								imageManager.CleanupImages(runImageName)
 							})
 
-							it("fails with a message", func() {
+							it("continues with a warning", func() {
 								output, err := pack.Run(
 									"build", repoName,
 									"-p", filepath.Join("testdata", "mock_app"),
 									"--run-image", runImageName,
 								)
-								assert.NotNil(err)
+								assert.Nil(err)
 
 								assertOutput := assertions.NewOutputAssertionManager(t, output)
 								assertOutput.ReportsRunImageStackNotMatchingBuilder(

--- a/acceptance/assertions/output.go
+++ b/acceptance/assertions/output.go
@@ -114,7 +114,7 @@ func (o OutputAssertionManager) ReportsRunImageStackNotMatchingBuilder(runImageS
 
 	o.assert.Contains(
 		o.output,
-		fmt.Sprintf("run-image stack id '%s' does not match builder stack '%s'", runImageStack, builderStack),
+		fmt.Sprintf("Warning: run-image stack id '%s' does not match builder stack '%s' (deprecated usage of stack)", runImageStack, builderStack),
 	)
 }
 

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -531,14 +531,14 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, fakeRunImage.SetLabel("io.buildpacks.stack.id", "other.stack"))
 				})
 
-				it("errors", func() {
-					h.AssertError(t, subject.Build(context.TODO(), BuildOptions{
+				it("warning", func() {
+					err := subject.Build(context.TODO(), BuildOptions{
 						Image:    "some/app",
 						Builder:  defaultBuilderName,
 						RunImage: "custom/run",
-					}),
-						"invalid run-image 'custom/run': run-image stack id 'other.stack' does not match builder stack 'some.stack.id'",
-					)
+					})
+					h.AssertNil(t, err)
+					h.AssertContains(t, outBuf.String(), "Warning: run-image stack id 'other.stack' does not match builder stack 'some.stack.id' (deprecated usage of stack)")
 				})
 			})
 


### PR DESCRIPTION
## Summary
Continues with a warning instead of an error

## Output
Warning: No schema version declared in project.toml, defaulting to schema version 0.1
latest: Pulling from paketobuildpacks/builder-jammy-base
Digest: sha256:a298c00780bd587a8867adbaed0baf6196b3b114f635acb7d2c33455327f6f46
Status: Image is up to date for paketobuildpacks/builder-jammy-base:latest
latest: Pulling from buildpacks/builder/php
Digest: sha256:91065e07a53b1c048fcaf8e49936a9d19c388b2dfdf2e7e589885aab2f5aae79
Status: Image is up to date for gcr.io/buildpacks/builder/php:latest
Warning: run-image stack id 'google' does not match builder stack 'io.buildpacks.stacks.jammy' (deprecated usage of stack)

#### Before

build process was exiting giving an error message

#### After

build process continues with a warning

## Related
Continuation of PR #2119 

Fixes #2104 
