### PR TITLE
Correct wording for `buildpack new` targets flag

### DIFF
--- a/internal/commands/buildpack_new.go
+++ b/internal/commands/buildpack_new.go
@@ -104,7 +104,7 @@ func BuildpackNew(logger logging.Logger, creator BuildpackCreator) *cobra.Comman
 	cmd.Flags().StringSliceVarP(&flags.Stacks, "stacks", "s", nil, "Stack(s) this buildpack will be compatible with"+stringSliceHelp("stack"))
 	cmd.Flags().MarkDeprecated("stacks", "prefer `--targets` instead: https://github.com/buildpacks/rfcs/blob/main/text/0096-remove-stacks-mixins.md")
 	cmd.Flags().StringSliceVarP(&flags.Targets, "targets", "t", nil,
-		`Targets are the list platforms that one targeting, these are generated as part of scaffolding inside buildpack.toml file. one can provide target platforms in format [os][/arch][/variant]:[distroname@osversion@anotherversion];[distroname@osversion]
+		`Targets are of the form 'os/arch/variant', for example 'linux/amd64' or 'linux/arm64/v9'. The full format for targets follows the form [os][/arch][/variant]:[distroname@osversion@anotherversion];[distroname@osversion]
 	- Base case for two different architectures :  '--targets "linux/amd64" --targets "linux/arm64"'
 	- case for distribution version: '--targets "windows/amd64:windows-nano@10.0.19041.1415"'
 	- case for different architecture with distributed versions : '--targets "linux/arm/v6:ubuntu@14.04"  --targets "linux/arm/v6:ubuntu@16.04"'


### PR DESCRIPTION
## Summary

I'm not a native speaker, but the output from 
`pack buildpack new`
regarding the flag `--targets` confuses me. I hope my change/suggestion makes it more understandable.

## Output


#### Before

```
Error: accepts 1 arg(s), received 0
Usage:
  pack buildpack new <id> [flags]

Examples:
pack buildpack new sample/my-buildpack

Flags:
  -a, --api string        Buildpack API compatibility of the generated buildpack (default "0.8")
  -h, --help              Help for 'new'
  -p, --path string       Path to generate the buildpack
  -t, --targets strings   Targets are the list platforms that one targeting, these are generated as part of scaffolding inside buildpack.toml file. one can provide target platforms in format [os][/arch][/variant]:[distroname@osversion@anotherversion];[distroname@osversion]
                          	- Base case for two different architectures :  '--targets "linux/amd64" --targets "linux/arm64"'
                          	- case for distribution version: '--targets "windows/amd64:windows-nano@10.0.19041.1415"'
                          	- case for different architecture with distributed versions : '--targets "linux/arm/v6:ubuntu@14.04"  --targets "linux/arm/v6:ubuntu@16.04"'

  -V, --version string    Version of the generated buildpack (default "1.0.0")

Global Flags:
      --force-color   Force color output
      --no-color      Disable color output
  -q, --quiet         Show less output
      --timestamps    Enable timestamps in output
  -v, --verbose       Show more output
```

#### After

```
Usage:
  pack buildpack new <id> [flags]

Examples:
pack buildpack new sample/my-buildpack

Flags:
  -a, --api string        Buildpack API compatibility of the generated buildpack (default "0.8")
  -h, --help              Help for 'new'
  -p, --path string       Path to generate the buildpack
  -t, --targets strings   Targets are of the form 'os/arch/variant', for example 'linux/amd64' or 'linux/arm64/v9'. The full format for targets follows the form [os][/arch][/variant]:[distroname@osversion@anotherversion];[distroname@osversion]
                          	- Base case for two different architectures :  '--targets "linux/amd64" --targets "linux/arm64"'
                          	- case for distribution version: '--targets "windows/amd64:windows-nano@10.0.19041.1415"'
                          	- case for different architecture with distributed versions : '--targets "linux/arm/v6:ubuntu@14.04"  --targets "linux/arm/v6:ubuntu@16.04"'
                          	
  -V, --version string    Version of the generated buildpack (default "1.0.0")

Global Flags:
      --force-color   Force color output
      --no-color      Disable color output
  -q, --quiet         Show less output
      --timestamps    Enable timestamps in output
  -v, --verbose       Show more output

```

## Documentation
- Should this change be documented?
    - [ ] Yes, see #___
    - [X] No