### PR TITLE
Add `--append-image-name-suffix` to `pack extension package`

### DIFF
--- a/internal/commands/extension_package.go
+++ b/internal/commands/extension_package.go
@@ -19,13 +19,14 @@ import (
 
 // ExtensionPackageFlags define flags provided to the ExtensionPackage command
 type ExtensionPackageFlags struct {
-	PackageTomlPath string
-	Format          string
-	Targets         []string
-	Publish         bool
-	Policy          string
-	Path            string
-	AdditionalTags  []string
+	PackageTomlPath       string
+	Format                string
+	Targets               []string
+	Publish               bool
+	Policy                string
+	Path                  string
+	AppendImageNameSuffix bool
+	AdditionalTags        []string
 }
 
 // ExtensionPackager packages extensions
@@ -114,15 +115,20 @@ func ExtensionPackage(logger logging.Logger, cfg config.Config, packager Extensi
 				defer clean(filesToClean)
 			}
 
+			if !flags.Publish && flags.AppendImageNameSuffix {
+				logger.Warnf("--append-image-name-suffix will be ignored, use combined with --publish")
+			}
+
 			if err := packager.PackageExtension(cmd.Context(), client.PackageBuildpackOptions{
-				RelativeBaseDir: relativeBaseDir,
-				Name:            name,
-				Format:          flags.Format,
-				Config:          exPackageCfg,
-				Publish:         flags.Publish,
-				PullPolicy:      pullPolicy,
-				Targets:         multiArchCfg.Targets(),
-				AdditionalTags:  flags.AdditionalTags,
+				RelativeBaseDir:       relativeBaseDir,
+				Name:                  name,
+				Format:                flags.Format,
+				Config:                exPackageCfg,
+				Publish:               flags.Publish,
+				AppendImageNameSuffix: flags.AppendImageNameSuffix && flags.Publish,
+				PullPolicy:            pullPolicy,
+				Targets:               multiArchCfg.Targets(),
+				AdditionalTags:        flags.AdditionalTags,
 			}); err != nil {
 				return err
 			}
@@ -145,6 +151,7 @@ func ExtensionPackage(logger logging.Logger, cfg config.Config, packager Extensi
 	cmd.Flags().StringVarP(&flags.PackageTomlPath, "config", "c", "", "Path to package TOML config")
 	cmd.Flags().StringVarP(&flags.Format, "format", "f", "", `Format to save package as ("image" or "file")`)
 	cmd.Flags().BoolVar(&flags.Publish, "publish", false, `Publish the extension directly to the container registry specified in <name>, instead of the daemon (applies to "--format=image" only).`)
+	cmd.Flags().BoolVar(&flags.AppendImageNameSuffix, "append-image-name-suffix", false, "When publishing to a registry that doesn't allow overwrite existing tags use this flag to append a [os]-[arch] suffix to package <name>")
 	cmd.Flags().StringVar(&flags.Policy, "pull-policy", "", "Pull policy to use. Accepted values are always, never, and if-not-present. The default is always")
 	cmd.Flags().StringVarP(&flags.Path, "path", "p", "", "Path to the Extension that needs to be packaged")
 	cmd.Flags().StringSliceVarP(&flags.Targets, "target", "t", nil,

--- a/internal/commands/extension_package_test.go
+++ b/internal/commands/extension_package_test.go
@@ -181,6 +181,39 @@ func testExtensionPackageCommand(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("--append-image-name-suffix", func() {
+			it("passes the flag to the packager when publishing", func() {
+				cmd := packageExtensionCommand(withExtensionPackager(fakeExtensionPackager))
+				cmd.SetArgs([]string{
+					"some-image-name",
+					"--config", "/path/to/some/file",
+					"--publish",
+					"--append-image-name-suffix",
+				})
+				h.AssertNil(t, cmd.Execute())
+
+				receivedOptions := fakeExtensionPackager.CreateCalledWithOptions
+				h.AssertEq(t, receivedOptions.AppendImageNameSuffix, true)
+			})
+
+			it("is ignored and warns when not publishing", func() {
+				cmd := packageExtensionCommand(
+					withExtensionPackager(fakeExtensionPackager),
+					withExtensionLogger(logger),
+				)
+				cmd.SetArgs([]string{
+					"some-image-name",
+					"--config", "/path/to/some/file",
+					"--append-image-name-suffix",
+				})
+				h.AssertNil(t, cmd.Execute())
+
+				receivedOptions := fakeExtensionPackager.CreateCalledWithOptions
+				h.AssertEq(t, receivedOptions.AppendImageNameSuffix, false)
+				h.AssertContains(t, outBuf.String(), "--append-image-name-suffix will be ignored")
+			})
+		})
+
 		when("no config path is specified", func() {
 			when("no path is specified", func() {
 				it("creates a default config with the uri set to the current working directory", func() {

--- a/pkg/client/package_extension.go
+++ b/pkg/client/package_extension.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/buildpacks/pack/internal/layer"
+	"github.com/buildpacks/pack/internal/name"
 	"github.com/buildpacks/pack/internal/style"
 	"github.com/buildpacks/pack/pkg/buildpack"
 	"github.com/buildpacks/pack/pkg/dist"
@@ -103,7 +104,14 @@ func (c *Client) packageExtensionTarget(ctx context.Context, opts PackageBuildpa
 			return digest, err
 		}
 	case FormatImage:
-		img, err := packageBuilder.SaveAsImage(opts.Name, opts.Publish, target, opts.Labels, opts.AdditionalTags...)
+		packageName := opts.Name
+		if multiArch && opts.AppendImageNameSuffix {
+			packageName, err = name.AppendSuffix(packageName, target)
+			if err != nil {
+				return "", errors.Wrap(err, "invalid image name")
+			}
+		}
+		img, err := packageBuilder.SaveAsImage(packageName, opts.Publish, target, opts.Labels, opts.AdditionalTags...)
 		if err != nil {
 			return digest, errors.Wrapf(err, "saving image")
 		}


### PR DESCRIPTION
## Summary

`pack buildpack package` supports `--append-image-name-suffix`, but `pack extension package` does not.

When publishing a multi-arch extension with `--publish`, pack builds one image per target platform and pushes them before assembling the final image index. Without a suffix, every platform image is pushed to the same tag. On a registry that doesn't allow overwriting an existing tag, the second platform's push is rejected and the publish fails.

This adds `--append-image-name-suffix` to `pack extension package`, mirroring the existing buildpack command. When the flag is set on a multi-arch `--publish`, each platform image is pushed to a distinct `[os]-[arch]` tag, so no two pushes collide. The final image index is unchanged and still resolves to all platforms. The suffix only applies when the build is multi-arch (`len(targets) > 1`) and `--publish` is set.

The change reuses the shared `client.PackageBuildpackOptions` (it already has the `AppendImageNameSuffix` field), so it closely mirrors the buildpack code:

- Flag struct field — [`buildpack_package.go#L33`](https://github.com/buildpacks/pack/blob/a7f39ca33f3c2d65211843d04c48f114db1f080a/internal/commands/buildpack_package.go#L33)
- Warning when used without `--publish` — [`buildpack_package.go#L135-L137`](https://github.com/buildpacks/pack/blob/a7f39ca33f3c2d65211843d04c48f114db1f080a/internal/commands/buildpack_package.go#L135-L137)
- Passing the option (gated on `--publish`) — [`buildpack_package.go#L145`](https://github.com/buildpacks/pack/blob/a7f39ca33f3c2d65211843d04c48f114db1f080a/internal/commands/buildpack_package.go#L145)
- Flag registration — [`buildpack_package.go#L174`](https://github.com/buildpacks/pack/blob/a7f39ca33f3c2d65211843d04c48f114db1f080a/internal/commands/buildpack_package.go#L174)
- Suffix logic in the client — [`package_buildpack.go#L204-L211`](https://github.com/buildpacks/pack/blob/a7f39ca33f3c2d65211843d04c48f114db1f080a/pkg/client/package_buildpack.go#L204-L211)

I added unit tests covering that the flag is passed through when publishing and ignored (with a warning) when not. I did not add a client-level test for the suffix itself: the transformation it calls (`name.AppendSuffix`) is already covered in `internal/name`, and a multi-arch publish test would need significant new mocking the buildpack path doesn't have either. Happy to add one if preferred.

## Output

Publishing the samples `cowsay` extension to two platforms:

```
pack extension package <registry>/cowsay --path extensions/cowsay --publish \
  --target linux/amd64 --target linux/arm64 [--append-image-name-suffix]
```

#### Before

Only the index tag is created. On a registry that blocks tag overwrites, the publish fails when the second platform pushes to the already-existing tag:

```
$ curl -s <registry>/v2/cowsay/tags/list
{"name":"cowsay","tags":["latest"]}

# on an overwrite-protected registry:
ERROR: saving image: failed to write image to the following tags:
[<registry>/cowsay: PUT .../manifests/latest: <rejected: tag already exists>]
```

#### After

Each platform gets its own tag, so nothing is overwritten and the publish succeeds. `latest` still resolves to both platforms:

```
$ curl -s <registry>/v2/cowsay/tags/list
{"name":"cowsay","tags":["latest","linux-amd64","linux-arm64"]}
```

I verified the failure and the fix against an immutable-tag registry (zot configured to allow creating tags but not overwriting them). The exact rejection text is registry-specific; in my zot setup it surfaced as `UNAUTHORIZED`, while other registries phrase it as a tag-immutability error. The common behavior is that the second push to an existing tag is rejected.

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

<!-- The pack CLI reference appears to be generated from the command definitions, so the new flag should show up without a separate docs change. Happy to be corrected. -->

## Related

Resolves #2366
