### PR TITLE
chore: upgrade Go to 1.25.10 to fix stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -157,4 +157,4 @@ require (
 
 replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v1.3.2
 
-go 1.25.9
+go 1.25.10


### PR DESCRIPTION
## Summary
- Bumps minimum Go version from 1.25.9 to 1.25.10 in `go.mod`
- Addresses stdlib vulnerabilities flagged by grype scans in #2595 and #2600

## Test plan
- [ ] CI build passes on Go 1.25.10
- [ ] Unit and acceptance test suites pass
- [ ] Re-run `grype` on the built `out/pack` binary to confirm stdlib CVEs are resolved

Fixes #2595 
Fixes #2600

Signed-off-by: Juan Bustamante <bustamantejj@gmail.com>