### PR TITLE
Do not select target for daemon only from os if arch is specified

### DIFF
--- a/pkg/client/package_buildpack.go
+++ b/pkg/client/package_buildpack.go
@@ -281,10 +281,11 @@ func (c *Client) daemonTarget(ctx context.Context, targets []dist.Target) (dist.
 	if err != nil {
 		return dist.Target{}, err
 	}
+
 	for _, t := range targets {
 		if t.Arch != "" && t.OS == info.Os && t.Arch == info.Arch {
 			return t, nil
-		} else if t.OS == info.Os {
+		} else if t.Arch == "" && t.OS == info.Os {
 			return t, nil
 		}
 	}


### PR DESCRIPTION
## Summary
PR: #2384

Currently when not publishing, pack will find the first target that matches the os of the docker daemon, rather than the os **and** the arch. This makes it so that is not the case.

for old behavior, a target with only os can be added as the last item in the targets array.

```toml
[[targets]]
os = "linux"
arch = "amd64"

[[targets]]
os = "linux"
arch = "arm64"

[[targets]]
os = "linux"
```



## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [x] Yes, see #2384
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2384
