### PR TITLE
Add try-always pull policy and unit tests

### DIFF
--- a/internal/builder/image_fetcher_wrapper.go
+++ b/internal/builder/image_fetcher_wrapper.go
@@ -19,6 +19,7 @@ type ImageFetcher interface {
 	// the behavior is dictated by the pull policy, which can have the following behavior
 	//   - PullNever: returns false
 	//   - PullAlways Or PullIfNotPresent: it will check read access for the remote image.
+	//   - PullIfAvailable: it will check read access for the remote image, if the image is not found then false.
 	// When FetchOptions.Daemon is false it will check read access for the remote image.
 	CheckReadAccess(repo string, options image.FetchOptions) bool
 }

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -275,7 +275,7 @@ This option may set DOCKER_HOST environment variable for the build container if 
 `)
 	cmd.Flags().StringVar(&buildFlags.LifecycleImage, "lifecycle-image", cfg.LifecycleImage, `Custom lifecycle image to use for analysis, restore, and export when builder is untrusted.`)
 	cmd.Flags().StringVar(&buildFlags.Platform, "platform", "", `Platform to build on (e.g., "linux/amd64").`)
-	cmd.Flags().StringVar(&buildFlags.Policy, "pull-policy", "", `Pull policy to use. Accepted values are always, never, and if-not-present. (default "always")`)
+	cmd.Flags().StringVar(&buildFlags.Policy, "pull-policy", "", `Pull policy to use. Accepted values are always, never, if-not-present and try-always. (default "always")`)
 	cmd.Flags().StringVarP(&buildFlags.Registry, "buildpack-registry", "r", cfg.DefaultRegistryName, "Buildpack Registry by name")
 	cmd.Flags().StringVar(&buildFlags.RunImage, "run-image", "", "Run image (defaults to default stack's run image)")
 	cmd.Flags().StringSliceVarP(&buildFlags.AdditionalTags, "tag", "t", nil, "Additional tags to push the output image to.\nTags should be in the format 'image:tag' or 'repository/image:tag'."+stringSliceHelp("tag"))

--- a/internal/commands/builder_create.go
+++ b/internal/commands/builder_create.go
@@ -131,7 +131,7 @@ Creating a custom builder allows you to control what buildpacks are used and wha
 	cmd.Flags().StringVarP(&flags.BuilderTomlPath, "config", "c", "", "Path to builder TOML file (required)")
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, "Publish the builder directly to the container registry specified in <image-name>, instead of the daemon.")
 	cmd.Flags().BoolVar(&flags.AppendImageNameSuffix, "append-image-name-suffix", false, "When publishing to a registry that doesn't allow overwrite existing tags use this flag to append a [os]-[arch] suffix to <image-name>")
-	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
+	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, if-not-present and try-always. The default is always")
 	cmd.Flags().StringArrayVar(&flags.Flatten, "flatten", nil, "List of buildpacks to flatten together into a single layer (format: '<buildpack-id>@<buildpack-version>,<buildpack-id>@<buildpack-version>'")
 	cmd.Flags().StringToStringVarP(&flags.Label, "label", "l", nil, "Labels to add to the builder image, in the form of '<name>=<value>'")
 	cmd.Flags().StringSliceVarP(&flags.Targets, "target", "t", nil,

--- a/internal/commands/buildpack_package.go
+++ b/internal/commands/buildpack_package.go
@@ -170,7 +170,7 @@ func BuildpackPackage(logger logging.Logger, cfg config.Config, packager Buildpa
 	cmd.Flags().StringVarP(&flags.Format, "format", "f", "", `Format to save package as ("image" or "file")`)
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, `Publish the buildpack directly to the container registry specified in <name>, instead of the daemon (applies to "--format=image" only).`)
 	cmd.Flags().BoolVar(&flags.AppendImageNameSuffix, "append-image-name-suffix", false, "When publishing to a registry that doesn't allow overwrite existing tags use this flag to append a [os]-[arch] suffix to package <name>")
-	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
+	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, if-not-present and try-always. The default is always")
 	cmd.Flags().StringVarP(&flags.Path, "path", "p", "", "Path to the Buildpack that needs to be packaged")
 	cmd.Flags().StringVarP(&flags.BuildpackRegistry, "buildpack-registry", "r", "", "Buildpack Registry name")
 	cmd.Flags().BoolVar(&flags.Flatten, "flatten", false, "Flatten the buildpack into a single layer")

--- a/internal/commands/config_pull_policy.go
+++ b/internal/commands/config_pull_policy.go
@@ -16,12 +16,12 @@ func ConfigPullPolicy(logger logging.Logger, cfg config.Config, cfgPath string) 
 	var unset bool
 
 	cmd := &cobra.Command{
-		Use:   "pull-policy <always | if-not-present | never>",
+		Use:   "pull-policy <always | if-not-present | never | try-always>",
 		Args:  cobra.MaximumNArgs(1),
 		Short: "List, set and unset the global pull policy used by other commands",
 		Long: "You can use this command to list, set, and unset the default pull policy that will be used when working with containers:\n" +
 			"* To list your pull policy, run `pack config pull-policy`.\n" +
-			"* To set your pull policy, run `pack config pull-policy <always | if-not-present | never>`.\n" +
+			"* To set your pull policy, run `pack config pull-policy <always | if-not-present | never | try-always>`.\n" +
 			"* To unset your pull policy, run `pack config pull-policy --unset`.\n" +
 			fmt.Sprintf("Unsetting the pull policy will reset the policy to the default, which is %s", style.Symbol("always")),
 		RunE: logError(logger, func(cmd *cobra.Command, args []string) error {

--- a/internal/commands/config_pull_policy_test.go
+++ b/internal/commands/config_pull_policy_test.go
@@ -96,6 +96,18 @@ func testConfigPullPolicyCommand(t *testing.T, when spec.G, it spec.S) {
 					assert.Contains(outBuf.String(), "if-not-present")
 				})
 			})
+
+			when("policy set to try-always in config", func() {
+				it("lists try-always as pull policy", func() {
+					cfg.PullPolicy = "try-always"
+					command = commands.ConfigPullPolicy(logger, cfg, configFile)
+					command.SetArgs([]string{})
+
+					h.AssertNil(t, command.Execute())
+
+					assert.Contains(outBuf.String(), "try-always")
+				})
+			})
 		})
 		when("set", func() {
 			when("policy provided is the same as configured pull policy", func() {

--- a/internal/commands/create_builder.go
+++ b/internal/commands/create_builder.go
@@ -90,6 +90,6 @@ Creating a custom builder allows you to control what buildpacks are used and wha
 	}
 	cmd.Flags().StringVarP(&flags.BuilderTomlPath, "config", "c", "", "Path to builder TOML file (required)")
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, "Publish the builder directly to the container registry specified in <image-name>, instead of the daemon.")
-	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
+	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, if-not-present and try-always. The default is always")
 	return cmd
 }

--- a/internal/commands/extension_package.go
+++ b/internal/commands/extension_package.go
@@ -103,7 +103,7 @@ func ExtensionPackage(logger logging.Logger, cfg config.Config, packager Extensi
 	cmd.Flags().StringVarP(&flags.PackageTomlPath, "config", "c", "", "Path to package TOML config")
 	cmd.Flags().StringVarP(&flags.Format, "format", "f", "", `Format to save package as ("image" or "file")`)
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, `Publish the extension directly to the container registry specified in <name>, instead of the daemon (applies to "--format=image" only).`)
-	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
+	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, if-not-present and try-always. The default is always")
 	AddHelpFlag(cmd, "package")
 	return cmd
 }

--- a/internal/commands/package_buildpack.go
+++ b/internal/commands/package_buildpack.go
@@ -86,7 +86,7 @@ func PackageBuildpack(logger logging.Logger, cfg config.Config, packager Buildpa
 
 	cmd.Flags().StringVarP(&flags.Format, "format", "f", "", `Format to save package as ("image" or "file")`)
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, `Publish the buildpack directly to the container registry specified in <name>, instead of the daemon (applies to "--format=image" only).`)
-	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
+	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, if-not-present and try-always. The default is always")
 	cmd.Flags().StringVarP(&flags.BuildpackRegistry, "buildpack-registry", "r", "", "Buildpack Registry name")
 
 	AddHelpFlag(cmd, "package-buildpack")

--- a/internal/commands/package_buildpack_test.go
+++ b/internal/commands/package_buildpack_test.go
@@ -129,6 +129,17 @@ func testPackageBuildpackCommand(t *testing.T, when spec.G, it spec.S) {
 					receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
 					h.AssertEq(t, receivedOptions.PullPolicy, image.PullAlways)
 				})
+
+				it("pull-policy=try-always sets policy", func() {
+					args = append(args, "--pull-policy", "try-always")
+					cmd.SetArgs(args)
+
+					err := cmd.Execute()
+					h.AssertNil(t, err)
+
+					receivedOptions := fakeBuildpackPackager.CreateCalledWithOptions
+					h.AssertEq(t, receivedOptions.PullPolicy, image.PullIfAvailable)
+				})
 				it("takes precedence over a configured pull policy", func() {
 					logger := logging.NewLogWithWriters(&bytes.Buffer{}, &bytes.Buffer{})
 					configReader := fakes.NewFakePackageConfigReader()

--- a/internal/commands/rebase.go
+++ b/internal/commands/rebase.go
@@ -48,7 +48,7 @@ func Rebase(logger logging.Logger, cfg config.Config, pack PackClient) *cobra.Co
 
 	cmd.Flags().BoolVar(&opts.Publish, "publish", false, "Publish the rebased application image directly to the container registry specified in <image-name>, instead of the daemon. The previous application image must also reside in the registry.")
 	cmd.Flags().StringVar(&opts.RunImage, "run-image", "", "Run image to use for rebasing")
-	cmd.Flags().StringVar(&policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
+	cmd.Flags().StringVar(&policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, if-not-present and try-always. The default is always")
 	cmd.Flags().StringVar(&opts.PreviousImage, "previous-image", "", "Image to rebase. Set to a particular tag reference, digest reference, or (when performing a daemon build) image ID. Use this flag in combination with <image-name> to avoid replacing the original image.")
 	cmd.Flags().StringVar(&opts.ReportDestinationDir, "report-output-dir", "", "Path to export build report.toml.\nOmitting the flag yield no report file.")
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "Perform rebase operation without target validation (only available for API >= 0.12)")

--- a/internal/fakes/fake_image_fetcher.go
+++ b/internal/fakes/fake_image_fetcher.go
@@ -65,5 +65,5 @@ func shouldPull(localFound, remoteFound bool, policy image.PullPolicy) bool {
 		return true
 	}
 
-	return remoteFound && policy == image.PullAlways
+	return remoteFound && (policy == image.PullAlways || policy == image.PullIfAvailable)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -54,6 +54,7 @@ type ImageFetcher interface {
 	//   - PullNever: try to use the daemon to return a `local.Image`.
 	//   - PullIfNotPResent: try look to use the daemon to return a `local.Image`, if none is found  fetch a remote image.
 	//   - PullAlways: it will only try to fetch a remote image.
+	//	 - PullIfAvailable: it will try to fetch a remote image, if none is found it will try to use the daemon to return a `local.Image`.
 	//
 	// These PullPolicies that these interact with the daemon argument.
 	// PullIfNotPresent and daemon = false, gives us the same behavior as PullAlways.
@@ -65,6 +66,7 @@ type ImageFetcher interface {
 	// the behavior is dictated by the pull policy, which can have the following behavior
 	//   - PullNever: returns false
 	//   - PullAlways Or PullIfNotPresent: it will check read access for the remote image.
+	//   - PullIfAvailable: it will check read access for the remote image, if the image is not found then false.
 	// When FetchOptions.Daemon is false it will check read access for the remote image.
 	CheckReadAccess(repo string, options image.FetchOptions) bool
 }

--- a/pkg/image/fetcher.go
+++ b/pkg/image/fetcher.go
@@ -128,10 +128,13 @@ func (f *Fetcher) Fetch(ctx context.Context, name string, options FetchOptions) 
 			err = f.pullImage(ctx, name, "")
 		}
 	}
-	if err != nil && !errors.Is(err, ErrNotFound) {
+
+	if err != nil {
+		if errors.Is(err, ErrNotFound) && options.PullPolicy == PullIfAvailable {
+			return f.fetchDaemonImage(name)
+		}
 		return nil, err
 	}
-
 	return f.fetchDaemonImage(name)
 }
 

--- a/pkg/image/pull_policy.go
+++ b/pkg/image/pull_policy.go
@@ -14,9 +14,11 @@ const (
 	PullNever
 	// PullIfNotPresent pulls images if they aren't present
 	PullIfNotPresent
+	// PullIfAvailable pulls images if they are available in the registry else check locally
+	PullIfAvailable
 )
 
-var nameMap = map[string]PullPolicy{"always": PullAlways, "never": PullNever, "if-not-present": PullIfNotPresent, "": PullAlways}
+var nameMap = map[string]PullPolicy{"always": PullAlways, "never": PullNever, "if-not-present": PullIfNotPresent, "try-always": PullIfAvailable, "": PullAlways}
 
 // ParsePullPolicy from string
 func ParsePullPolicy(policy string) (PullPolicy, error) {
@@ -35,6 +37,8 @@ func (p PullPolicy) String() string {
 		return "never"
 	case PullIfNotPresent:
 		return "if-not-present"
+	case PullIfAvailable:
+		return "try-always"
 	}
 
 	return ""

--- a/pkg/image/pull_policy_test.go
+++ b/pkg/image/pull_policy_test.go
@@ -34,6 +34,12 @@ func testPullPolicy(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, policy, image.PullIfNotPresent)
 		})
 
+		it("returns PullIfAvailable for try-always", func() {
+			policy, err := image.ParsePullPolicy("try-always")
+			h.AssertNil(t, err)
+			h.AssertEq(t, policy, image.PullIfAvailable)
+		})
+
 		it("defaults to PullAlways, if empty string", func() {
 			policy, err := image.ParsePullPolicy("")
 			h.AssertNil(t, err)
@@ -51,6 +57,7 @@ func testPullPolicy(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, image.PullAlways.String(), "always")
 			h.AssertEq(t, image.PullNever.String(), "never")
 			h.AssertEq(t, image.PullIfNotPresent.String(), "if-not-present")
+			h.AssertEq(t, image.PullIfAvailable.String(), "try-always")
 		})
 	})
 }


### PR DESCRIPTION
## Summary
This PR adds a new pull-policy called `try-always`. 
This policy first checks if an image is present in the remote registry and pulls it if available. If the image is not available on remote then it falls back to the local and looks for the image with the daemon.
The `try-always` pull-policy follows a behaviour opposite to `if-not-present` as it checks the remote first and then checks the local. 

## Output

#### Before
- If we used the pull-policy of `always` and the image was not there on remote then pack would give an error.
- If we used the pull-policy of `if-not-present` then it would only pull if we didn't have it locally.

#### After
- Now using `try-always` we can have a custom image locally and still pull a fresh new image from the remote.
- If the image is not found on remote then instead of giving error it will fall back to using the locally available image. 

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2201 
