### PR TITLE
fix: migrate Windows CI testing from Equinix LCOW to GitHub-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [macos, linux, windows-lcow]
+        config: [macos, linux, windows]
         include:
           - config: macos
             # since macos-14 the latest runner is arm64
@@ -33,10 +33,10 @@ jobs:
             runner: ubuntu-latest
             no_docker: "false"
             pack_bin: pack
-          - config: windows-lcow
+          - config: windows
             os: windows
-            runner: [self-hosted, windows, lcow]
-            no_docker: "false"
+            runner: windows-latest
+            no_docker: "true"
             pack_bin: pack.exe
     runs-on: ${{ matrix.runner }}
     env:
@@ -84,6 +84,9 @@ jobs:
           echo "GOPATH=$(go env GOPATH)"| Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           echo "$(go env GOPATH)\bin" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
         shell: powershell
+      - name: Install Make on Windows
+        if: runner.os == 'Windows'
+        run: choco install make -y
       - name: Verify
         run: make verify
       - name: Test


### PR DESCRIPTION
## Summary

This PR addresses issue #2505 by migrating Windows CI testing away from the Equinix Metal self-hosted LCOW (Linux Containers On Windows) runner to GitHub-hosted `windows-latest` runners.

## Background

Equinix Metal has decided to sunset their support for open-source projects ([CNCF announcement](https://www.cncf.io/blog/2025/06/04/thank-you-equinix-metal-the-cncf-community-bids-farewell-to-the-bare-metal-cluster/)). Our CI pipeline currently uses a self-hosted Windows runner for LCOW testing hosted on Equinix infrastructure.

## Changes

- **Replaced** `windows-lcow` config with `windows` config using `windows-latest` runner
- **Set** `NO_DOCKER=true` for Windows testing (GitHub runners don't support LCOW due to lack of nested virtualization)
- **Added** step to install Make via Chocolatey for Windows runner (not pre-installed on windows-latest)
- **Maintained** `pack.exe` artifact generation for Chocolatey distribution and releases

## Testing Strategy

The new Windows configuration:
- ✅ Runs unit tests (without Docker-dependent tests)
- ✅ Runs `make verify` for format verification and linting
- ✅ Builds `pack.exe` binary for releases
- ✅ Validates basic pack CLI functionality on Windows
- ❌ Does not run Docker/LCOW tests (requires nested virtualization unavailable on GitHub-hosted runners)
- ❌ Does not run acceptance tests (require Linux containers)

## Trade-offs

**What we keep:**
- Windows unit tests
- Windows binary builds for releases
- Chocolatey distribution support
- Basic pack CLI validation on Windows

**What we lose:**
- LCOW (Linux Containers On Windows) testing
- Docker-dependent acceptance tests on Windows

## Rationale

This is an **incremental solution** that:
1. Removes the Equinix infrastructure dependency
2. Maintains Windows support for releases and Chocolatey
3. Provides basic Windows testing coverage
4. Can be enhanced later if better Windows container testing becomes available

## Research Notes

GitHub-hosted Windows runners do not support LCOW because:
- GitHub Actions Windows VMs are not enabled for nested virtualization
- LCOW requires Hyper-V support (nested VM)
- The GitHub Actions VMs are already nested one level deep
- Even Windows Server 2025 with WSL2 doesn't solve this on GitHub runners

## Test plan

- [x] Verify CI passes on this PR
- [ ] Confirm `pack-windows` artifact is generated
- [ ] Validate Windows tests run without errors
- [x] Check that Make installation step works
- [ ] Ensure release workflow can still package Windows binaries

Resolves #2505

🤖 Generated with [Claude Code](https://claude.com/claude-code)