### PR TITLE
Drop Ubuntu Bionic (18.04) support from PPA delivery

### DIFF
--- a/.github/workflows/delivery-ubuntu.yml
+++ b/.github/workflows/delivery-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          target: [bionic, focal, jammy, noble, oracular, plucky]
+          target: [focal, jammy, noble, oracular, plucky]
       runs-on: ubuntu-22.04
       steps:
           - name: Checkout code
@@ -67,17 +67,6 @@ jobs:
             # following steps per variant.
             ###
 
-          - name: Deliver bionic
-            if: matrix.target == 'bionic'
-            uses: docker://ubuntu:bionic
-            with:
-              entrypoint: .github/workflows/delivery/ubuntu/deliver.sh
-            env:
-              DEBIAN_FRONTEND: "noninteractive"
-              GO_DEP_PACKAGE_NAME: golang
-              GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-              GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
-              PACKAGE_VERSION: ${{ steps.version.outputs.result }}
 
           - name: Deliver focal
             if: matrix.target == 'focal'


### PR DESCRIPTION
## Summary
Removes Ubuntu Bionic (18.04 LTS) from the Ubuntu PPA delivery workflow as it has reached End of Life and is causing build failures.

## Motivation
As documented in issue #2435, Ubuntu Bionic support should be dropped because:

1. **Ubuntu 18.04 reached End of Life on May 31, 2023** - over 2 years ago
2. **Build failures for pack v0.38.0+** due to Go 1.24 not being available for i386 architecture on Bionic
3. **No free security updates** available since May 2023 (only paid ESM support)

## Changes
- Removed `bionic` from the Ubuntu delivery workflow matrix
- Removed the bionic-specific delivery step from the workflow

## Supported Ubuntu Versions After This Change

| Ubuntu Version | Codename | Support Until |
|----------------|----------|---------------|
| 20.04 LTS | Focal | April 2025 (ESM: 2030) |
| 22.04 LTS | Jammy | April 2027 (ESM: 2032) |
| 24.04 LTS | Noble | April 2029 (ESM: 2034) |
| 24.10 | Oracular | July 2025 |
| 25.04 | Plucky | January 2026 |

## Impact
- Users on Ubuntu 18.04 will need to:
  - Upgrade to Ubuntu 20.04 LTS or newer
  - Or continue using pack v0.37.0 (last version supporting Go 1.23)

## Testing
- [ ] Verify GitHub Actions workflow validates successfully
- [ ] Confirm PPA builds succeed for remaining Ubuntu versions

Fixes #2435

🤖 Generated with [Claude Code](https://claude.ai/code)