### PR TITLE
Pin Beta Release tag to build commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -373,6 +373,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          target_commitish: ${{ github.sha }}
           tag_name: v${{ env.PACK_VERSION }}
           name: pack v${{ env.PACK_VERSION }}
           draft: true


### PR DESCRIPTION
The `Create Beta Release` step in `build.yml` doesn't set `target_commitish`, so `softprops/action-gh-release` defaults the tag to `main`. Because `release-merge.yml` runs in parallel and pushes the release branch into `main`, by the time the Beta Release step runs, `main` may include commits that aren't in the binary — causing the published artifacts and the source at the tag to silently disagree (as happened in v0.40.5).

Set `target_commitish: ${{ github.sha }}` to pin the tag to the release-branch commit the binaries were built from. Mirrors what the `Create Pre-Release` step already does.

Fixes #2603