### PR TITLE
Match known trusted builders by repository

### DIFF
--- a/internal/builder/trusted_builder.go
+++ b/internal/builder/trusted_builder.go
@@ -109,8 +109,26 @@ var KnownBuilders = []KnownBuilder{
 }
 
 func IsKnownTrustedBuilder(builderName string) bool {
+	builderReference, err := name.ParseReference(builderName, name.WithDefaultTag(""))
+	if err != nil {
+		return false
+	}
+
+	return isKnownTrustedBuilderReference(builderReference)
+}
+
+func isKnownTrustedBuilderReference(builderReference name.Reference) bool {
 	for _, knownBuilder := range KnownBuilders {
-		if builderName == knownBuilder.Image && knownBuilder.Trusted {
+		if !knownBuilder.Trusted {
+			continue
+		}
+
+		knownBuilderReference, err := name.ParseReference(knownBuilder.Image, name.WithDefaultTag(""))
+		if err != nil {
+			continue
+		}
+
+		if referencesMatch(knownBuilderReference, builderReference) {
 			return true
 		}
 	}
@@ -122,20 +140,27 @@ func IsTrustedBuilder(cfg config.Config, builderName string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+
+	if isKnownTrustedBuilderReference(builderReference) {
+		return true, nil
+	}
+
 	for _, trustedBuilder := range cfg.TrustedBuilders {
 		trustedBuilderReference, err := name.ParseReference(trustedBuilder.Name, name.WithDefaultTag(""))
 		if err != nil {
 			return false, err
 		}
-		if trustedBuilderReference.Identifier() != "" {
-			if builderReference.Name() == trustedBuilderReference.Name() {
-				return true, nil
-			}
-		} else {
-			if builderReference.Context().RepositoryStr() == trustedBuilderReference.Context().RepositoryStr() {
-				return true, nil
-			}
+		if referencesMatch(trustedBuilderReference, builderReference) {
+			return true, nil
 		}
 	}
 	return false, nil
+}
+
+func referencesMatch(trustedReference name.Reference, builderReference name.Reference) bool {
+	if trustedReference.Identifier() != "" {
+		return builderReference.Name() == trustedReference.Name()
+	}
+
+	return builderReference.Context().RepositoryStr() == trustedReference.Context().RepositoryStr()
 }

--- a/internal/builder/trusted_builder_test.go
+++ b/internal/builder/trusted_builder_test.go
@@ -21,15 +21,27 @@ func TestTrustedBuilder(t *testing.T) {
 
 func trustedBuilder(t *testing.T, when spec.G, it spec.S) {
 	when("IsKnownTrustedBuilder", func() {
-		it("matches exactly", func() {
+		it("trusts tagless known builder entries by repository", func() {
 			h.AssertTrue(t, bldr.IsKnownTrustedBuilder("paketobuildpacks/builder-jammy-base"))
-			h.AssertFalse(t, bldr.IsKnownTrustedBuilder("paketobuildpacks/builder-jammy-base:latest"))
-			h.AssertFalse(t, bldr.IsKnownTrustedBuilder("paketobuildpacks/builder-jammy-base:1.2.3"))
+			h.AssertTrue(t, bldr.IsKnownTrustedBuilder("paketobuildpacks/builder-jammy-base:latest"))
+			h.AssertTrue(t, bldr.IsKnownTrustedBuilder("paketobuildpacks/builder-jammy-base:1.2.3"))
 			h.AssertFalse(t, bldr.IsKnownTrustedBuilder("my/private/builder"))
+		})
+
+		it("keeps tagged known builder entries tag-exact", func() {
+			h.AssertTrue(t, bldr.IsKnownTrustedBuilder("heroku/builder:24"))
+			h.AssertFalse(t, bldr.IsKnownTrustedBuilder("heroku/builder:25"))
+			h.AssertFalse(t, bldr.IsKnownTrustedBuilder("heroku/builder"))
 		})
 	})
 
 	when("IsTrustedBuilder", func() {
+		it("includes known trusted builders", func() {
+			isTrusted, err := bldr.IsTrustedBuilder(config.Config{}, "paketobuildpacks/builder-jammy-base:latest")
+			h.AssertNil(t, err)
+			h.AssertTrue(t, isTrusted)
+		})
+
 		it("trust image without tag", func() {
 			cfg := config.Config{
 				TrustedBuilders: []config.TrustedBuilder{

--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -121,7 +121,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 			if err != nil {
 				return err
 			}
-			trustBuilder := isTrusted || bldr.IsKnownTrustedBuilder(builder) || flags.TrustBuilder
+			trustBuilder := isTrusted || flags.TrustBuilder
 			if trustBuilder {
 				logger.Debugf("Builder %s is trusted", style.Symbol(builder))
 				if flags.LifecycleImage != "" {

--- a/internal/commands/build_test.go
+++ b/internal/commands/build_test.go
@@ -139,6 +139,19 @@ func testBuildCommand(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 
+			when("the builder matches a tagless known trusted builder", func() {
+				it("sets the trust builder option", func() {
+					mockClient.EXPECT().
+						Build(gomock.Any(), EqBuildOptionsWithTrustedBuilder(true)).
+						Return(nil)
+
+					logger.WantVerbose(true)
+					command.SetArgs([]string{"image", "--builder", "paketobuildpacks/builder-jammy-base:latest"})
+					h.AssertNil(t, command.Execute())
+					h.AssertContains(t, outBuf.String(), "Builder 'paketobuildpacks/builder-jammy-base:latest' is trusted")
+				})
+			})
+
 			when("the image name matches a builder name", func() {
 				it("refuses to build", func() {
 					logger.WantVerbose(true)

--- a/internal/commands/builder_inspect.go
+++ b/internal/commands/builder_inspect.go
@@ -71,7 +71,7 @@ func inspectBuilder(
 	builderInfo := writer.SharedBuilderInfo{
 		Name:      imageName,
 		IsDefault: imageName == cfg.DefaultBuilder,
-		Trusted:   isTrusted || bldr.IsKnownTrustedBuilder(imageName),
+		Trusted:   isTrusted,
 	}
 
 	localInfo, localErr := inspector.InspectBuilder(imageName, true, client.WithDetectionOrderDepth(flags.Depth))

--- a/internal/commands/builder_inspect_test.go
+++ b/internal/commands/builder_inspect_test.go
@@ -215,7 +215,7 @@ func testBuilderInspectCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("image is a known trusted builder", func() {
+		when("image matches a known trusted builder", func() {
 			it("passes builder info with trusted true to the writer's `Print` method", func() {
 				builderWriter := newDefaultBuilderWriter()
 
@@ -225,7 +225,7 @@ func testBuilderInspectCommand(t *testing.T, when spec.G, it spec.S) {
 					newDefaultBuilderInspector(),
 					newWriterFactory(returnsForWriter(builderWriter)),
 				)
-				command.SetArgs([]string{"heroku/builder:24"})
+				command.SetArgs([]string{"paketobuildpacks/builder-jammy-base:latest"})
 
 				err := command.Execute()
 				assert.Nil(err)

--- a/internal/commands/config_trusted_builder.go
+++ b/internal/commands/config_trusted_builder.go
@@ -55,7 +55,7 @@ func addTrustedBuilder(args []string, logger logging.Logger, cfg config.Config, 
 	if err != nil {
 		return err
 	}
-	if isTrusted || bldr.IsKnownTrustedBuilder(imageName) {
+	if isTrusted {
 		logger.Infof("Builder %s is already trusted", style.Symbol(imageName))
 		return nil
 	}

--- a/internal/commands/config_trusted_builder_test.go
+++ b/internal/commands/config_trusted_builder_test.go
@@ -179,7 +179,7 @@ func testTrustedBuilderCommand(t *testing.T, when spec.G, it spec.S) {
 				it("does nothing", func() {
 					h.AssertNil(t, os.WriteFile(configPath, []byte(""), os.ModePerm))
 
-					command.SetArgs(append(args, "paketobuildpacks/builder-jammy-base"))
+					command.SetArgs(append(args, "paketobuildpacks/builder-jammy-base:latest"))
 					h.AssertNil(t, command.Execute())
 					oldContents, err := os.ReadFile(configPath)
 					h.AssertNil(t, err)


### PR DESCRIPTION
## Summary

- Matched known trusted builders with the same reference-aware semantics used for configured trusted builders.
- Kept explicitly tagged known builders tag-exact, so entries like `heroku/builder:24` do not trust unrelated tags.
- Centralized command trust checks on `IsTrustedBuilder` so build, inspect, and config add paths do not patch known and configured trust separately.

## Context

Fixes #2572.

Known trusted builders listed without a tag, such as `paketobuildpacks/builder-jammy-base`, previously only matched the exact string and did not trust `paketobuildpacks/builder-jammy-base:latest`. Configured trusted builders already matched tagless entries by repository, so this applies the same behavior to known trusted builders while preserving exact tag matching for tagged known entries.

## Validation

- `go test ./internal/builder -run TestTrustedBuilder -count=1`
- `go test ./internal/builder ./internal/commands -run 'TestTrustedBuilder|TestBuildCommand|TestBuilderInspectCommand|TestTrustedBuilderCommand' -count=1`
- `go test ./internal/commands ./pkg/client -count=1`

Note: `go test ./internal/builder -count=1` still fails locally on `TestBuilder/.../when_CNB_BUILD_CONFIG_DIR_is_defined/adds_the_env_vars_as_files_to_the_image` because it expects `/cnb/dup-build-config-dir/env/SOME_KEY` but the generated layer contains `/cnb/build-config/env/SOME_KEY`. The trust-builder suite in that package passes.
