### PR TITLE
Bump to go 1.25

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24
+          go-version: 1.25
           check-latest: true
           go-version-file: 'go.mod'
       - name: Set up go env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG base_image=gcr.io/distroless/static
 
-FROM golang:1.24 as builder
+FROM golang:1.25 as builder
 ARG pack_version
 ENV PACK_VERSION=$pack_version
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,8 @@ install-golangci-lint:
 
 ## mod-tidy: Tidy Go modules
 mod-tidy:
-	$(GOCMD) mod tidy  -compat=1.24
-	cd tools && $(GOCMD) mod tidy -compat=1.24
+	$(GOCMD) mod tidy  -compat=1.25
+	cd tools && $(GOCMD) mod tidy -compat=1.25
 
 ## tidy: Tidy modules and format the code
 tidy: mod-tidy format

--- a/internal/build/testdata/fake-lifecycle/go.mod
+++ b/internal/build/testdata/fake-lifecycle/go.mod
@@ -82,4 +82,4 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 )
 
-go 1.23
+go 1.23.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,8 @@
 module github.com/buildpacks/pack/tools
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.2
+toolchain go1.25.3
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
## Summary
Bump to the latest go version 1.25

## Changes
- Updated `tools/go.mod` from Go 1.24.0 to 1.25.0
- Updated toolchain from go1.24.2 to go1.25.3
- Updated `Makefile` mod-tidy compatibility flag from 1.24 to 1.25
- Updated `Dockerfile` base Go image from golang:1.24 to golang:1.25
- Updated `.github/workflows/benchmark.yml` go-version from 1.24 to 1.25

## Testing
All unit tests passed successfully.

## Documentation
- Should this change be documented?
    - [ ] Yes, see #___
    - [X] No

Resolves #2483 