### PR TITLE
fix: guard HTTP buildpack download against disk exhaustion

### DIFF
--- a/pkg/blob/downloader.go
+++ b/pkg/blob/downloader.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/mitchellh/ioprogress"
 	"github.com/pkg/errors"
@@ -20,6 +21,10 @@ import (
 const (
 	cacheDirPrefix = "c"
 	cacheVersion   = "2"
+
+	// maxDownloadBytes is the maximum number of bytes that will be written to
+	// the download cache from a single HTTP response, guarding against disk exhaustion.
+	maxDownloadBytes int64 = 500 * 1024 * 1024 // 500 MB
 )
 
 type Logger interface {
@@ -50,7 +55,12 @@ func NewDownloader(logger Logger, baseCacheDir string, opts ...DownloaderOption)
 	d := &downloader{
 		logger:       logger,
 		baseCacheDir: baseCacheDir,
-		client:       http.DefaultClient,
+		client: &http.Client{
+			Timeout: 10 * time.Minute,
+			Transport: &http.Transport{
+				ResponseHeaderTimeout: 30 * time.Second,
+			},
+		},
 	}
 
 	for _, opt := range opts {
@@ -139,9 +149,13 @@ func (d *downloader) handleHTTP(ctx context.Context, uri string) (string, error)
 	}
 	defer fh.Close()
 
-	_, err = io.Copy(fh, reader)
+	n, err := io.Copy(fh, io.LimitReader(reader, maxDownloadBytes+1))
 	if err != nil {
 		return "", errors.Wrap(err, "writing cache")
+	}
+	if n > maxDownloadBytes {
+		_ = os.Remove(cachePath)
+		return "", fmt.Errorf("download from %s exceeded maximum allowed size of %d bytes", uri, maxDownloadBytes)
 	}
 
 	if err = os.WriteFile(etagFile, []byte(etag), 0744); err != nil {
@@ -168,6 +182,10 @@ func (d *downloader) downloadAsStream(ctx context.Context, uri string, etag stri
 	}
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if resp.ContentLength > maxDownloadBytes {
+			resp.Body.Close()
+			return nil, "", fmt.Errorf("response from %s too large: %d bytes (max %d)", uri, resp.ContentLength, maxDownloadBytes)
+		}
 		d.logger.Infof("Downloading from %s", style.Symbol(uri))
 		return withProgress(d.logger.Writer(), resp.Body, resp.ContentLength), resp.Header.Get("Etag"), nil
 	}

--- a/pkg/blob/downloader_test.go
+++ b/pkg/blob/downloader_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/heroku/color"
 	"github.com/onsi/gomega/ghttp"
@@ -158,6 +160,44 @@ func testDownloader(t *testing.T, when spec.G, it spec.S) {
 					it("should return error", func() {
 						_, err := subject.Download(context.TODO(), "not-supported://file.tgz")
 						h.AssertError(t, err, "unsupported protocol 'not-supported'")
+					})
+				})
+
+				when("response Content-Length exceeds limit", func() {
+					it("returns an error without writing to disk", func() {
+						srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							w.Header().Set("Content-Length", fmt.Sprintf("%d", 500*1024*1024+1))
+							w.WriteHeader(http.StatusOK)
+						}))
+						defer srv.Close()
+
+						_, err := subject.Download(context.TODO(), srv.URL+"/huge.tgz")
+						h.AssertError(t, err, "too large")
+
+						// No cache file should have been written (c2 dir may exist but must be empty).
+						entries, _ := os.ReadDir(filepath.Join(cacheDir, "c2"))
+						h.AssertEq(t, len(entries), 0)
+					})
+				})
+
+				when("server does not respond in time", func() {
+					it("times out and returns an error", func() {
+						hangCh := make(chan struct{})
+						srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							<-hangCh
+						}))
+						defer func() {
+							close(hangCh)
+							srv.Close()
+						}()
+
+						fastClient := &http.Client{Timeout: 50 * time.Millisecond}
+						dl := blob.NewDownloader(&logger{io.Discard}, cacheDir, blob.WithClient(fastClient))
+
+						_, err := dl.Download(context.TODO(), srv.URL+"/slow.tgz")
+						if err == nil {
+							t.Error("expected timeout error, got nil")
+						}
 					})
 				})
 			})


### PR DESCRIPTION
## Summary

- Add `maxDownloadBytes` constant (500 MB) to `pkg/blob/downloader.go`
- Reject responses whose declared `Content-Length` exceeds the limit in `downloadAsStream` before any bytes are written to disk (Option B)
- Wrap `io.Copy` in `handleHTTP` with `io.LimitReader` and remove the partial cache file if the limit is hit (Option A — catches chunked/no-Content-Length responses)
- Replace `http.DefaultClient` in `NewDownloader` with a client that has a 10-minute timeout and 30-second `ResponseHeaderTimeout`, closing the slow-drip attack vector (Option C)
- Two new unit tests cover the Content-Length rejection and timeout paths

## Motivation

`pkg/blob/downloader.go` previously called `io.Copy(fh, reader)` with no size bound when caching HTTP buildpack downloads. A malicious endpoint referenced via `--buildpack`, `project.toml`, or a builder config could stream an arbitrarily large response to fill the victim's disk partition. The default cache location (`~/.pack/download-cache`) shares the home partition on typical systems, so exhaustion disrupts unrelated processes. Reported by bugbunny.ai, CVSS 3.1: 6.5 (`CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H`).

## Test plan

- [ ] `go test ./pkg/blob/... -v` — all 9 cases pass
- [ ] `make build` — binary builds cleanly
- [ ] `make lint` — 0 issues