### PR TITLE
  Fix default userns=host behavior to be opt-in

### DIFF
--- a/internal/build/fakes/enable_userns_host.go
+++ b/internal/build/fakes/enable_userns_host.go
@@ -1,0 +1,1 @@
+package fakes

--- a/internal/build/fakes/enable_userns_host.go
+++ b/internal/build/fakes/enable_userns_host.go
@@ -1,1 +1,0 @@
-package fakes

--- a/internal/build/fakes/fake_builder.go
+++ b/internal/build/fakes/fake_builder.go
@@ -122,3 +122,10 @@ func WithBuilder(builder *FakeBuilder) func(*build.LifecycleOptions) {
 		opts.Builder = builder
 	}
 }
+
+// WithEnableUsernsHost creates a LifecycleOptions option that enables userns=host
+func WithEnableUsernsHost() func(*build.LifecycleOptions) {
+	return func(opts *build.LifecycleOptions) {
+		opts.EnableUsernsHost = true
+	}
+}

--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -103,6 +103,7 @@ type LifecycleOptions struct {
 	SBOMDestinationDir              string
 	CreationTime                    *time.Time
 	Keychain                        authn.Keychain
+	EnableUsernsHost                bool
 }
 
 func NewLifecycleExecutor(logger logging.Logger, docker DockerClient) *LifecycleExecutor {

--- a/internal/build/phase_config_provider.go
+++ b/internal/build/phase_config_provider.go
@@ -35,7 +35,9 @@ type PhaseConfigProvider struct {
 
 func NewPhaseConfigProvider(name string, lifecycleExec *LifecycleExecution, ops ...PhaseConfigProviderOperation) *PhaseConfigProvider {
 	hostConf := new(container.HostConfig)
-	hostConf.UsernsMode = "host"
+	if lifecycleExec.opts.EnableUsernsHost {
+		hostConf.UsernsMode = "host"
+	}
 	if lifecycleExec.os != "windows" {
 		hostConf.SecurityOpt = []string{"no-new-privileges=true"}
 	}

--- a/internal/build/phase_config_provider_test.go
+++ b/internal/build/phase_config_provider_test.go
@@ -59,8 +59,23 @@ func testPhaseConfigProvider(t *testing.T, when spec.G, it spec.S) {
 			h.AssertSliceContainsMatch(t, phaseConfigProvider.HostConfig().Binds, "pack-app-.*:/workspace")
 
 			h.AssertEq(t, phaseConfigProvider.HostConfig().Isolation, container.IsolationEmpty)
-			h.AssertEq(t, phaseConfigProvider.HostConfig().UsernsMode, container.UsernsMode("host"))
+			h.AssertEq(t, phaseConfigProvider.HostConfig().UsernsMode, container.UsernsMode(""))
 			h.AssertSliceContains(t, phaseConfigProvider.HostConfig().SecurityOpt, "no-new-privileges=true")
+		})
+
+		when("userns-host is enabled", func() {
+			it("sets user namespace mode to host", func() {
+				expectedBuilderImage := ifakes.NewImage("some-builder-name", "", nil)
+				fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithImage(expectedBuilderImage))
+				h.AssertNil(t, err)
+				lifecycle := newTestLifecycleExec(t, false, "some-temp-dir", fakes.WithBuilder(fakeBuilder))
+				lifecycle.opts.EnableUsernsHost = true
+				expectedPhaseName := "some-name"
+
+				phaseConfigProvider := build.NewPhaseConfigProvider(expectedPhaseName, lifecycle)
+
+				h.AssertEq(t, phaseConfigProvider.HostConfig().UsernsMode, container.UsernsMode("host"))
+			})
 		})
 
 		when("building for Windows", func() {

--- a/internal/build/phase_config_provider_test.go
+++ b/internal/build/phase_config_provider_test.go
@@ -68,8 +68,7 @@ func testPhaseConfigProvider(t *testing.T, when spec.G, it spec.S) {
 				expectedBuilderImage := ifakes.NewImage("some-builder-name", "", nil)
 				fakeBuilder, err := fakes.NewFakeBuilder(fakes.WithImage(expectedBuilderImage))
 				h.AssertNil(t, err)
-				lifecycle := newTestLifecycleExec(t, false, "some-temp-dir", fakes.WithBuilder(fakeBuilder))
-				lifecycle.opts.EnableUsernsHost = true
+				lifecycle := newTestLifecycleExec(t, false, "some-temp-dir", fakes.WithBuilder(fakeBuilder), fakes.WithEnableUsernsHost())
 				expectedPhaseName := "some-name"
 
 				phaseConfigProvider := build.NewPhaseConfigProvider(expectedPhaseName, lifecycle)

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -59,6 +59,7 @@ type BuildFlags struct {
 	DateTime             string
 	PreBuildpacks        []string
 	PostBuildpacks       []string
+	EnableUsernsHost     bool
 }
 
 // Build an image from source code
@@ -209,6 +210,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				CreationTime:             dateTime,
 				PreBuildpacks:            flags.PreBuildpacks,
 				PostBuildpacks:           flags.PostBuildpacks,
+				EnableUsernsHost:         flags.EnableUsernsHost,
 				LayoutConfig: &client.LayoutConfig{
 					Sparse:             flags.Sparse,
 					InputImage:         inputImageName,
@@ -290,6 +292,7 @@ This option may set DOCKER_HOST environment variable for the build container if 
 	cmd.Flags().StringVar(&buildFlags.ReportDestinationDir, "report-output-dir", "", "Path to export build report.toml.\nOmitting the flag yield no report file.")
 	cmd.Flags().BoolVar(&buildFlags.Interactive, "interactive", false, "Launch a terminal UI to depict the build process")
 	cmd.Flags().BoolVar(&buildFlags.Sparse, "sparse", false, "Use this flag to avoid saving on disk the run-image layers when the application image is exported to OCI layout format")
+	cmd.Flags().BoolVar(&buildFlags.EnableUsernsHost, "userns-host", false, "Enable user namespace isolation for the build containers")
 	if !cfg.Experimental {
 		cmd.Flags().MarkHidden("interactive")
 		cmd.Flags().MarkHidden("sparse")

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -225,6 +225,9 @@ type BuildOptions struct {
 
 	// Configuration to export to OCI layout format
 	LayoutConfig *LayoutConfig
+
+	// Enable user namespace isolation for the build containers
+	EnableUsernsHost bool
 }
 
 func (b *BuildOptions) Layout() bool {
@@ -647,6 +650,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		CreationTime:             opts.CreationTime,
 		Layout:                   opts.Layout(),
 		Keychain:                 c.keychain,
+		EnableUsernsHost:         opts.EnableUsernsHost,
 	}
 
 	switch {


### PR DESCRIPTION
## Summary

The flag `--userns-host` is now required to enable the user namespace isolation for build containers. By default, this is disabled, which resolves the incompatibility with Docker plugins that don't support "userns as host" functionality.

This reverts the default behavior from pack 0.35.0 where user namespace isolation was enabled by default, while still allowing users who want this feature to opt in.

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2369
