### PR TITLE
bump Docker API version to 1.44

### DIFF
--- a/benchmarks/build_test.go
+++ b/benchmarks/build_test.go
@@ -32,7 +32,7 @@ var (
 
 func BenchmarkBuild(b *testing.B) {
 	setEnv()
-	dockerClient, err := dockerCli.NewClientWithOpts(dockerCli.FromEnv, dockerCli.WithVersion("1.38"))
+	dockerClient, err := dockerCli.NewClientWithOpts(dockerCli.FromEnv, dockerCli.WithVersion("1.44"))
 	if err != nil {
 		b.Error(errors.Wrap(err, "creating docker client"))
 	}

--- a/pkg/cache/image_cache_test.go
+++ b/pkg/cache/image_cache_test.go
@@ -32,7 +32,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
+			dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.44"))
 			h.AssertNil(t, err)
 		})
 
@@ -81,7 +81,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
+			dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.44"))
 			h.AssertNil(t, err)
 		})
 
@@ -104,7 +104,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
+			dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.44"))
 			h.AssertNil(t, err)
 			ctx = context.TODO()
 

--- a/pkg/cache/volume_cache_test.go
+++ b/pkg/cache/volume_cache_test.go
@@ -41,7 +41,7 @@ func testCache(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
+		dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.44"))
 		h.AssertNil(t, err)
 		logger = logging.NewSimpleLogger(&outBuf)
 	})
@@ -305,7 +305,7 @@ func testCache(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
+			dockerClient, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.44"))
 			h.AssertNil(t, err)
 			ctx = context.TODO()
 

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -126,7 +126,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 		fakeLifecycleImage = newLinuxImage(fmt.Sprintf("%s:%s", cfg.DefaultLifecycleImageRepo, builder.DefaultLifecycleVersion), "", nil)
 		fakeImageFetcher.LocalImages[fakeLifecycleImage.Name()] = fakeLifecycleImage
 
-		docker, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithVersion("1.38"))
+		docker, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithVersion("1.44"))
 		h.AssertNil(t, err)
 
 		logger = logging.NewLogWithWriters(&outBuf, &outBuf)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -262,7 +262,7 @@ func WithKeychain(keychain authn.Keychain) Option {
 	}
 }
 
-const DockerAPIVersion = "1.38"
+const DockerAPIVersion = "1.44"
 
 // NewClient allocates and returns a Client configured with the specified options.
 func NewClient(opts ...Option) (*Client, error) {

--- a/pkg/image/fetcher_test.go
+++ b/pkg/image/fetcher_test.go
@@ -44,7 +44,7 @@ func TestFetcher(t *testing.T) {
 	os.Setenv("DOCKER_CONFIG", registryConfig.DockerConfigDir)
 
 	var err error
-	docker, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
+	docker, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.44"))
 	h.AssertNil(t, err)
 	spec.Run(t, "Fetcher", testFetcher, spec.Parallel(), spec.Report(report.Terminal{}))
 }

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -347,7 +347,7 @@ var dockerCliErr error
 
 func dockerCli(t *testing.T) client.APIClient {
 	dockerCliOnce.Do(func() {
-		dockerCliVal, dockerCliErr = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
+		dockerCliVal, dockerCliErr = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.44"))
 	})
 	AssertNil(t, dockerCliErr)
 	return dockerCliVal


### PR DESCRIPTION
## Summary
This bumps the Docker API version from `1.38` to `1.44`. This API version was introduced in Docker Engine is now `25`.

## Output
None

#### Before

#### After

## Documentation
Do we document the Docker API version anywhere?

- Should this change be documented?
    - [ ] Yes
    - [ ] No

## Related

Resolves #2464
