### PR TITLE
Fix link to `Get Started with Podman` page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,7 +269,7 @@ jobs:
           body: |
             ## Prerequisites
 
-            - A container runtime such as [Docker](https://www.docker.com/get-started) or [podman](https://podman.io/getting-started/) must be available to execute builds.
+            - A container runtime such as [Docker](https://www.docker.com/get-started) or [podman](https://podman.io/get-started) must be available to execute builds.
 
             ## Install
 
@@ -348,7 +348,7 @@ jobs:
           body: |
             ## Prerequisites
 
-            - A container runtime such as [Docker](https://www.docker.com/get-started) or [podman](https://podman.io/getting-started/) must be available to execute builds.
+            - A container runtime such as [Docker](https://www.docker.com/get-started) or [podman](https://podman.io/get-started) must be available to execute builds.
 
             ## Install
 


### PR DESCRIPTION

## Summary

Correct link to podman.io Get Started page.

The previous link
https://podman.io/getting-started/
points to a 404 page.

## Output

#### Before
Visit
https://github.com/buildpacks/pack/releases
and click on the first `podman` link.
-> Opens
https://podman.io/get-started
which is a 404 page.

#### After
https://podman.io/get-started
