### PR TITLE
fix: upgrade Go to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -156,4 +156,4 @@ require (
 
 replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v1.3.2
 
-go 1.25.3
+go 1.25.5

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/buildpacks/pack/tools
 
 go 1.25.0
 
-toolchain go1.25.3
+toolchain go1.25.5
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
## Summary
This PR upgrades the Go version from 1.25.3 to 1.25.5 to address two security vulnerabilities discovered by Grype in the Go standard library.

**Security Fixes:**
- CVE-2025-61729 (High severity)
- CVE-2025-61727 (Medium severity)

**Changes Made:**
- Updated `go.mod`: `go 1.25.3` → `go 1.25.5`
- Updated `tools/go.mod`: `toolchain go1.25.3` → `toolchain go1.25.5`

The Dockerfile already uses `golang:1.25` which will automatically pull the latest 1.25.x version (1.25.5), so no changes were needed there.

## Output
N/A - This is a Go version upgrade with no user-facing changes.

## Documentation
- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related
Resolves #2499
Resolves #2502 

🤖 Generated with [Claude Code](https://claude.com/claude-code)