### PR TITLE
Updating to Ubuntu jammy the delivery workflow

### DIFF
--- a/.github/workflows/delivery-ubuntu.yml
+++ b/.github/workflows/delivery-ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
         fail-fast: false
         matrix:
           target: [bionic, focal, jammy, noble, oracular, plucky]
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
       steps:
           - name: Checkout code
             uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Ubuntu Runner 20.04 was deprecated see (https://github.com/actions/runner-images/issues/11101) updating to 22.04

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #2397 
