### PR TITLE
Fix registryPattern to support registry names with port numbers

### DIFF
--- a/pkg/buildpack/locator_type.go
+++ b/pkg/buildpack/locator_type.go
@@ -36,7 +36,7 @@ const (
 var (
 	// https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 	semverPattern   = `(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`
-	registryPattern = regexp.MustCompile(`^[a-z0-9\-\.]+\/[a-z0-9\-\.]+(?:@` + semverPattern + `)?$`)
+	registryPattern = regexp.MustCompile(`^[a-z0-9\-\.]+(?::[0-9]+)?\/[a-z0-9\-\.]+(?:@` + semverPattern + `)?$`)
 )
 
 func (l LocatorType) String() string {

--- a/pkg/buildpack/locator_type_test.go
+++ b/pkg/buildpack/locator_type_test.go
@@ -156,6 +156,14 @@ func testGetLocatorType(t *testing.T, when spec.G, it spec.S) {
 			expectedType: buildpack.RegistryLocator,
 		},
 		{
+			locator:      "localhost:5000/foo",
+			expectedType: buildpack.RegistryLocator,
+		},
+		{
+			locator:      "myregistry:8080/bar",
+			expectedType: buildpack.RegistryLocator,
+		},
+		{
 			locator:      "cnbs/sample-package@hello-universe",
 			expectedType: buildpack.InvalidLocator,
 		},


### PR DESCRIPTION
## Summary

- Fixes `canBeRegistryRef` returning false for valid registry references that include port numbers (e.g., `localhost:5000/namespace/name`)
- Adds optional port number group `(?:[0-9]+)?` to the `registryPattern` regex
- Adds test cases for registry locators with port numbers

Fixes #2536

## Test plan

- [ ] Existing tests pass without modification
- [ ] New test cases verify `localhost:5000/foo` and `myregistry:8080/bar` are recognized as `RegistryLocator`
- [ ] Registry references without ports continue to work as before