### PR TITLE
Add as suggested builder the ubi8 builder image

### DIFF
--- a/internal/builder/trusted_builder.go
+++ b/internal/builder/trusted_builder.go
@@ -71,6 +71,13 @@ var KnownBuilders = []KnownBuilder{
 		Suggested:          true,
 		Trusted:            true,
 	},
+	{
+		Vendor:             "Paketo Buildpacks",
+		Image:              "paketobuildpacks/builder-ubi8-base",
+		DefaultDescription: "Universal Base Image (RHEL8) with buildpacks to build Node.js or Java runtimes. Support also the new extension feature (aka apply Dockerfile)",
+		Suggested:          true,
+		Trusted:            true,
+	},
 }
 
 func IsKnownTrustedBuilder(builderName string) bool {


### PR DESCRIPTION
## Summary

Add as suggested/trusted builder the ubi8 builder image

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes. Ideally this page should be updated to include it: https://paketo.io/docs/reference/builders-reference/. That will be done in a separate PR
    - [ ] No

