### PR TITLE
Adding Unit Tests for Issue: `pack builder create` does not accurately build for targets when not publishing

### DIFF
--- a/pkg/client/testdata/buildpack-multi-platform/buildpack-new-format/linux/buildpack.toml
+++ b/pkg/client/testdata/buildpack-multi-platform/buildpack-new-format/linux/buildpack.toml
@@ -1,0 +1,17 @@
+api = "0.10"
+
+[buildpack]
+id = "samples/multi-platform"
+version = "0.0.1"
+
+[[targets]]
+os = "linux"
+arch = "amd64"
+
+[[targets]]
+os = "linux"
+arch = "arm64"
+
+[[stacks]]
+id = "*"
+


### PR DESCRIPTION
## Summary

The current daemonTarget function in pack has a flawed target selection logic that prevents proper multi-architecture builds when not publishing.  This issue was fixed with PR [2388](https://github.com/buildpacks/pack/pull/2388). This PR adds some unit tests that I was unable to include in the original PR because the fork doesn't allow any changes.

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related

Resolves #2385 
