### PR TITLE
Writer Factory: Support FreeBSD

### DIFF
--- a/internal/layer/writer_factory.go
+++ b/internal/layer/writer_factory.go
@@ -15,8 +15,8 @@ type WriterFactory struct {
 }
 
 func NewWriterFactory(imageOS string) (*WriterFactory, error) {
-	if imageOS != "linux" && imageOS != "windows" {
-		return nil, fmt.Errorf("provided image OS '%s' must be either 'linux' or 'windows'", imageOS)
+	if imageOS != "freebsd" && imageOS != "linux" && imageOS != "windows" {
+		return nil, fmt.Errorf("provided image OS '%s' must be either 'freebsd', 'linux' or 'windows'", imageOS)
 	}
 
 	return &WriterFactory{os: imageOS}, nil
@@ -27,6 +27,6 @@ func (f *WriterFactory) NewWriter(fileWriter io.Writer) archive.TarWriter {
 		return ilayer.NewWindowsWriter(fileWriter)
 	}
 
-	// Linux images use tar.Writer
+	// Linux and FreeBSD images use tar.Writer
 	return tar.NewWriter(fileWriter)
 }

--- a/internal/layer/writer_factory_test.go
+++ b/internal/layer/writer_factory_test.go
@@ -20,11 +20,21 @@ func testWriterFactory(t *testing.T, when spec.G, it spec.S) {
 	when("#NewWriterFactory", func() {
 		it("returns an error for invalid image OS", func() {
 			_, err := layer.NewWriterFactory("not-an-os")
-			h.AssertError(t, err, "provided image OS 'not-an-os' must be either 'linux' or 'windows'")
+			h.AssertError(t, err, "provided image OS 'not-an-os' must be either 'freebsd', 'linux' or 'windows'")
 		})
 	})
 
 	when("#NewWriter", func() {
+		it("returns a regular tar writer for FreeBSD", func() {
+			factory, err := layer.NewWriterFactory("freebsd")
+			h.AssertNil(t, err)
+
+			_, ok := factory.NewWriter(nil).(*tar.Writer)
+			if !ok {
+				t.Fatal("returned writer was not a regular tar writer")
+			}
+		})
+
 		it("returns a regular tar writer for Linux", func() {
 			factory, err := layer.NewWriterFactory("linux")
 			h.AssertNil(t, err)


### PR DESCRIPTION
## Summary

This allows to use `pack` under FreeBSD together with Podman.

This change would allow to create a FreeBSD port for `pack` and also use it.

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [X] No