### PR TITLE
Use `unix` build constraint

### DIFF
--- a/internal/paths/defaults_unix.go
+++ b/internal/paths/defaults_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build unix
 
 package paths
 

--- a/internal/sshdialer/ssh_agent_unix.go
+++ b/internal/sshdialer/ssh_agent_unix.go
@@ -1,4 +1,4 @@
-//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+//go:build unix
 
 package sshdialer
 

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build unix
 
 package archive
 


### PR DESCRIPTION
## Summary

Simplify go:build constraints that include `linux` and `darwin` to unix. This can potentially also support `freebsd` in the future.

The constraint unix is available since Go 1.19: https://tip.golang.org/doc/go1.19#go-unix

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [X] No

## Related

Similar change in `lifecycle`: https://github.com/buildpacks/lifecycle/pull/1432
