### PR TITLE
fix(commands): issues with dockerhost/podman

### DIFF
--- a/.github/workflows/delivery-docker.yml
+++ b/.github/workflows/delivery-docker.yml
@@ -61,7 +61,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
-      - uses: buildpacks/github-actions/setup-tools@v5.9.1
+      - uses: buildpacks/github-actions/setup-tools@v5.9.2
       - name: Buildx Build/Publish
         run: |
           docker buildx build . \

--- a/internal/commands/builder_create.go
+++ b/internal/commands/builder_create.go
@@ -27,6 +27,7 @@ type BuilderCreateFlags struct {
 	Flatten               []string
 	Targets               []string
 	Label                 map[string]string
+	DockerHost            string
 }
 
 // CreateBuilder creates a builder image, based on a builder config
@@ -131,6 +132,7 @@ Creating a custom builder allows you to control what buildpacks are used and wha
 				Labels:                flags.Label,
 				Targets:               multiArchCfg.Targets(),
 				TempDirectory:         tempDir,
+				DockerHost:            flags.DockerHost,
 			}); err != nil {
 				return err
 			}
@@ -156,6 +158,12 @@ Creating a custom builder allows you to control what buildpacks are used and wha
 - To specify the distribution version: '--target "linux/arm/v6:ubuntu@14.04"'
 - To specify multiple distribution versions: '--target "linux/arm/v6:ubuntu@14.04"  --target "linux/arm/v6:ubuntu@16.04"'
 	`)
+	cmd.Flags().StringVar(&flags.DockerHost, "docker-host", "",
+		`Address to docker daemon that will be exposed to the build container.
+If not set (or set to empty string) the standard socket location will be used.
+Special value 'inherit' may be used in which case DOCKER_HOST environment variable will be used.
+This option may set DOCKER_HOST environment variable for the build container if needed.
+`)
 
 	AddHelpFlag(cmd, "create")
 	return cmd

--- a/internal/commands/buildpack_package.go
+++ b/internal/commands/buildpack_package.go
@@ -31,6 +31,7 @@ type BuildpackPackageFlags struct {
 	Publish               bool
 	Flatten               bool
 	AppendImageNameSuffix bool
+	DockerHost            string
 }
 
 // BuildpackPackager packages buildpacks
@@ -148,6 +149,7 @@ func BuildpackPackage(logger logging.Logger, cfg config.Config, packager Buildpa
 				FlattenExclude:        flags.FlattenExclude,
 				Labels:                flags.Label,
 				Targets:               multiArchCfg.Targets(),
+				DockerHost:            flags.DockerHost,
 			}); err != nil {
 				return err
 			}
@@ -183,6 +185,10 @@ Targets should be in the format '[os][/arch][/variant]:[distroname@osversion@ano
 - To specify the distribution version: '--target "linux/arm/v6:ubuntu@14.04"'
 - To specify multiple distribution versions: '--target "linux/arm/v6:ubuntu@14.04"  --target "linux/arm/v6:ubuntu@16.04"'
 	`)
+	cmd.Flags().StringVar(&flags.DockerHost, "docker-host", "",
+		`Address to docker daemon that will be exposed to the build container.
+If not set (or set to empty string) the standard socket location will be used.
+Special value 'inherit' may be used in which case the value from DOCKER_HOST environment variable will be used.`)
 	if !cfg.Experimental {
 		cmd.Flags().MarkHidden("flatten")
 		cmd.Flags().MarkHidden("flatten-exclude")

--- a/internal/commands/extension_package.go
+++ b/internal/commands/extension_package.go
@@ -25,6 +25,7 @@ type ExtensionPackageFlags struct {
 	Publish         bool
 	Policy          string
 	Path            string
+	DockerHost      string
 }
 
 // ExtensionPackager packages extensions
@@ -121,6 +122,7 @@ func ExtensionPackage(logger logging.Logger, cfg config.Config, packager Extensi
 				Publish:         flags.Publish,
 				PullPolicy:      pullPolicy,
 				Targets:         multiArchCfg.Targets(),
+				DockerHost:      flags.DockerHost,
 			}); err != nil {
 				return err
 			}
@@ -152,6 +154,10 @@ Targets should be in the format '[os][/arch][/variant]:[distroname@osversion@ano
 - To specify the distribution version: '--target "linux/arm/v6:ubuntu@14.04"'
 - To specify multiple distribution versions: '--target "linux/arm/v6:ubuntu@14.04"  --target "linux/arm/v6:ubuntu@16.04"'
 	`)
+	cmd.Flags().StringVar(&flags.DockerHost, "docker-host", "",
+		`Address to docker daemon that will be exposed to the build container.
+If not set (or set to empty string) the standard socket location will be used.
+Special value 'inherit' may be used in which case the value from DOCKER_HOST environment variable will be used.`)
 	AddHelpFlag(cmd, "package")
 	return cmd
 }

--- a/pkg/client/create_builder.go
+++ b/pkg/client/create_builder.go
@@ -67,6 +67,10 @@ type CreateBuilderOptions struct {
 
 	// Temporary directory to use for downloading lifecycle images.
 	TempDirectory string
+
+	// Address of docker daemon exposed to build container
+	// e.g. tcp://example.com:1234, unix:///run/user/1000/podman/podman.sock
+	DockerHost string
 }
 
 // CreateBuilder creates and saves a builder image to a registry with the provided options.

--- a/pkg/client/create_builder.go
+++ b/pkg/client/create_builder.go
@@ -85,7 +85,7 @@ func (c *Client) CreateBuilder(ctx context.Context, opts CreateBuilderOptions) e
 		if host != "" {
 			OS.Setenv("DOCKER_HOST", host)
 			newDocker, err := client.NewClientWithOpts(
-				client.WithHost(host),
+				client.FromEnv,
 				client.WithVersion(DockerAPIVersion),
 			)
 			if err != nil {

--- a/pkg/client/create_builder.go
+++ b/pkg/client/create_builder.go
@@ -10,13 +10,14 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/buildpacks/pack/internal/name"
-
 	"github.com/Masterminds/semver"
 	"github.com/buildpacks/imgutil"
+	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+
+	"github.com/buildpacks/pack/internal/name"
 
 	pubbldr "github.com/buildpacks/pack/builder"
 	"github.com/buildpacks/pack/internal/builder"
@@ -25,7 +26,6 @@ import (
 	"github.com/buildpacks/pack/pkg/buildpack"
 	"github.com/buildpacks/pack/pkg/dist"
 	"github.com/buildpacks/pack/pkg/image"
-	"github.com/docker/docker/client"
 )
 
 // CreateBuilderOptions is a configuration object used to change the behavior of

--- a/pkg/client/package_buildpack.go
+++ b/pkg/client/package_buildpack.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/buildpacks/pack/internal/name"
-
+	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
+
+	"github.com/buildpacks/pack/internal/name"
 
 	pubbldpkg "github.com/buildpacks/pack/buildpackage"
 	"github.com/buildpacks/pack/internal/layer"
@@ -18,7 +19,6 @@ import (
 	"github.com/buildpacks/pack/pkg/buildpack"
 	"github.com/buildpacks/pack/pkg/dist"
 	"github.com/buildpacks/pack/pkg/image"
-	"github.com/docker/docker/client"
 )
 
 const (

--- a/pkg/client/package_buildpack.go
+++ b/pkg/client/package_buildpack.go
@@ -88,7 +88,7 @@ func (c *Client) PackageBuildpack(ctx context.Context, opts PackageBuildpackOpti
 		if host != "" {
 			os.Setenv("DOCKER_HOST", host)
 			newDocker, err := client.NewClientWithOpts(
-				client.WithHost(host),
+				client.FromEnv,
 				client.WithVersion(DockerAPIVersion),
 			)
 			if err != nil {


### PR DESCRIPTION
## Summary
<!-- Provide a high-level summary of the change. -->

Added `--docker-host` flag support to `pack builder create` command to enable compatibility with alternative container runtimes like Podman. This flag was already available in `pack build` but was missing from builder creation, causing issues when users needed to specify custom Docker daemon endpoints.

The implementation adds the `--docker-host` flag with the same functionality and description as the existing flag in `pack build`, allowing users to:
- Specify custom Docker daemon addresses (TCP, Unix socket)
- Use `--docker-host=inherit` to inherit from the `DOCKER_HOST` environment variable
- Maintain compatibility with Podman and other Docker-compatible runtimes

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

```bash
$ pack builder create buildpacks/builder:glibc --config ./builder.toml --docker-host=inherit
Error: unknown flag: --docker-host
Usage:
  pack builder create <image-name> --config <builder-config-path> [flags]
```

#### After

```bash
$ pack builder create buildpacks/builder:glibc --config ./builder.toml --docker-host=inherit
Pro tip: use --targets flag OR [[targets]] in builder.toml to specify the desired platform
# Command proceeds successfully (no unknown flag error)
```

```bash
$ pack builder create --help
...
      --docker-host string         Address to docker daemon that will be exposed to the build container.
                                   If not set (or set to empty string) the standard socket location will be used.
                                   Special value 'inherit' may be used in which case DOCKER_HOST environment variable will be used.
                                   This option may set DOCKER_HOST environment variable for the build container if needed.
...
```
## Resolves

Fixes #2350 