### PR TITLE
chore: add .grype.yaml to ignore unreachable docker daemon CVEs

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,7 @@
+ignore:
+  - vulnerability: CVE-2015-5237 # false positive, see https://github.com/anchore/grype/issues/558
+  - vulnerability: CVE-2021-22570 # false positive, see https://github.com/anchore/grype/issues/558
+  - vulnerability: CVE-2024-41110 # non-impactful as we only use docker as a client
+  - vulnerability: GHSA-v23v-6jw2-98fq # non-impactful as we only use docker as a client
+  - vulnerability: GHSA-x744-4wpc-v9h2 # AuthZ plugin bypass; not exploitable as pack only uses docker as a client. Fixed in moby/moby/v2 but not backported to docker/docker module.
+  - vulnerability: GHSA-pxq6-2prw-chj9 # plugin privilege validation off-by-one; not exploitable as pack only uses docker as a client. Fixed in moby/moby/v2 but not backported to docker/docker module.


### PR DESCRIPTION
## Summary
- Adds `.grype.yaml` mirroring the ignore list used by [`buildpacks/lifecycle`](https://github.com/buildpacks/lifecycle/blob/main/.grype.yaml).
- Silences the scheduled `check-latest-release.yml` grype scan, which currently fails on two unreachable docker daemon advisories:
  - `GHSA-pxq6-2prw-chj9` (Medium) — plugin install privilege validation off-by-one (daemon-side)
  - `GHSA-x744-4wpc-v9h2` (High) — AuthZ plugin bypass (daemon-side)
- Both are fixed upstream in `github.com/moby/moby/v2` but not backported to the `github.com/docker/docker` module, so grype cannot auto-resolve them. Pack uses docker as a client only, so neither code path is reachable.
- Also pre-emptively ignores two related docker issues (`CVE-2024-41110`, `GHSA-v23v-6jw2-98fq`) and two well-known protobuf false positives (`CVE-2015-5237`, `CVE-2021-22570`), matching lifecycle's posture.

## Test plan
- [ ] After merge, re-run `anchore/scan-action` (or `grype`) against the pack image / binary and confirm a clean report
- [ ] Next scheduled run of `check-latest-release.yml` does not fail or auto-open a CVE issue

Signed-off-by: Juan Bustamante <bustamantejj@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)