### PR TITLE
fix(buildpack): correct yank registry issue body (add `yank = true` + code fence)

### DIFF
--- a/internal/registry/registry_cache.go
+++ b/internal/registry/registry_cache.go
@@ -36,11 +36,11 @@ type Cache struct {
 }
 
 const GithubIssueTitleTemplate = "{{ if .Yanked }}YANK{{ else }}ADD{{ end }} {{.Namespace}}/{{.Name}}@{{.Version}}"
-const GithubIssueBodyTemplate = `
-id = "{{.Namespace}}/{{.Name}}"
+const GithubIssueBodyTemplate = "```\n" +
+	`id = "{{.Namespace}}/{{.Name}}"
 version = "{{.Version}}"
-{{ if .Yanked }}{{ else if .Address }}addr = "{{.Address}}"{{ end }}
-`
+{{ if .Yanked }}yank = true{{ else if .Address }}addr = "{{.Address}}"{{ end }}
+` + "```\n"
 const GitCommitTemplate = `{{ if .Yanked }}YANK{{else}}ADD{{end}} {{.Namespace}}/{{.Name}}@{{.Version}}`
 
 // Entry is a list of buildpacks stored in a registry


### PR DESCRIPTION
Fixes #2461

`pack buildpack yank` generated a registry issue body that the registry-index bot (`compute-metadata`) rejects: it omitted `yank = true`, so the bot treated the request as an ADD and failed with "invalid address". This adds `yank = true` and wraps the TOML in a code fence (the bot strips the fence before parsing; it improves how the issue renders for human review).