### PR TITLE
fix(buildpack): allow port numbers in registry reference URIs

### DIFF
--- a/internal/registry/index.go
+++ b/internal/registry/index.go
@@ -11,10 +11,10 @@ import (
 )
 
 var (
-	validCharsPattern       = "[a-z0-9\\-.]+"
+	validCharsPattern         = "[a-z0-9\\-.]+"
 	validCharsPatternWithPort = "[a-z0-9\\-.:]+"
-	validCharsRegexp        = regexp.MustCompile(fmt.Sprintf("^%s$", validCharsPattern))
-	validCharsPortRegexp    = regexp.MustCompile(fmt.Sprintf("^%s$", validCharsPatternWithPort))
+	validCharsRegexp          = regexp.MustCompile(fmt.Sprintf("^%s$", validCharsPattern))
+	validCharsPortRegexp      = regexp.MustCompile(fmt.Sprintf("^%s$", validCharsPatternWithPort))
 )
 
 // IndexPath resolves the path for a specific namespace and name of buildpack

--- a/internal/registry/index.go
+++ b/internal/registry/index.go
@@ -11,17 +11,19 @@ import (
 )
 
 var (
-	validCharsPattern = "[a-z0-9\\-.]+"
-	validCharsRegexp  = regexp.MustCompile(fmt.Sprintf("^%s$", validCharsPattern))
+	validCharsPattern       = "[a-z0-9\\-.]+"
+	validCharsPatternWithPort = "[a-z0-9\\-.:]+"
+	validCharsRegexp        = regexp.MustCompile(fmt.Sprintf("^%s$", validCharsPattern))
+	validCharsPortRegexp    = regexp.MustCompile(fmt.Sprintf("^%s$", validCharsPatternWithPort))
 )
 
 // IndexPath resolves the path for a specific namespace and name of buildpack
 func IndexPath(rootDir, ns, name string) (string, error) {
-	if err := validateField("namespace", ns); err != nil {
+	if err := validateField("namespace", ns, validCharsPortRegexp); err != nil {
 		return "", err
 	}
 
-	if err := validateField("name", name); err != nil {
+	if err := validateField("name", name, validCharsRegexp); err != nil {
 		return "", err
 	}
 
@@ -40,7 +42,7 @@ func IndexPath(rootDir, ns, name string) (string, error) {
 	return filepath.Join(rootDir, indexDir, fmt.Sprintf("%s_%s", ns, name)), nil
 }
 
-func validateField(field, value string) error {
+func validateField(field, value string, re *regexp.Regexp) error {
 	length := len(value)
 	switch {
 	case length == 0:
@@ -49,7 +51,7 @@ func validateField(field, value string) error {
 		return errors.Errorf("%s too long (max 253 chars)", style.Symbol(field))
 	}
 
-	if !validCharsRegexp.MatchString(value) {
+	if !re.MatchString(value) {
 		return errors.Errorf("%s contains illegal characters (must match %s)", style.Symbol(field), style.Symbol(validCharsPattern))
 	}
 

--- a/pkg/buildpack/locator_type.go
+++ b/pkg/buildpack/locator_type.go
@@ -36,7 +36,7 @@ const (
 var (
 	// https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 	semverPattern   = `(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`
-	registryPattern = regexp.MustCompile(`^[a-z0-9\-\.]+\/[a-z0-9\-\.]+(?:@` + semverPattern + `)?$`)
+	registryPattern = regexp.MustCompile(`^[a-z0-9\-\.]+(?::\d+)?\/[a-z0-9\-\.]+(?:@` + semverPattern + `)?$`)
 )
 
 func (l LocatorType) String() string {

--- a/pkg/buildpack/locator_type.go
+++ b/pkg/buildpack/locator_type.go
@@ -36,7 +36,7 @@ const (
 var (
 	// https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 	semverPattern   = `(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`
-	registryPattern = regexp.MustCompile(`^[a-z0-9\-\.]+(?::\d+)?\/[a-z0-9\-\.]+(?:@` + semverPattern + `)?$`)
+	registryPattern = regexp.MustCompile(`^[a-z0-9\-\.]+\/[a-z0-9\-\.]+(?:@` + semverPattern + `)?$`)
 )
 
 func (l LocatorType) String() string {
@@ -71,7 +71,7 @@ func GetLocatorType(locator string, relativeBaseDir string, buildpacksFromBuilde
 
 	if paths.IsURI(locator) {
 		if HasDockerLocator(locator) {
-			if _, err := name.ParseReference(locator); err == nil {
+			if _, err := name.ParseReference(ParsePackageLocator(locator)); err == nil {
 				return PackageLocator, nil
 			}
 		}


### PR DESCRIPTION
`canBeRegistryRef` regex didn't allow port numbers in registry hostnames. URIs like `docker://localhost:5000/foo/bar` were incorrectly rejected.

The fix adds an optional port group to the registry pattern: `:[0-9]+` after the hostname.

Fixes #2536