### PR TITLE
fix: clean up podman temp layer extracts after build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -156,3 +156,5 @@ require (
 replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v1.3.2
 
 go 1.25.12
+
+replace github.com/buildpacks/imgutil => github.com/locker95/imgutil v0.0.0-20260720191354-2a1b4da9512c

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/buildpacks/imgutil v0.0.0-20251202182233-51c1c8c186ea h1:91PTHjeL3uzjr2/jk1SJuFZp3ObodKawy79BKdio+VE=
-github.com/buildpacks/imgutil v0.0.0-20251202182233-51c1c8c186ea/go.mod h1:yw2U9Ec8KUk7jWY97K0+e6GqrUAr05uTK6LwOEZyupw=
 github.com/buildpacks/lifecycle v0.21.0 h1:s2okNv1I4rETBC4CRm4ly7DRr5eTqx1bpKXyf+ywVms=
 github.com/buildpacks/lifecycle v0.21.0/go.mod h1:5Rb9kld2v1XYQC14fJrIGESqmuJvSYHVlUxAW5MAxNU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -250,6 +248,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/locker95/imgutil v0.0.0-20260720191354-2a1b4da9512c h1:FSmc1S+/NJKZXDUHhfOYz2qexP1tKvimMFbnM9ggb8k=
+github.com/locker95/imgutil v0.0.0-20260720191354-2a1b4da9512c/go.mod h1:EBy9ZOatKkTBAWOgN2Y0aNV4P40dOdGyzzB9q2a5HBE=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=


### PR DESCRIPTION
## Summary

With podman, ephemeral builder saves cannot omit base layers the way Docker allows. imgutil falls back to extracting builder layers under `/tmp/imgutil.local.image.*` and historically never deleted those dirs, so repeated `pack build` filled `/tmp` (especially painful when `/tmp` is on tmpfs).

The cleanup is implemented in imgutil: after `Save`/`SaveFile` finish reading extracted base layers, those temp dirs are removed. Layers pack adds on purpose (builder scratch artifacts, daemon/image cache) are not deleted.

- Root fix: https://github.com/buildpacks/imgutil/pull/309
- This PR wires pack to that revision via a temporary `replace` until #309 lands on `buildpacks/imgutil`. After merge, the replace can be dropped in favor of a normal `require` bump.

## Output

#### Before

```text
# after pack build with podman
$ ls -d /tmp/imgutil.local.image.*
/tmp/imgutil.local.image.xxx
/tmp/imgutil.local.image.yyy   # accumulates on every build
```

#### After

```text
# extract dirs are removed when Save returns
$ ls -d /tmp/imgutil.local.image.*
ls: cannot access '/tmp/imgutil.local.image.*': No such file or directory
```

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related

Resolves #1167  
Depends on https://github.com/buildpacks/imgutil/pull/309