### PR TITLE
fix: improve error message when daemon architecture doesn't match target

### DIFF
--- a/pkg/client/create_builder_test.go
+++ b/pkg/client/create_builder_test.go
@@ -1368,7 +1368,9 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 							}
 
 							err := subject.CreateBuilder(context.TODO(), opts)
-							h.AssertError(t, err, "could not find a target that matches daemon os=linux and architecture=amd64")
+							h.AssertError(t, err, "unable to save image to docker daemon")
+							h.AssertError(t, err, "do not match the daemon's os/architecture")
+							h.AssertError(t, err, "use the --publish flag")
 						})
 					})
 
@@ -1425,7 +1427,9 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 							}
 
 							err := subject.CreateBuilder(context.TODO(), opts)
-							h.AssertError(t, err, "could not find a target that matches daemon os=linux and architecture=arm64")
+							h.AssertError(t, err, "unable to save image to docker daemon")
+							h.AssertError(t, err, "do not match the daemon's os/architecture")
+							h.AssertError(t, err, "use the --publish flag")
 						})
 					})
 				})

--- a/pkg/client/package_buildpack_test.go
+++ b/pkg/client/package_buildpack_test.go
@@ -893,7 +893,9 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 										Targets:    targets,
 										PullPolicy: image.PullNever,
 									})
-									h.AssertError(t, err, "could not find a target that matches daemon os=linux and architecture=amd64")
+									h.AssertError(t, err, "unable to save image to docker daemon")
+									h.AssertError(t, err, "do not match the daemon's os/architecture")
+									h.AssertError(t, err, "use the --publish flag")
 								})
 							})
 
@@ -1046,7 +1048,9 @@ func testPackageBuildpack(t *testing.T, when spec.G, it spec.S) {
 										Targets:    targets,
 										PullPolicy: image.PullNever,
 									})
-									h.AssertError(t, err, "could not find a target that matches daemon os=linux and architecture=arm64")
+									h.AssertError(t, err, "unable to save image to docker daemon")
+									h.AssertError(t, err, "do not match the daemon's os/architecture")
+									h.AssertError(t, err, "use the --publish flag")
 								})
 							})
 						})


### PR DESCRIPTION
## Summary

This PR improves the error message when a user attempts to build a builder or buildpack for a different architecture than the Docker daemon supports (e.g., building `linux/amd64` on an arm64 Mac).

**Before:**
```
ERROR: could not find a target that matches daemon os=linux and architecture=arm64
```

**After:**
```
ERROR: unable to save image to docker daemon: the specified target(s) 'linux/amd64', 'windows/amd64' do not match the daemon's os/architecture 'linux/arm64'. To build for a different platform than the daemon, use the --publish flag to push directly to a registry
```

## Changes

- Updated `daemonTarget` function in `pkg/client/package_buildpack.go` to provide a more informative error message that:
  1. Lists which targets were specified that couldn't match
  2. Shows the daemon's current os/architecture
  3. Suggests using the `--publish` flag as a workaround
- Updated test assertions in `pkg/client/create_builder_test.go` and `pkg/client/package_buildpack_test.go` to match the new error message format

## Test plan

- [ ] Verified test assertions were updated to match new error message
- [ ] Manual testing: Build a builder with `--target linux/amd64` on an arm64 machine without `--publish` flag - should see improved error message


🤖 Generated with [Claude Code](https://claude.ai/code)