### PR TITLE
#2648 Pass descriptor path through client

### DIFF
--- a/internal/build/lifecycle_executor.go
+++ b/internal/build/lifecycle_executor.go
@@ -79,6 +79,7 @@ type LifecycleOptions struct {
 	RunImage                        string
 	FetchRunImageWithLifecycleLayer func(name string) (string, error)
 	ProjectMetadata                 files.ProjectMetadata
+	ProjectDescriptor               string
 	ClearCache                      bool
 	Publish                         bool
 	TrustBuilder                    bool


### PR DESCRIPTION
## Summary

Pass the project descriptor path from the build command to the detect phase.

This allows the detect phase to know which descriptor was provided with `--descriptor`.

## Output

#### Before

The detect phase could not determine which descriptor was passed.

#### After

The detect phase can access the descriptor path provided with `--descriptor`.

## Documentation

- [x] No

## Related

Resolves #2648