### PR TITLE
upding delivery workflow to correct the wrong format

### DIFF
--- a/.github/workflows/delivery-ubuntu.yml
+++ b/.github/workflows/delivery-ubuntu.yml
@@ -67,7 +67,7 @@ jobs:
             # following steps per variant.
             ###
 
-          - name: Deliver {{matrix.target}}
+          - name: Deliver ${{ matrix.target }}
             uses: docker://ubuntu:${{ matrix.target }}
             with:
               entrypoint: .github/workflows/delivery/ubuntu/deliver.sh


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->

Fixes incorrect matrix variable syntax in the Ubuntu delivery workflow step name. The workflow was using token replacement syntax (`{{matrix.target}}`) instead of the proper GitHub Actions matrix syntax (`${{ matrix.target }}`), causing the workflow to fail during execution.

This change aligns the step name syntax with how matrix variables are correctly used elsewhere in the same workflow, ensuring consistent behavior across all Ubuntu target versions (bionic, focal, jammy, noble, oracular, plucky).

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before
```yaml
- name: Deliver {{matrix.target}}
  uses: docker://ubuntu:${{ matrix.target }}
  with:
    entrypoint: .github/workflows/delivery/ubuntu/deliver.sh
```

#### After
```yaml
- name: Deliver ${{ matrix.target }}
  uses: docker://ubuntu:${{ matrix.target }}
  with:
    entrypoint: .github/workflows/delivery/ubuntu/deliver.sh
```

The change ensures the step name will properly interpolate to values like "Deliver bionic", "Deliver focal", etc., instead of literally displaying "Deliver {{matrix.target}}" in the workflow execution logs.

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2397
