### PR TITLE
Remove obsolete // +build lines

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package acceptance
 

--- a/acceptance/assertions/image.go
+++ b/acceptance/assertions/image.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package assertions
 

--- a/acceptance/assertions/lifecycle_output.go
+++ b/acceptance/assertions/lifecycle_output.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package assertions
 

--- a/acceptance/assertions/output.go
+++ b/acceptance/assertions/output.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package assertions
 

--- a/acceptance/assertions/test_buildpack_output.go
+++ b/acceptance/assertions/test_buildpack_output.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package assertions
 

--- a/acceptance/buildpacks/archive_buildpack.go
+++ b/acceptance/buildpacks/archive_buildpack.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package buildpacks
 

--- a/acceptance/buildpacks/folder_buildpack.go
+++ b/acceptance/buildpacks/folder_buildpack.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package buildpacks
 

--- a/acceptance/buildpacks/manager.go
+++ b/acceptance/buildpacks/manager.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package buildpacks
 

--- a/acceptance/buildpacks/package_file_buildpack.go
+++ b/acceptance/buildpacks/package_file_buildpack.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package buildpacks
 

--- a/acceptance/buildpacks/package_image_buildpack.go
+++ b/acceptance/buildpacks/package_image_buildpack.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package buildpacks
 

--- a/acceptance/config/asset_manager.go
+++ b/acceptance/config/asset_manager.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package config
 

--- a/acceptance/config/github_asset_fetcher.go
+++ b/acceptance/config/github_asset_fetcher.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package config
 

--- a/acceptance/config/input_configuration_manager.go
+++ b/acceptance/config/input_configuration_manager.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package config
 

--- a/acceptance/config/lifecycle_asset.go
+++ b/acceptance/config/lifecycle_asset.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package config
 

--- a/acceptance/config/pack_assets.go
+++ b/acceptance/config/pack_assets.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package config
 

--- a/acceptance/config/run_combination.go
+++ b/acceptance/config/run_combination.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package config
 

--- a/acceptance/invoke/pack.go
+++ b/acceptance/invoke/pack.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package invoke
 

--- a/acceptance/invoke/pack_fixtures.go
+++ b/acceptance/invoke/pack_fixtures.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package invoke
 

--- a/acceptance/managers/image_manager.go
+++ b/acceptance/managers/image_manager.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package managers
 

--- a/acceptance/os/variables.go
+++ b/acceptance/os/variables.go
@@ -1,5 +1,4 @@
 //go:build acceptance && !windows
-// +build acceptance,!windows
 
 package os
 

--- a/acceptance/os/variables_darwin.go
+++ b/acceptance/os/variables_darwin.go
@@ -1,5 +1,4 @@
 //go:build acceptance && darwin && amd64
-// +build acceptance,darwin,amd64
 
 package os
 

--- a/acceptance/os/variables_darwin_arm64.go
+++ b/acceptance/os/variables_darwin_arm64.go
@@ -1,5 +1,4 @@
 //go:build acceptance && darwin && arm64
-// +build acceptance,darwin,arm64
 
 package os
 

--- a/acceptance/os/variables_linux.go
+++ b/acceptance/os/variables_linux.go
@@ -1,5 +1,4 @@
 //go:build acceptance && linux
-// +build acceptance,linux
 
 package os
 

--- a/acceptance/os/variables_windows.go
+++ b/acceptance/os/variables_windows.go
@@ -1,5 +1,4 @@
 //go:build acceptance && windows
-// +build acceptance,windows
 
 package os
 

--- a/acceptance/suite_manager.go
+++ b/acceptance/suite_manager.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package acceptance
 

--- a/benchmarks/build_test.go
+++ b/benchmarks/build_test.go
@@ -1,5 +1,4 @@
 //go:build benchmarks
-// +build benchmarks
 
 package benchmarks
 

--- a/internal/paths/defaults_unix.go
+++ b/internal/paths/defaults_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package paths
 

--- a/internal/sshdialer/posix_test.go
+++ b/internal/sshdialer/posix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package sshdialer_test
 

--- a/internal/sshdialer/ssh_agent_unix.go
+++ b/internal/sshdialer/ssh_agent_unix.go
@@ -1,5 +1,4 @@
 //go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package sshdialer
 

--- a/internal/sshdialer/windows_test.go
+++ b/internal/sshdialer/windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package sshdialer_test
 

--- a/pkg/client/example_build_test.go
+++ b/pkg/client/example_build_test.go
@@ -1,5 +1,4 @@
 //go:build !windows && example
-// +build !windows,example
 
 package client_test
 

--- a/pkg/client/example_buildpack_downloader_test.go
+++ b/pkg/client/example_buildpack_downloader_test.go
@@ -1,5 +1,4 @@
 //go:build !windows && example
-// +build !windows,example
 
 package client_test
 

--- a/pkg/client/example_fetcher_test.go
+++ b/pkg/client/example_fetcher_test.go
@@ -1,5 +1,4 @@
 //go:build !windows && example
-// +build !windows,example
 
 package client_test
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package tools
 


### PR DESCRIPTION
## Summary

Get rid of obsolete `// +build` lines that are deprecated.

https://tip.golang.org/doc/go1.18#go-build-lines

## Documentation

- Should this change be documented?
    - [ ] Yes
    - [X] No

## Related

Corresponding lifecycle change: https://github.com/buildpacks/lifecycle/pull/1431
