### PR TITLE
chore: upgrade Go to 1.25.8 to fix stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -156,4 +156,4 @@ require (
 
 replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v1.3.2
 
-go 1.25.7
+go 1.25.8


### PR DESCRIPTION
## Summary

- Bumps Go version from `1.25.7` to `1.25.8` in `go.mod`
- Fixes three vulnerabilities in the Go standard library detected via `grype` on the `buildpacksio/pack:0.40.1` image

| CVE | Severity | Fixed in |
|-----|----------|----------|
| CVE-2026-25679 | High | 1.25.8 |
| CVE-2026-27142 | High | 1.25.8 |
| CVE-2026-27139 | Low  | 1.25.8 |

The `Dockerfile` (`golang:1.25`) and CI workflows already use floating minor-version tags, so they will automatically pick up 1.25.8.

## Test plan

- [ ] CI passes with Go 1.25.8
- [ ] Re-run `grype` on the new image to confirm vulnerabilities are resolved

Resolves #2547