### PR TITLE
Updating lifecycle version to v0.20.19

### DIFF
--- a/acceptance/testdata/pack_fixtures/report_output.txt
+++ b/acceptance/testdata/pack_fixtures/report_output.txt
@@ -2,7 +2,7 @@ Pack:
   Version:  {{ .Version }}
   OS/Arch:  {{ .OS }}/{{ .Arch }}
 
-Default Lifecycle Version:  0.20.11
+Default Lifecycle Version:  0.20.19
 
 Supported Platform APIs:  0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13
 

--- a/internal/builder/lifecycle.go
+++ b/internal/builder/lifecycle.go
@@ -14,7 +14,7 @@ import (
 
 // DefaultLifecycleVersion A snapshot of the latest tested lifecycle version values
 const (
-	DefaultLifecycleVersion = "0.20.11"
+	DefaultLifecycleVersion = "0.20.19"
 )
 
 // Blob is an interface to wrap opening blobs


### PR DESCRIPTION
Update remaining references to lifecycle version to match go.mod which already has v0.20.19.

Note: go.mod was already updated to v0.20.19 in PR #2476, but the version references in other files were still at 0.20.11. This PR brings them all in sync.

Files updated:
- acceptance/testdata/pack_fixtures/report_output.txt
- internal/builder/lifecycle.go