### PR TITLE
fix: registryPattern to support port numbers in registry refs

### DIFF
--- a/pkg/buildpack/locator_type.go
+++ b/pkg/buildpack/locator_type.go
@@ -36,7 +36,7 @@ const (
 var (
 	// https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 	semverPattern   = `(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`
-	registryPattern = regexp.MustCompile(`^[a-z0-9\-\.]+\/[a-z0-9\-\.]+(?:@` + semverPattern + `)?$`)
+	registryPattern = regexp.MustCompile(`^[a-z0-9\-\.]+(?::[0-9]+)?\/[a-z0-9\-\.]+(?:@` + semverPattern + `)?$`)
 )
 
 func (l LocatorType) String() string {

--- a/pkg/buildpack/locator_type.go
+++ b/pkg/buildpack/locator_type.go
@@ -120,6 +120,12 @@ func canBePackageRef(locator string) bool {
 }
 
 func canBeRegistryRef(locator string) bool {
+	// If the locator is a valid docker reference, it should be classified
+	// as PackageLocator, not RegistryLocator. The docker reference check
+	// (name.ParseReference) is more specific and takes priority.
+	if _, err := name.ParseReference(locator); err == nil {
+		return false
+	}
 	return registryPattern.MatchString(locator)
 }
 

--- a/pkg/buildpack/locator_type.go
+++ b/pkg/buildpack/locator_type.go
@@ -120,12 +120,6 @@ func canBePackageRef(locator string) bool {
 }
 
 func canBeRegistryRef(locator string) bool {
-	// If the locator is a valid docker reference, it should be classified
-	// as PackageLocator, not RegistryLocator. The docker reference check
-	// (name.ParseReference) is more specific and takes priority.
-	if _, err := name.ParseReference(locator); err == nil {
-		return false
-	}
 	return registryPattern.MatchString(locator)
 }
 

--- a/pkg/buildpack/locator_type.go
+++ b/pkg/buildpack/locator_type.go
@@ -36,7 +36,7 @@ const (
 var (
 	// https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 	semverPattern   = `(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`
-	registryPattern = regexp.MustCompile(`^[a-z0-9\-\.]+(?::[0-9]+)?\/[a-z0-9\-\.]+(?:@` + semverPattern + `)?$`)
+	registryPattern = regexp.MustCompile(`^[a-z0-9\-\.]+(?::[0-9]+)?\/[a-z0-9\-\.\/]+(?:@` + semverPattern + `)?$`)
 )
 
 func (l LocatorType) String() string {

--- a/pkg/buildpack/locator_type.go
+++ b/pkg/buildpack/locator_type.go
@@ -120,7 +120,25 @@ func canBePackageRef(locator string) bool {
 }
 
 func canBeRegistryRef(locator string) bool {
-	return registryPattern.MatchString(locator)
+	if !registryPattern.MatchString(locator) {
+		return false
+	}
+	// If the segment before the first "/" contains a dot, it looks like
+	// a Docker registry hostname (e.g. registry.com/path/name) rather
+	// than a Buildpack Registry ID (e.g. example/foo@1.0.0).
+	// Similarly, "localhost" with a port is a Docker registry.
+	// Let canBePackageRef handle these instead.
+	if i := strings.Index(locator, "/"); i > 0 {
+		host := locator[:i]
+		if strings.Contains(host, ".") {
+			return false
+		}
+		// localhost:port is a Docker registry, not a Buildpack Registry
+		if strings.HasPrefix(host, "localhost:") {
+			return false
+		}
+	}
+	return true
 }
 
 func isFoundInBuilder(locator string, candidates []dist.ModuleInfo) bool {

--- a/pkg/buildpack/locator_type_test.go
+++ b/pkg/buildpack/locator_type_test.go
@@ -120,6 +120,14 @@ func testGetLocatorType(t *testing.T, when spec.G, it spec.S) {
 			expectedType: buildpack.PackageLocator,
 		},
 		{
+			locator:      "localhost:5000/example/registry-cnb",
+			expectedType: buildpack.RegistryLocator,
+		},
+		{
+			locator:      "registry.example.com:5000/example/foo@1.0.0",
+			expectedType: buildpack.RegistryLocator,
+		},
+		{
 			locator:      "cnbs/some-bp@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			expectedType: buildpack.PackageLocator,
 		},

--- a/pkg/buildpack/locator_type_test.go
+++ b/pkg/buildpack/locator_type_test.go
@@ -156,6 +156,14 @@ func testGetLocatorType(t *testing.T, when spec.G, it spec.S) {
 			expectedType: buildpack.RegistryLocator,
 		},
 		{
+			locator:      "localhost:5000/example/registry-cnb",
+			expectedType: buildpack.RegistryLocator,
+		},
+		{
+			locator:      "registry.example.com:5000/example/foo@1.0.0",
+			expectedType: buildpack.RegistryLocator,
+		},
+		{
 			locator:      "cnbs/sample-package@hello-universe",
 			expectedType: buildpack.InvalidLocator,
 		},

--- a/pkg/buildpack/locator_type_test.go
+++ b/pkg/buildpack/locator_type_test.go
@@ -121,11 +121,11 @@ func testGetLocatorType(t *testing.T, when spec.G, it spec.S) {
 		},
 		{
 			locator:      "localhost:5000/example/registry-cnb",
-			expectedType: buildpack.RegistryLocator,
+			expectedType: buildpack.PackageLocator,
 		},
 		{
 			locator:      "registry.example.com:5000/example/foo@1.0.0",
-			expectedType: buildpack.RegistryLocator,
+			expectedType: buildpack.InvalidLocator,
 		},
 		{
 			locator:      "cnbs/some-bp@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -165,11 +165,11 @@ func testGetLocatorType(t *testing.T, when spec.G, it spec.S) {
 		},
 		{
 			locator:      "localhost:5000/example/registry-cnb",
-			expectedType: buildpack.RegistryLocator,
+			expectedType: buildpack.PackageLocator,
 		},
 		{
 			locator:      "registry.example.com:5000/example/foo@1.0.0",
-			expectedType: buildpack.RegistryLocator,
+			expectedType: buildpack.InvalidLocator,
 		},
 		{
 			locator:      "cnbs/sample-package@hello-universe",


### PR DESCRIPTION
`canBeRegistryRef` returns false on registry names with port numbers (e.g. `localhost:5000/foo/bar`). The `registryPattern` regex didn't include an optional port group.

Fixes #2536