### PR TITLE
Removing validation of deprecated io.buildpacks.stack.id

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -2185,7 +2185,24 @@ func testAcceptance(
 								imageManager.CleanupImages(runImageName)
 							})
 
+							it("fails with a message", func() {
+								h.SkipIf(t, pack.SupportsFeature(invoke.StackWarning), "stack is validated in prior versions")
+								output, err := pack.Run(
+									"build", repoName,
+									"-p", filepath.Join("testdata", "mock_app"),
+									"--run-image", runImageName,
+								)
+								assert.NotNil(err)
+
+								assertOutput := assertions.NewOutputAssertionManager(t, output)
+								assertOutput.ReportsRunImageStackNotMatchingBuilder(
+									"other.stack.id",
+									"pack.test.stack",
+								)
+							})
+
 							it("succeeds with a warning", func() {
+								h.SkipIf(t, !pack.SupportsFeature(invoke.StackWarning), "stack is no longer validated")
 								output, err := pack.Run(
 									"build", repoName,
 									"-p", filepath.Join("testdata", "mock_app"),
@@ -2194,7 +2211,7 @@ func testAcceptance(
 								assert.Nil(err)
 
 								assertOutput := assertions.NewOutputAssertionManager(t, output)
-								assertOutput.ReportsRunImageStackNotMatchingBuilder()
+								assertOutput.ReportsDeprecatedUseOfStack()
 							})
 						})
 					})

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -2185,19 +2185,16 @@ func testAcceptance(
 								imageManager.CleanupImages(runImageName)
 							})
 
-							it("fails with a message", func() {
+							it("succeeds with a warning", func() {
 								output, err := pack.Run(
 									"build", repoName,
 									"-p", filepath.Join("testdata", "mock_app"),
 									"--run-image", runImageName,
 								)
-								assert.NotNil(err)
+								assert.Nil(err)
 
 								assertOutput := assertions.NewOutputAssertionManager(t, output)
-								assertOutput.ReportsRunImageStackNotMatchingBuilder(
-									"other.stack.id",
-									"pack.test.stack",
-								)
+								assertOutput.ReportsRunImageStackNotMatchingBuilder()
 							})
 						})
 					})

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -2185,38 +2185,45 @@ func testAcceptance(
 								imageManager.CleanupImages(runImageName)
 							})
 
-							it("fails with a message", func() {
+							when("should validate stack", func() {
 								it.Before(func() {
 									h.SkipIf(t, pack.SupportsFeature(invoke.StackWarning), "stack is validated in prior versions")
 								})
-								output, err := pack.Run(
-									"build", repoName,
-									"-p", filepath.Join("testdata", "mock_app"),
-									"--run-image", runImageName,
-								)
-								assert.NotNil(err)
+								it("fails with a message", func() {
 
-								assertOutput := assertions.NewOutputAssertionManager(t, output)
-								assertOutput.ReportsRunImageStackNotMatchingBuilder(
-									"other.stack.id",
-									"pack.test.stack",
-								)
+									output, err := pack.Run(
+										"build", repoName,
+										"-p", filepath.Join("testdata", "mock_app"),
+										"--run-image", runImageName,
+									)
+									assert.NotNil(err)
+
+									assertOutput := assertions.NewOutputAssertionManager(t, output)
+									assertOutput.ReportsRunImageStackNotMatchingBuilder(
+										"other.stack.id",
+										"pack.test.stack",
+									)
+								})
 							})
 
-							it("succeeds with a warning", func() {
+							when("should not validate stack", func() {
 								it.Before(func() {
 									h.SkipIf(t, !pack.SupportsFeature(invoke.StackWarning), "stack is no longer validated")
 								})
-								output, err := pack.Run(
-									"build", repoName,
-									"-p", filepath.Join("testdata", "mock_app"),
-									"--run-image", runImageName,
-								)
-								assert.Nil(err)
+								it("succeeds with a warning", func() {
 
-								assertOutput := assertions.NewOutputAssertionManager(t, output)
-								assertOutput.ReportsDeprecatedUseOfStack()
+									output, err := pack.Run(
+										"build", repoName,
+										"-p", filepath.Join("testdata", "mock_app"),
+										"--run-image", runImageName,
+									)
+									assert.Nil(err)
+
+									assertOutput := assertions.NewOutputAssertionManager(t, output)
+									assertOutput.ReportsDeprecatedUseOfStack()
+								})
 							})
+
 						})
 					})
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -2186,7 +2186,9 @@ func testAcceptance(
 							})
 
 							it("fails with a message", func() {
-								h.SkipIf(t, pack.SupportsFeature(invoke.StackWarning), "stack is validated in prior versions")
+								it.Before(func() {
+									h.SkipIf(t, pack.SupportsFeature(invoke.StackWarning), "stack is validated in prior versions")
+								})
 								output, err := pack.Run(
 									"build", repoName,
 									"-p", filepath.Join("testdata", "mock_app"),
@@ -2202,7 +2204,9 @@ func testAcceptance(
 							})
 
 							it("succeeds with a warning", func() {
-								h.SkipIf(t, !pack.SupportsFeature(invoke.StackWarning), "stack is no longer validated")
+								it.Before(func() {
+									h.SkipIf(t, !pack.SupportsFeature(invoke.StackWarning), "stack is no longer validated")
+								})
 								output, err := pack.Run(
 									"build", repoName,
 									"-p", filepath.Join("testdata", "mock_app"),

--- a/acceptance/assertions/output.go
+++ b/acceptance/assertions/output.go
@@ -109,13 +109,10 @@ func (o OutputAssertionManager) ReportsSkippingRestore() {
 	o.assert.Contains(o.output, "Skipping 'restore' due to clearing cache")
 }
 
-func (o OutputAssertionManager) ReportsRunImageStackNotMatchingBuilder(runImageStack, builderStack string) {
+func (o OutputAssertionManager) ReportsRunImageStackNotMatchingBuilder() {
 	o.testObject.Helper()
 
-	o.assert.Contains(
-		o.output,
-		fmt.Sprintf("run-image stack id '%s' does not match builder stack '%s'", runImageStack, builderStack),
-	)
+	o.assert.Contains(o.output, "Warning: deprecated usage of stack")
 }
 
 func (o OutputAssertionManager) WithoutColors() {

--- a/acceptance/assertions/output.go
+++ b/acceptance/assertions/output.go
@@ -109,7 +109,16 @@ func (o OutputAssertionManager) ReportsSkippingRestore() {
 	o.assert.Contains(o.output, "Skipping 'restore' due to clearing cache")
 }
 
-func (o OutputAssertionManager) ReportsRunImageStackNotMatchingBuilder() {
+func (o OutputAssertionManager) ReportsRunImageStackNotMatchingBuilder(runImageStack, builderStack string) {
+	o.testObject.Helper()
+
+	o.assert.Contains(
+		o.output,
+		fmt.Sprintf("run-image stack id '%s' does not match builder stack '%s'", runImageStack, builderStack),
+	)
+}
+
+func (o OutputAssertionManager) ReportsDeprecatedUseOfStack() {
 	o.testObject.Helper()
 
 	o.assert.Contains(o.output, "Warning: deprecated usage of stack")

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -241,6 +241,7 @@ const (
 	ManifestCommands
 	PlatformOption
 	MultiPlatformBuildersAndBuildPackages
+	StackWarning
 )
 
 var featureTests = map[Feature]func(i *PackInvoker) bool{
@@ -285,6 +286,9 @@ var featureTests = map[Feature]func(i *PackInvoker) bool{
 	},
 	MultiPlatformBuildersAndBuildPackages: func(i *PackInvoker) bool {
 		return i.atLeast("v0.34.0")
+	},
+	StackWarning: func(i *PackInvoker) bool {
+		return !i.atLeast("v0.37.0")
 	},
 }
 

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -288,7 +288,7 @@ var featureTests = map[Feature]func(i *PackInvoker) bool{
 		return i.atLeast("v0.34.0")
 	},
 	StackWarning: func(i *PackInvoker) bool {
-		return !i.atLeast("v0.37.0")
+		return i.atLeast("v0.37.0")
 	},
 }
 

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -957,17 +957,7 @@ func (c *Client) validateRunImage(context context.Context, name string, opts ima
 	}
 
 	if stackID != expectedStack {
-		v, err := semver.NewVersion(c.Version())
-		if err != nil {
-			return nil, nil, fmt.Errorf("error parsing pack client version: %w", err)
-		}
-		shouldValidateStack := v.LessThan(semver.MustParse("0.37.0"))
-		if shouldValidateStack {
-			err = fmt.Errorf("run-image stack id '%s' does not match builder stack '%s'", stackID, expectedStack)
-		} else {
-			warnings = append(warnings, "deprecated usage of stack")
-		}
-		return img, warnings, err
+		warnings = append(warnings, "deprecated usage of stack")
 	}
 
 	return img, warnings, err

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -405,9 +405,12 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		pathsConfig.targetRunImagePath = targetRunImagePath
 		pathsConfig.hostRunImagePath = hostRunImagePath
 	}
-	runImage, err := c.validateRunImage(ctx, runImageName, fetchOptions, bldr.StackID)
+	runImage, warnings, err := c.validateRunImage(ctx, runImageName, fetchOptions, bldr.StackID)
 	if err != nil {
 		return errors.Wrapf(err, "invalid run-image '%s'", runImageName)
+	}
+	for _, warning := range warnings {
+		c.logger.Warn(warning)
 	}
 
 	var runMixins []string
@@ -939,22 +942,22 @@ func (c *Client) getBuilder(img imgutil.Image) (*builder.Builder, error) {
 	return bldr, nil
 }
 
-func (c *Client) validateRunImage(context context.Context, name string, opts image.FetchOptions, expectedStack string) (imgutil.Image, error) {
+func (c *Client) validateRunImage(context context.Context, name string, opts image.FetchOptions, expectedStack string) (runImage imgutil.Image, warnings []string, err error) {
 	if name == "" {
-		return nil, errors.New("run image must be specified")
+		return nil, nil, errors.New("run image must be specified")
 	}
 	img, err := c.imageFetcher.Fetch(context, name, opts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	stackID, err := img.Label("io.buildpacks.stack.id")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if stackID != expectedStack {
-		return nil, fmt.Errorf("run-image stack id '%s' does not match builder stack '%s'", stackID, expectedStack)
+		warnings = append(warnings, "deprecated usage of stack")
 	}
-	return img, nil
+	return img, warnings, nil
 }
 
 func (c *Client) validateMixins(additionalBuildpacks []buildpack.BuildModule, bldr *builder.Builder, runImageName string, runMixins []string) error {

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -287,7 +287,8 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 						AppPath: filepath.Join("testdata", "some-app"),
 					}))
 
-					h.AssertEq(t, strings.TrimSpace(outBuf.String()), "some/app@sha256:363c754893f0efe22480b4359a5956cf3bd3ce22742fc576973c61348308c2e4")
+					actual := strings.TrimSpace(outBuf.String())
+					h.AssertEq(t, actual, "some/app@sha256:363c754893f0efe22480b4359a5956cf3bd3ce22742fc576973c61348308c2e4")
 				})
 			})
 		})
@@ -531,14 +532,14 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, fakeRunImage.SetLabel("io.buildpacks.stack.id", "other.stack"))
 				})
 
-				it("errors", func() {
-					h.AssertError(t, subject.Build(context.TODO(), BuildOptions{
+				it("warning", func() {
+					err := subject.Build(context.TODO(), BuildOptions{
 						Image:    "some/app",
 						Builder:  defaultBuilderName,
 						RunImage: "custom/run",
-					}),
-						"invalid run-image 'custom/run': run-image stack id 'other.stack' does not match builder stack 'some.stack.id'",
-					)
+					})
+					h.AssertNil(t, err)
+					h.AssertContains(t, outBuf.String(), "Warning: deprecated usage of stack")
 				})
 			})
 

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -533,6 +533,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("warning", func() {
+					subject.version = "0.37.0"
 					err := subject.Build(context.TODO(), BuildOptions{
 						Image:    "some/app",
 						Builder:  defaultBuilderName,

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -287,8 +287,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 						AppPath: filepath.Join("testdata", "some-app"),
 					}))
 
-					actual := strings.TrimSpace(outBuf.String())
-					h.AssertEq(t, actual, "some/app@sha256:363c754893f0efe22480b4359a5956cf3bd3ce22742fc576973c61348308c2e4")
+					h.AssertEq(t, strings.TrimSpace(outBuf.String()), "some/app@sha256:363c754893f0efe22480b4359a5956cf3bd3ce22742fc576973c61348308c2e4")
 				})
 			})
 		})

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -533,7 +533,6 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("warning", func() {
-					subject.version = "0.37.0"
 					err := subject.Build(context.TODO(), BuildOptions{
 						Image:    "some/app",
 						Builder:  defaultBuilderName,


### PR DESCRIPTION
## Summary
This PR picks up where https://github.com/buildpacks/pack/pull/2119 left off.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
<img width="1151" alt="Screenshot 2024-11-27 at 4 17 14 PM" src="https://github.com/user-attachments/assets/709d5199-43ad-4fb3-be3f-da3f235e53cf">

#### After
<img width="1213" alt="Screenshot 2024-11-27 at 4 26 28 PM" src="https://github.com/user-attachments/assets/ac1f719e-ab56-4dd1-b474-162c8317eb44">

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves https://github.com/buildpacks/pack/issues/2104
