### PR TITLE
fix(registry): fix yank buildpack issue body template

### DIFF
--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -36,11 +36,7 @@ type Cache struct {
 }
 
 const GithubIssueTitleTemplate = "{{ if .Yanked }}YANK{{ else }}ADD{{ end }} {{.Namespace}}/{{.Name}}@{{.Version}}"
-const GithubIssueBodyTemplate = `
-id = "{{.Namespace}}/{{.Name}}"
-version = "{{.Version}}"
-{{ if .Yanked }}{{ else if .Address }}addr = "{{.Address}}"{{ end }}
-`
+const GithubIssueBodyTemplate = "```\nid = \"{{.Namespace}}/{{.Name}}\"\nversion = \"{{.Version}}\"\n{{ if .Yanked }}yank = true{{ else if .Address }}addr = \"{{.Address}}\"{{ end }}\n```"
 const GitCommitTemplate = `{{ if .Yanked }}YANK{{else}}ADD{{end}} {{.Namespace}}/{{.Name}}@{{.Version}}`
 
 // Entry is a list of buildpacks stored in a registry


### PR DESCRIPTION
## Summary

Fixes #2461. The `pack buildpack yank` command generated an invalid GitHub issue body — it was missing `yank = true` when the buildpack is yanked, and the body was missing triple backtick code block delimiters.

## Root Cause

In `internal/registry/registry_cache.go`, the `GithubIssueBodyTemplate` had two bugs:
1. When `.Yanked` is true, the template output nothing (empty `{{ if .Yanked }}{{ else }}...`)
2. The template wasn't wrapped in triple backticks, so the issue body wasn't formatted as a code block

## Fix

- Changed `{{ if .Yanked }}{{ else if .Address }}` to `{{ if .Yanked }}yank = true{{ else if .Address }}`
- Wrapped the template in triple backtick delimiters (```)

## Testing

The generated issue body now correctly includes `yank = true` for yanked buildpacks and is properly wrapped in a code block.