### PR TITLE
fix: upgrade imgutil to fix containerd snapshotter issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/apex/log v1.9.0
-	github.com/buildpacks/imgutil v0.0.0-20250814164739-4b1c8875ba7e
+	github.com/buildpacks/imgutil v0.0.0-20250909162057-9db16db815e3
 	github.com/buildpacks/lifecycle v0.20.19
 	github.com/chainguard-dev/kaniko v1.25.5
 	github.com/containerd/errdefs v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/buildpacks/imgutil v0.0.0-20250814164739-4b1c8875ba7e h1:a+vpYYeK7E7+3uGqseiRutzKA7yNNjAOPON9+VOADiw=
-github.com/buildpacks/imgutil v0.0.0-20250814164739-4b1c8875ba7e/go.mod h1:UH4th60x/wM1DdH7+eSgzbp0kgsJMhVgngWzXoF21cs=
+github.com/buildpacks/imgutil v0.0.0-20250909162057-9db16db815e3 h1:tm7oOjDEdtwfKL9ukn0cnCo7bgYNYCe0HFk9rbPAKNQ=
+github.com/buildpacks/imgutil v0.0.0-20250909162057-9db16db815e3/go.mod h1:UH4th60x/wM1DdH7+eSgzbp0kgsJMhVgngWzXoF21cs=
 github.com/buildpacks/lifecycle v0.20.19 h1:RyQe2QO524eiJNUpFNTdQKVgasPRP5Dl7zrqrFeJA6k=
 github.com/buildpacks/lifecycle v0.20.19/go.mod h1:Sp2Gc7hPquJ0BivUJjn1FKMzdNNrIAFP0MjNlkwxNGc=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=


### PR DESCRIPTION
## Summary

Upgrades imgutil from `v0.0.0-20250814164739-4b1c8875ba7e` to `v0.0.0-20250909162057-9db16db815e3` to fix a critical bug where builder images created with Docker's containerd snapshotter storage driver had malformed manifests.

The bug caused the first several base image layers to be replaced with empty blob references in the manifest while the config retained correct diff_ids, creating invalid images that failed OCI spec validation with tools like skopeo.

The fix was already merged in [buildpacks/imgutil#297](https://github.com/buildpacks/imgutil/pull/297), which reverted the problematic "fast path" optimization commits that incorrectly assumed Docker's blank layer placeholder mechanism would work identically across all storage drivers.

## Output

#### Before

```bash
# With Docker using containerd snapshotter
$ pack builder create test-builder:latest --config builders/noble/builder.toml
Successfully created builder image 'test-builder:latest'

$ skopeo copy docker-daemon:test-builder:latest oci:/tmp/test
FATA[0001] determining manifest MIME type for docker-daemon:test-builder:latest: 
Layer tarfile "blobs/sha256/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" 
used for two different DiffID values
```

#### After

```bash
# With Docker using containerd snapshotter
$ pack builder create test-builder:latest --config builders/noble/builder.toml
Successfully created builder image 'test-builder:latest'

$ skopeo copy docker-daemon:test-builder:latest oci:/tmp/test
Getting image source signatures
Copying blob sha256:a8346d259389bc6221b4f3c61bad4e48087c5b82308e8f53ce703cfc8333c7b3
Copying blob sha256:4ea3b5141be57efe60a721cf8e9e5324602348abb0e51413ffe04421de0927cf
...
Copying config sha256:4ce6d734d3b12b0977d8d328ba321fc44f3e9cf4f3d95190aa21b5fe27515a0f
Writing manifest to image destination
✅ Success - all 18 blobs copied without errors
```

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related

Resolves #2490
