### PR TITLE
#2648 Pass descriptor argument to detect phase

### DIFF
--- a/internal/commands/build.go
+++ b/internal/commands/build.go
@@ -200,6 +200,7 @@ func Build(logger logging.Logger, cfg config.Config, packClient PackClient) *cob
 				},
 				DefaultProcessType:       flags.DefaultProcessType,
 				ProjectDescriptorBaseDir: filepath.Dir(actualDescriptorPath),
+				ProjectDescriptorPath:    actualDescriptorPath,
 				ProjectDescriptor:        descriptor,
 				Cache:                    flags.Cache,
 				CacheImage:               flags.CacheImage,

--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -179,6 +179,9 @@ type BuildOptions struct {
 	// ProjectDescriptorBaseDir is the base directory to find relative resources referenced by the ProjectDescriptor
 	ProjectDescriptorBaseDir string
 
+
+	ProjectDescriptorPath String
+
 	// ProjectDescriptor describes the project and any configuration specific to the project
 	ProjectDescriptor projectTypes.Descriptor
 


### PR DESCRIPTION
## Summary

Pass the project descriptor path from the build command to the detect phase.

This allows the detect phase to know which descriptor was provided with `--descriptor`.

## Output

#### Before

The detect phase could not determine the descriptor passed to `pack build`.

#### After

The detect phase can access the descriptor path passed with `--descriptor`.

## Documentation

- [x] No

## Related

Resolves #2648