### PR TITLE
fix: guard ReadTarEntry against decompression bombs (OOM)

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -4,6 +4,7 @@ package archive // import "github.com/buildpacks/pack/pkg/archive"
 import (
 	"archive/tar"
 	"archive/zip"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -15,6 +16,10 @@ import (
 
 	"github.com/buildpacks/pack/internal/paths"
 )
+
+// maxTarEntrySize is the maximum number of bytes that ReadTarEntry will read
+// from a single tar entry, guarding against decompression bombs.
+const maxTarEntrySize = 4 * 1024 * 1024 // 4 MB
 
 var NormalizedDateTime time.Time
 var Umask fs.FileMode
@@ -147,9 +152,15 @@ func ReadTarEntry(rc io.Reader, entryPath string) (*tar.Header, []byte, error) {
 		}
 
 		if paths.CanonicalTarPath(header.Name) == canonicalEntryPath {
-			buf, err := io.ReadAll(tr)
+			if header.Size > maxTarEntrySize {
+				return nil, nil, fmt.Errorf("tar entry %q is too large: %d bytes (max %d)", entryPath, header.Size, maxTarEntrySize)
+			}
+			buf, err := io.ReadAll(io.LimitReader(tr, maxTarEntrySize+1))
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "failed to read contents of '%s'", entryPath)
+			}
+			if int64(len(buf)) > maxTarEntrySize {
+				return nil, nil, fmt.Errorf("tar entry %q exceeds maximum allowed size of %d bytes", entryPath, maxTarEntrySize)
 			}
 
 			return header, buf, nil

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -2,6 +2,7 @@ package archive_test
 
 import (
 	"archive/tar"
+	"bytes"
 	"net"
 	"os"
 	"path/filepath"
@@ -154,6 +155,42 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 				reader := strings.NewReader("abcde")
 				_, _, err := archive.ReadTarEntry(reader, "file1")
 				h.AssertError(t, err, "get next tar entry")
+			})
+		})
+
+		when("tar entry exceeds max size via header", func() {
+			it("returns an error", func() {
+				var buf bytes.Buffer
+				tw := tar.NewWriter(&buf)
+				h.AssertNil(t, tw.WriteHeader(&tar.Header{
+					Name: "bigfile",
+					Size: 5 * 1024 * 1024, // 5 MB — over the 4 MB limit
+					Mode: 0644,
+				}))
+				// Don't write data; ReadTarEntry rejects on header size before reading.
+				_ = tw.Close()
+
+				_, _, err := archive.ReadTarEntry(&buf, "bigfile")
+				h.AssertError(t, err, "too large")
+			})
+		})
+
+		when("tar entry exceeds max size via actual content", func() {
+			it("returns an error", func() {
+				var buf bytes.Buffer
+				tw := tar.NewWriter(&buf)
+				content := make([]byte, 5*1024*1024) // 5 MB
+				h.AssertNil(t, tw.WriteHeader(&tar.Header{
+					Name: "bigfile",
+					Size: int64(len(content)),
+					Mode: 0644,
+				}))
+				_, writeErr := tw.Write(content)
+				h.AssertNil(t, writeErr)
+				h.AssertNil(t, tw.Close())
+
+				_, _, err := archive.ReadTarEntry(&buf, "bigfile")
+				h.AssertError(t, err, "too large")
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

- Add `maxTarEntrySize` constant (4 MB) to `pkg/archive/archive.go`
- `ReadTarEntry` now rejects entries whose declared `header.Size` exceeds the limit before reading any data
- A secondary `io.LimitReader` + byte-count check catches malformed archives where the header size is understated
- Two new unit tests cover both rejection paths

## Motivation

A malicious or malformed buildpack image could include a tar entry (e.g. `buildpack.toml` / `lifecycle.toml`) with an arbitrarily large payload. `ReadTarEntry` previously called `io.ReadAll` with no bound, allowing a decompression bomb to exhaust heap memory. This is CVSS 3.1 score 6.5.

## Test plan

- [ ] `go test ./pkg/archive/... -run TestArchive/Archive/#ReadTarEntry` — all 6 cases pass
- [ ] `make build` — binary builds cleanly
- [ ] `make lint` — 0 issues
- [ ] `make tidy` — no changes