### PR TITLE
fix: fetch builder image per platform

### DIFF
--- a/internal/fakes/fake_image_fetcher.go
+++ b/internal/fakes/fake_image_fetcher.go
@@ -18,16 +18,18 @@ type FetchArgs struct {
 }
 
 type FakeImageFetcher struct {
-	LocalImages  map[string]imgutil.Image
-	RemoteImages map[string]imgutil.Image
-	FetchCalls   map[string]*FetchArgs
+	LocalImages           map[string]imgutil.Image
+	RemoteImages          map[string]imgutil.Image
+	FetchCalls            map[string]*FetchArgs
+	FetchForPlatformCalls map[string]*FetchArgs
 }
 
 func NewFakeImageFetcher() *FakeImageFetcher {
 	return &FakeImageFetcher{
-		LocalImages:  map[string]imgutil.Image{},
-		RemoteImages: map[string]imgutil.Image{},
-		FetchCalls:   map[string]*FetchArgs{},
+		LocalImages:           map[string]imgutil.Image{},
+		RemoteImages:          map[string]imgutil.Image{},
+		FetchCalls:            map[string]*FetchArgs{},
+		FetchForPlatformCalls: map[string]*FetchArgs{},
 	}
 }
 
@@ -61,8 +63,8 @@ func (f *FakeImageFetcher) CheckReadAccess(_ string, _ image.FetchOptions) bool 
 }
 
 func (f *FakeImageFetcher) FetchForPlatform(ctx context.Context, name string, options image.FetchOptions) (imgutil.Image, error) {
-	// For the fake implementation, FetchForPlatform behaves the same as Fetch
-	// since we don't need to simulate the platform-specific digest resolution
+	f.FetchForPlatformCalls[name] = &FetchArgs{Daemon: options.Daemon, PullPolicy: options.PullPolicy, Target: options.Target, LayoutOption: options.LayoutOption}
+	// For the fake, platform-specific digest resolution is a no-op; delegate to Fetch.
 	return f.Fetch(ctx, name, options)
 }
 

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -367,7 +367,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		}
 	}()
 
-	rawBuilderImage, err := c.imageFetcher.Fetch(
+	rawBuilderImage, err := c.imageFetcher.FetchForPlatform(
 		ctx,
 		builderRef.Name(),
 		image.FetchOptions{

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -2334,6 +2334,13 @@ api = "0.2"
 					h.AssertEq(t, args.PullPolicy, image.PullAlways)
 					h.AssertEq(t, args.Target.ValuesAsPlatform(), "linux/arm64")
 
+					// builder must be fetched via FetchForPlatform so that containerd-backed daemons
+					// return the platform-specific image config (and its labels) instead of the
+					// manifest list or the host-arch image.
+					platformArgs := fakeImageFetcher.FetchForPlatformCalls[defaultBuilderName]
+					h.AssertNotNil(t, platformArgs)
+					h.AssertEq(t, platformArgs.Target.ValuesAsPlatform(), "linux/arm64")
+
 					args = fakeImageFetcher.FetchCalls["default/run"]
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.PullPolicy, image.PullAlways)
@@ -2348,6 +2355,24 @@ api = "0.2"
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.PullPolicy, image.PullAlways)
 					h.AssertEq(t, args.Target.ValuesAsPlatform(), "linux/arm64")
+				})
+
+				it("fetches the builder image via FetchForPlatform to resolve platform-specific labels on containerd daemons", func() {
+					// Regression test for: pack build --platform linux/arm64 on a containerd-backed
+					// daemon returning 'missing label io.buildpacks.builder.metadata' because the
+					// host-arch (amd64) image config was inspected instead of the arm64 one.
+					h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+						Image:      "some/app",
+						Builder:    defaultBuilderName,
+						Platform:   "linux/arm64",
+						PullPolicy: image.PullAlways,
+					}))
+
+					// FetchForPlatform must have been called for the builder (not plain Fetch),
+					// which ensures the platform-specific digest is resolved before the daemon
+					// reads the image config.
+					h.AssertNotNil(t, fakeImageFetcher.FetchForPlatformCalls[defaultBuilderName])
+					h.AssertEq(t, fakeImageFetcher.FetchForPlatformCalls[defaultBuilderName].Target.ValuesAsPlatform(), "linux/arm64")
 				})
 			})
 
@@ -2368,6 +2393,9 @@ api = "0.2"
 					h.AssertEq(t, args.Daemon, true)
 					h.AssertEq(t, args.PullPolicy, image.PullAlways)
 					h.AssertEq(t, args.Target, (*dist.Target)(nil))
+
+					// builder is always fetched via FetchForPlatform regardless of --platform
+					h.AssertNotNil(t, fakeImageFetcher.FetchForPlatformCalls[defaultBuilderName])
 
 					args = fakeImageFetcher.FetchCalls["default/run"]
 					h.AssertEq(t, args.Daemon, true)

--- a/pkg/image/fetcher.go
+++ b/pkg/image/fetcher.go
@@ -263,7 +263,7 @@ func (f *Fetcher) FetchForPlatform(ctx context.Context, name string, options Fet
 	// Note: This may cause issues with containerd storage. Users should pre-pull the platform-specific
 	// digest if they encounter errors.
 	if options.Daemon && options.PullPolicy == PullNever {
-		f.logger.Debugf("Using lifecycle %s with platform %s (skipping digest resolution due to --pull-policy never)", name, platformStr)
+		f.logger.Debugf("Using image %s with platform %s (skipping digest resolution due to --pull-policy never)", name, platformStr)
 		return f.Fetch(ctx, name, options)
 	}
 
@@ -285,7 +285,7 @@ func (f *Fetcher) FetchForPlatform(ctx context.Context, name string, options Fet
 	}
 
 	// Log the resolution for visibility
-	f.logger.Debugf("Using lifecycle %s; pulling digest %s for platform %s", name, resolvedName, platformStr)
+	f.logger.Debugf("Using image %s; pulling digest %s for platform %s", name, resolvedName, platformStr)
 
 	return f.Fetch(ctx, resolvedName, options)
 }

--- a/pkg/image/fetcher.go
+++ b/pkg/image/fetcher.go
@@ -258,6 +258,12 @@ func (f *Fetcher) FetchForPlatform(ctx context.Context, name string, options Fet
 
 	platformStr := options.Target.ValuesAsPlatform()
 
+	// Log the pull attempt upfront so it appears in output regardless of whether
+	// digest resolution succeeds (mirrors the log emitted by Fetch for non-FetchForPlatform paths).
+	if options.Daemon {
+		f.logger.Debugf("Pulling image %s with platform %s", style.Symbol(name), style.Symbol(platformStr))
+	}
+
 	// When PullPolicy is PullNever, skip platform-specific digest resolution as it requires
 	// network access to fetch the manifest list. Instead, use the image as-is from the daemon.
 	// Note: This may cause issues with containerd storage. Users should pre-pull the platform-specific


### PR DESCRIPTION
## Summary

When using `pack build --platform linux/<arch>` against a Docker daemon with containerd storage (`io.containerd.snapshotter.v1`), the builder image was fetched with `Fetch()` which returns the manifest list or the host-arch image config. This caused two failures depending on Docker version:

- Docker 28.x + containerd: `NotFound: content digest`
- Docker 29.x + containerd: `missing label 'io.buildpacks.builder.metadata'`

Both share the same root cause: pack did not scope the builder image config lookup to the requested `--platform`.

This PR switches the builder image fetch from `Fetch()` to `FetchForPlatform()`, which resolves the platform-specific digest from the registry manifest list before pulling — the same fix already applied to lifecycle image fetching (#2467).

Also tracks `FetchForPlatformCalls` separately in `FakeImageFetcher` and adds regression tests.

## Output

#### Before

```
ERROR: failed to build: invalid builder '<builder>': builder '<builder>'
missing label 'io.buildpacks.builder.metadata' -- try recreating builder
```

```
ERROR: failed to build: failed to fetch base layers: saving image with ID
"sha256:9664dab..." from the docker daemon: Error response from daemon:
unable to create manifests file: NotFound: content digest sha256:508c4e1...: not found
```

#### After

Build proceeds normally when `--platform linux/arm64` is specified against a containerd-backed daemon.

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related

Resolves #2587
Resolves #2588