### PR TITLE
fix: support docker:// URIs with port numbers in registry references

### DIFF
--- a/pkg/buildpack/locator_type.go
+++ b/pkg/buildpack/locator_type.go
@@ -71,7 +71,8 @@ func GetLocatorType(locator string, relativeBaseDir string, buildpacksFromBuilde
 
 	if paths.IsURI(locator) {
 		if HasDockerLocator(locator) {
-			if _, err := name.ParseReference(locator); err == nil {
+			ref := strings.TrimPrefix(locator, "docker://")
+			if _, err := name.ParseReference(ref); err == nil {
 				return PackageLocator, nil
 			}
 		}

--- a/pkg/buildpack/locator_type_test.go
+++ b/pkg/buildpack/locator_type_test.go
@@ -120,6 +120,18 @@ func testGetLocatorType(t *testing.T, when spec.G, it spec.S) {
 			expectedType: buildpack.PackageLocator,
 		},
 		{
+			locator:      "docker://localhost:5000/foo/bar",
+			expectedType: buildpack.PackageLocator,
+		},
+		{
+			locator:      "docker://localhost:5000/foo/bar:latest",
+			expectedType: buildpack.PackageLocator,
+		},
+		{
+			locator:      "docker://myregistry:8080/cnbs/some-bp",
+			expectedType: buildpack.PackageLocator,
+		},
+		{
 			locator:      "cnbs/some-bp@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			expectedType: buildpack.PackageLocator,
 		},


### PR DESCRIPTION
## Summary
- Strip the `docker://` scheme prefix before passing references to `name.ParseReference`
- Fixes `docker://localhost:5000/foo/bar` being rejected as an invalid locator

## Motivation
Fixes #2536 — Docker URIs with port numbers (e.g. `docker://localhost:5000/foo/bar`) were not recognized as valid `PackageLocator` references. The `go-containerregistry` library's `name.ParseReference` expects bare Docker references without the URI scheme prefix.

## Root Cause
In `GetLocatorType`, when a `docker://` URI is detected, the full string including the scheme was passed to `name.ParseReference`. This works for simple refs like `docker://cnbs/some-bp` (where `docker` is interpreted as a registry host), but fails for refs with explicit ports like `docker://localhost:5000/foo/bar`.

## Changes
- `pkg/buildpack/locator_type.go`: `strings.TrimPrefix(locator, "docker://")` before `name.ParseReference`
- `pkg/buildpack/locator_type_test.go`: Add 3 test cases for docker:// URIs with port numbers

## Test plan
- [x] `docker://localhost:5000/foo/bar` → `PackageLocator`
- [x] `docker://localhost:5000/foo/bar:latest` → `PackageLocator`
- [x] `docker://myregistry:8080/cnbs/some-bp` → `PackageLocator`
- [x] Existing docker:// tests without ports still pass