### PR TITLE
Fetch run image locally for publish extensions

### DIFF
--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -420,7 +420,13 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		pathsConfig.hostRunImagePath = hostRunImagePath
 	}
 
-	runImage, warnings, err := c.validateRunImage(ctx, runImageName, fetchOptions, bldr.StackID)
+	runImageFetchOptions := fetchOptions
+	// Run image extensions create a local ephemeral run image from this base image.
+	if !opts.Layout() && (len(opts.Extensions) > 0 || len(bldr.OrderExtensions()) > 0) {
+		runImageFetchOptions.Daemon = true
+	}
+
+	runImage, warnings, err := c.validateRunImage(ctx, runImageName, runImageFetchOptions, bldr.StackID)
 	if err != nil {
 		return errors.Wrapf(err, "invalid run-image '%s'", runImageName)
 	}
@@ -686,7 +692,10 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 
 	lifecycleOpts.FetchRunImageWithLifecycleLayer = func(runImageName string) (string, error) {
 		ephemeralRunImageName := fmt.Sprintf("pack.local/run-image/%x:latest", randString(10))
-		runImage, err := c.imageFetcher.Fetch(ctx, runImageName, fetchOptions)
+		runImageFetchOptions := fetchOptions
+		// local.FromBaseImage requires the base image to be available in the daemon.
+		runImageFetchOptions.Daemon = true
+		runImage, err := c.imageFetcher.Fetch(ctx, runImageName, runImageFetchOptions)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/client/build_test.go
+++ b/pkg/client/build_test.go
@@ -1910,6 +1910,20 @@ api = "0.2"
 `)
 				})
 			})
+
+			it("fetches the run image into the daemon when publishing", func() {
+				fakeImageFetcher.RemoteImages[fakeDefaultRunImage.Name()] = fakeDefaultRunImage
+
+				h.AssertNil(t, subject.Build(context.TODO(), BuildOptions{
+					Image:      "some/app",
+					Builder:    defaultBuilderName,
+					Publish:    true,
+					Extensions: []string{"extension.1.id"},
+				}))
+
+				args := fakeImageFetcher.FetchCalls[defaultRunImageName]
+				h.AssertEq(t, args.Daemon, true)
+			})
 		})
 
 		//TODO: "all buildpacks are added to ephemeral builder" test after extractPackaged() is completed.


### PR DESCRIPTION
## Summary
- Fetched the run image into the Docker daemon when image extensions are used, even when `--publish` normally resolves it remotely.
- Forced the lifecycle extension run-image fetch path to use the daemon because it builds a local ephemeral run image from that base image.
- Added a regression test for `--publish` with `Extensions`.

## Output

#### Before

`pack build --publish --extension ...` could validate the run image remotely, then fail later when the extension flow tried to create a local ephemeral run image from a base image that was not in the daemon.

#### After

The run image is available in the daemon before the extension flow creates the local ephemeral run image.

## Documentation

- Should this change be documented?
    - [x] No

## Related

Resolves #2559

## Tests
- `go test ./pkg/client`

GitHub checks passed on the latest commit (`a4e1cec`): DCO, CodeQL, build tests on macOS/Linux/Windows, and compatibility acceptance combos.

`make unit` failed locally because Docker is not available at `/var/run/docker.sock`; the changed `pkg/client` package passed during that run.
