### PR TITLE
Update hardcoded error message to pull images without architecture

### DIFF
--- a/pkg/image/fetcher.go
+++ b/pkg/image/fetcher.go
@@ -123,8 +123,8 @@ func (f *Fetcher) Fetch(ctx context.Context, name string, options FetchOptions) 
 		// Sample error from docker engine:
 		// `image with reference <image> was found but does not match the specified platform: wanted linux/amd64, actual: linux`
 		if strings.Contains(err.Error(), "does not match the specified platform") &&
-			(strings.HasSuffix(strings.TrimSpace(err.Error()), "actual: linux") ||
-				strings.HasSuffix(strings.TrimSpace(err.Error()), "actual: windows")) {
+			(strings.Contains(strings.TrimSpace(err.Error()), "its platform (linux)") ||
+				strings.Contains(strings.TrimSpace(err.Error()), "its platform (windows)")) {
 			f.logger.Debugf(fmt.Sprintf("Pulling image %s", style.Symbol(name)))
 			err = f.pullImage(ctx, name, "")
 		}

--- a/pkg/image/fetcher.go
+++ b/pkg/image/fetcher.go
@@ -121,10 +121,9 @@ func (f *Fetcher) Fetch(ctx context.Context, name string, options FetchOptions) 
 		// FIXME: this matching is brittle and the fallback should be removed when https://github.com/buildpacks/pack/issues/2079
 		// has been fixed for a sufficient amount of time.
 		// Sample error from docker engine:
-		// `image with reference <image> was found but does not match the specified platform: wanted linux/amd64, actual: linux`
-		if strings.Contains(err.Error(), "does not match the specified platform") &&
-			(strings.Contains(strings.TrimSpace(err.Error()), "its platform (linux)") ||
-				strings.Contains(strings.TrimSpace(err.Error()), "its platform (windows)")) {
+		// `image with reference <image> was found but does not match the specified platform: wanted linux/amd64, actual: linux` or
+		// `image with reference <image> was found but its platform (linux) does not match the specified platform (linux/amd64)`
+		if strings.Contains(err.Error(), "does not match the specified platform") {
 			f.logger.Debugf(fmt.Sprintf("Pulling image %s", style.Symbol(name)))
 			err = f.pullImage(ctx, name, "")
 		}


### PR DESCRIPTION
## Summary

When the `--platform` flag was released, we wanted to keep compatibility with old buildpacks where `architecture` was not specified, we also didn't want to add an overhead on trying to pull an image when it doesn't exist in the registry.

The way we did it was to parse the error message returned by the pulling operation and try to match some strings, the message was `changed` in the upstream docker dependency and this ticket is just updating it.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

```bash
> pack build my-app -b gcr.io/paketo-buildpacks/nodejs:latest
Warning: Ignoring the provided lifecycle image as the builder is trusted, running the creator in a single container using the provided builder
...
Digest: sha256:ba59495fdb04ec023b79119ae9f0cf811a2d3f4b873db1ec545edcff4434b8b2
Status: Downloaded newer image for gcr.io/paketo-buildpacks/nodejs:latest
ERROR: failed to build: downloading buildpack: extracting from registry gcr.io/paketo-buildpacks/nodejs:latest: fetching image: image with reference gcr.io/paketo-buildpacks/nodejs:latest was found but its platform (linux) does not match the specified platform (linux/amd64)
```

We can see the error message: 

```bash
image with reference gcr.io/paketo-buildpacks/nodejs:latest was found but its platform (linux) does not match the specified platform (linux/amd64)
```

Is the new one updated in the upstream dependecy

#### After

```bash
> /home/juan/go/src/github.com/buildpacks/pack/out/pack build my-app -b gcr.io/paketo-buildpacks/nodejs:latest
Warning: Ignoring the provided lifecycle image as the builder is trusted, running the creator in a single container using the provided builder
latest: Pulling from paketobuildpacks/builder-jammy-base
...
Status: Image is up to date for gcr.io/paketo-buildpacks/nodejs:latest
latest: Pulling from paketo-buildpacks/nodejs
Digest: sha256:ba59495fdb04ec023b79119ae9f0cf811a2d3f4b873db1ec545edcff4434b8b2
Status: Image is up to date for gcr.io/paketo-buildpacks/nodejs:latest
Warning: Builder is trusted but additional modules were added; using the untrusted (5 phases) build flow
0.19.3: Pulling from buildpacksio/lifecycle
Digest: sha256:3184c0c4028b6ca18e851388f3dd54c10fcaea5e6f1e43cf660d0647be69d6cf
Status: Image is up to date for buildpacksio/lifecycle:0.19.3
===> ANALYZING
```
`pack` is pulling the image using an empty platform again once the error message match the condition to retry.

## Note
This solution is not the best, but it will unblock pack users for now

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2315
