### PR TITLE
chore: suppress unreachable docker daemon CVEs in grype config

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -3,5 +3,18 @@ ignore:
   - vulnerability: CVE-2021-22570 # false positive, see https://github.com/anchore/grype/issues/558
   - vulnerability: CVE-2024-41110 # non-impactful as we only use docker as a client
   - vulnerability: GHSA-v23v-6jw2-98fq # non-impactful as we only use docker as a client
-  - vulnerability: GHSA-x744-4wpc-v9h2 # AuthZ plugin bypass; not exploitable as pack only uses docker as a client. Fixed in moby/moby/v2 but not backported to docker/docker module.
-  - vulnerability: GHSA-pxq6-2prw-chj9 # plugin privilege validation off-by-one; not exploitable as pack only uses docker as a client. Fixed in moby/moby/v2 but not backported to docker/docker module.
+  # docker/docker daemon-side advisories: not exploitable as pack only uses docker as a client
+  # (imports api/types, client, volume/mounts and pkg/* helpers, never the daemon code paths).
+  # Fixed only in github.com/moby/moby/v2, not backported to the github.com/docker/docker module.
+  # NOTE: grype matches the printed primary ID, not aliases, so we list every ID form that can
+  # surface across the go-module (binary) scan and the released-image scan.
+  - vulnerability: GO-2026-4887 # AuthZ plugin bypass (CVE-2026-34040 / GHSA-x744-4wpc-v9h2)
+  - vulnerability: GHSA-x744-4wpc-v9h2
+  - vulnerability: GO-2026-4883 # plugin privilege validation off-by-one (CVE-2026-33997 / GHSA-pxq6-2prw-chj9)
+  - vulnerability: GHSA-pxq6-2prw-chj9
+  - vulnerability: GHSA-x86f-5xw2-fm2r # decompression-binary RCE via container filesystem (daemon-side)
+  - vulnerability: GHSA-rg2x-37c3-w2rh # docker cp bind-mount redirect race (CVE-2026-42306, daemon-side)
+  - vulnerability: GHSA-vp62-88p7-qqf5 # docker cp symlink-swap race (CVE-2026-41568, daemon-side)
+  # docker/cli: installed v29.4.3 is already newer than the fixed v29.2.0; grype mis-orders the
+  # +incompatible pseudo-version. Already remediated, kept here to silence the false positive.
+  - vulnerability: GO-2026-4610 # GHSA / CVE for docker/cli auth, fixed in 29.2.0 (we ship >= 29.4.3)


### PR DESCRIPTION
## Summary

The grype scan against the pack binary (and the released image) still flagged six docker findings that `.grype.yaml` was meant to ignore. The existing rules listed the **GHSA aliases**, but grype matches the **printed primary ID** — and the go-module scan prints the `GO-2026-*` IDs — so the suppressions never fired.

All six are non-impactful for pack and none are fixable by a bump:

- **`docker/docker`** `GO-2026-4887`, `GO-2026-4883`, `GHSA-x86f-5xw2-fm2r`, `GHSA-rg2x-37c3-w2rh`, `GHSA-vp62-88p7-qqf5` — all **daemon-side** (AuthZ bypass, plugin-privilege off-by-one, `docker cp` races, decompression RCE). pack only uses docker as a client (`api/types`, `client`, `volume/mounts`, `pkg/*` helpers) and never runs the daemon paths. There is **no fixed version in the `github.com/docker/docker` module** — the fix exists only in the rewritten `github.com/moby/moby/v2` module, which the ecosystem (lifecycle, kaniko) has not adopted and which pack doesn't need.
- **`docker/cli`** `GO-2026-4610` — already remediated: we ship `v29.4.3`, newer than the fixed `v29.2.0`; grype mis-orders the `+incompatible` pseudo-version.

Listing every ID form (GO + GHSA) makes the suppressions apply across both the go-module binary scan and the released-image scan.

## Output

#### Before

```
$ grype out/pack
   └── by severity: 0 critical, 6 high, 2 medium, 0 low, 0 negligible
NAME                      INSTALLED  ...  VULNERABILITY        SEVERITY
github.com/docker/docker  v28.5.2    ...  GO-2026-4887         High
github.com/docker/cli     v29.4.3    ...  GO-2026-4610         High
github.com/docker/docker  v28.5.2    ...  GO-2026-4883         High
github.com/docker/docker  v28.5.2    ...  GHSA-x86f-5xw2-fm2r  High
github.com/docker/docker  v28.5.2    ...  GHSA-rg2x-37c3-w2rh  High
github.com/docker/docker  v28.5.2    ...  GHSA-vp62-88p7-qqf5  Medium
```

#### After

```
$ grype out/pack
No vulnerabilities found
```

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related

Context: dependabot #2643 cannot fix these (it does not touch `docker/docker`, and `docker/cli` is already past its fix), while it reintroduces the `moby/moby/client` 0.5.0 + `go-containerregistry` 0.21.7 bumps that break daemon rebase and `manifest annotate` against the current imgutil. The long-term remediation is the upstream `moby/moby/v2` migration.
