### PR TITLE
fix: normalise CRLF line endings and skip comment lines in parseEnvFile

### DIFF
--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -387,9 +387,12 @@ func parseEnvFile(filename string) (map[string]string, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "open %s", filename)
 	}
-	for _, line := range strings.Split(string(f), "\n") {
+	// Normalise Windows CRLF to LF so that values read from env files created
+	// on Windows do not contain a trailing '\r' when processed on Linux/macOS.
+	normalised := strings.ReplaceAll(string(f), "\r\n", "\n")
+	for _, line := range strings.Split(normalised, "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" {
+		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
 		out = addEnvVar(out, line)


### PR DESCRIPTION
Problem
-------
`pack build --env-file` reads env files by splitting on LF (\n) only. When a developer creates an env file on Windows (CRLF line endings) and the same file is consumed inside a Linux build container -- or when a CI system checks out files with CRLF -- the trailing \r becomes part of the variable key or value.

For value-less variables the key itself ends up with a \r suffix, causing os.Getenv to silently return an empty string even when the variable is correctly set in the host environment:

  # env.file created on Windows (CRLF)
  MY_SECRET\r       <- resolved via os.Getenv("MY_SECRET\r") -> ""

Additionally, the parser did not skip comment lines (lines starting with '#'), which is the widely accepted convention in .env files used by Docker Compose, direnv, 12-factor tooling and other standard tooling. Passing an env file with comments currently injects the comment text as an environment variable name, silently corrupting the build environment.

Fix
---
- Normalise \r\n -> \n before splitting, so that CRLF-encoded env files are handled correctly on all platforms.
- Skip lines whose first non-whitespace character is '#'.

Both changes are additive: existing well-formed env files continue to work unchanged.

Signed-off-by: saiashok103@gmail.com

## Summary
<!-- Provide a high-level summary of the change. -->

## Output
<!-- If applicable, please provide examples of the output changes. -->

#### Before

#### After

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [ ] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
