### PR TITLE
fix: treat amd64 as equivalent to x86-64 for lifecycle binary selection

### DIFF
--- a/internal/builder/lifecycle.go
+++ b/internal/builder/lifecycle.go
@@ -122,5 +122,5 @@ func (l *lifecycle) binaries() []string {
 
 // SupportedLinuxArchitecture returns true for each binary architecture available at https://github.com/buildpacks/lifecycle/releases/
 func SupportedLinuxArchitecture(arch string) bool {
-	return arch == "arm64" || arch == "ppc64le" || arch == "s390x"
+	return arch == "arm64" || arch == "ppc64le" || arch == "s390x" || arch == "x86-64"
 }

--- a/pkg/client/create_builder.go
+++ b/pkg/client/create_builder.go
@@ -462,6 +462,10 @@ func (c *Client) uriFromLifecycleVersion(version semver.Version, os string, arch
 		return fmt.Sprintf("https://github.com/buildpacks/lifecycle/releases/download/v%s/lifecycle-v%s+windows.%s.tgz", version.String(), version.String(), arch)
 	}
 
+	if architecture == "amd64" {
+		architecture = "x86-64"
+	}
+
 	if builder.SupportedLinuxArchitecture(architecture) {
 		arch = architecture
 	} else {

--- a/pkg/client/create_builder_test.go
+++ b/pkg/client/create_builder_test.go
@@ -631,6 +631,44 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 			})
 
+			it("should download x86-64 lifecycle when architecture is amd64", func() {
+				prepareFetcherWithBuildImage()
+				prepareFetcherWithRunImages()
+				opts.Config.Lifecycle.URI = ""
+				opts.Config.Lifecycle.Version = "3.4.5"
+				h.AssertNil(t, fakeBuildImage.SetArchitecture("amd64"))
+
+				mockDownloader.EXPECT().Download(
+					gomock.Any(),
+					"https://github.com/buildpacks/lifecycle/releases/download/v3.4.5/lifecycle-v3.4.5+linux.x86-64.tgz",
+				).Return(
+					blob.NewBlob(filepath.Join("testdata", "lifecycle", "platform-0.4")), nil,
+				)
+
+				err := subject.CreateBuilder(context.TODO(), opts)
+				h.AssertNil(t, err)
+				h.AssertNotContains(t, out.String(), "failed to find a lifecycle binary")
+			})
+
+			it("should warn and default to x86-64 for unknown architecture", func() {
+				prepareFetcherWithBuildImage()
+				prepareFetcherWithRunImages()
+				opts.Config.Lifecycle.URI = ""
+				opts.Config.Lifecycle.Version = "3.4.5"
+				h.AssertNil(t, fakeBuildImage.SetArchitecture("riscv64"))
+
+				mockDownloader.EXPECT().Download(
+					gomock.Any(),
+					"https://github.com/buildpacks/lifecycle/releases/download/v3.4.5/lifecycle-v3.4.5+linux.x86-64.tgz",
+				).Return(
+					blob.NewBlob(filepath.Join("testdata", "lifecycle", "platform-0.4")), nil,
+				)
+
+				err := subject.CreateBuilder(context.TODO(), opts)
+				h.AssertNil(t, err)
+				h.AssertContains(t, out.String(), "failed to find a lifecycle binary")
+			})
+
 			when("windows", func() {
 				it("should download from predetermined uri", func() {
 					opts.Config.Extensions = nil      // TODO: downloading extensions doesn't work yet; to be implemented in https://github.com/buildpacks/pack/issues/1489


### PR DESCRIPTION
## Summary
- Map `amd64` architecture to `x86-64` when constructing lifecycle binary download URLs
- Eliminates the spurious warning on standard AMD64 systems (e.g. GitHub Actions `ubuntu-24.04`)

## Motivation
Fixes #2528 — On AMD64 systems, `pack builder create` emits a misleading warning:
```
Warning: failed to find a lifecycle binary for requested architecture 'amd64', defaulting to 'x86-64'
```
The correct binary was always downloaded since the default is `x86-64`, but the warning is confusing because `amd64` and `x86-64` are the same architecture.

## Root Cause
`uriFromLifecycleVersion` checks `SupportedLinuxArchitecture(architecture)` which only recognizes `arm64`, `ppc64le`, and `s390x`. When the architecture is `amd64`, it falls to the warning branch even though lifecycle releases name x86-64 binaries as `x86-64`.

## Changes
- `pkg/client/create_builder.go`: Normalize `amd64` → `x86-64` before the architecture check, and also accept `x86-64` as a valid architecture alongside those from `SupportedLinuxArchitecture`

## Test plan
- [x] `amd64` architecture → no warning, downloads `x86-64` binary
- [x] `x86-64` architecture → no warning, downloads `x86-64` binary
- [x] `arm64`, `ppc64le`, `s390x` → unchanged behavior
- [x] Unknown architecture → warning still emitted (unchanged)