### PR TITLE
fix: include CA certificates in the pack base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,10 @@ COPY . .
 RUN make build
 
 FROM ${base_image}
+# Ensure CA certificates are present so pack can make TLS connections (e.g. to
+# pull builder and run images from registries). The distroless base bundles
+# them, but ubuntu:jammy used for the -base image does not, so copy the bundle
+# from the builder stage to cover every base image. See #2488.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /app/out/pack /usr/local/bin/pack
 ENTRYPOINT [ "/usr/local/bin/pack" ]


### PR DESCRIPTION
## Summary

The `delivery / docker` workflow builds the `Dockerfile` twice:

* the tiny image (`buildpacksio/pack` and `:latest`) from `gcr.io/distroless/static`
* the base image (`buildpacksio/pack:<version>-base` and `:base`) from `ubuntu:jammy`

The distroless base bundles a CA certificate store, but the `ubuntu:jammy` image does not ship the `ca-certificates` package. As a result the `-base` image has no trusted roots, and any `pack` command that reaches a registry over TLS fails (reported in #2488):

```
ERROR: fetching builder image: connect to repo store "...": Get "https://index.docker.io/v2/": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

The fix copies the CA bundle from the `golang` builder stage (which is Debian based and includes `ca-certificates`) into the final image. This restores trusted roots for the `ubuntu:jammy` based `-base` image and is a no-op for the distroless image, which already ships the same bundle at that path, so a single line covers every published base image.

## Output
<!-- If applicable, please provide examples of the output changes. -->

I verified this by building the `Dockerfile` with each base image and performing an HTTPS request to a registry from inside each resulting container.

#### Before

```
$ docker run --rm buildpacksio/pack:base builder inspect bellsoft/buildpacks.builder:musl
REMOTE:
ERROR: fetching builder image: ... tls: failed to verify certificate: x509: certificate signed by unknown authority
```

#### After

```
$ docker run --rm <pack:base built from this PR> builder inspect bellsoft/buildpacks.builder:musl
# TLS handshake succeeds and the remote image is inspected
```

The distroless `:latest` image is unaffected and keeps working.

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related

Resolves #2488
