### PR TITLE
Remove Ubuntu 24.10 (Oracular Oriole) from delivery workflow

### DIFF
--- a/.github/workflows/delivery-ubuntu.yml
+++ b/.github/workflows/delivery-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          target: [focal, jammy, noble, oracular, plucky]
+          target: [focal, jammy, noble, plucky]
       runs-on: ubuntu-22.04
       steps:
           - name: Checkout code
@@ -95,18 +95,6 @@ jobs:
           - name: Deliver noble
             if: matrix.target == 'noble'
             uses: docker://ubuntu:noble
-            with:
-              entrypoint: .github/workflows/delivery/ubuntu/deliver.sh
-            env:
-              DEBIAN_FRONTEND: "noninteractive"
-              GO_DEP_PACKAGE_NAME: golang
-              GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-              GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
-              PACKAGE_VERSION: ${{ steps.version.outputs.result }}
-
-          - name: Deliver oracular
-            if: matrix.target == 'oracular'
-            uses: docker://ubuntu:oracular
             with:
               entrypoint: .github/workflows/delivery/ubuntu/deliver.sh
             env:


### PR DESCRIPTION
## Summary

Removes Ubuntu 24.10 (Oracular Oriole) from the delivery workflow as it has reached End of Life (July 11, 2025) and its repositories have been removed from the main archive.

## Changes

- Removed `oracular` from the matrix configuration in `.github/workflows/delivery-ubuntu.yml`
- Removed the "Deliver oracular" step from the workflow

## Testing

- The workflow will no longer attempt to deliver packages to Ubuntu 24.10
- Remaining supported versions: focal (20.04 LTS), jammy (22.04 LTS), noble (24.04 LTS), and plucky (25.04)

Fixes #2504

🤖 Generated with [Claude Code](https://claude.com/claude-code)