### PR TITLE
#2648 Pass descriptor path to lifecycle

### DIFF
--- a/pkg/client/build.go
+++ b/pkg/client/build.go
@@ -642,6 +642,7 @@ func (c *Client) Build(ctx context.Context, opts BuildOptions) error {
 		LifecycleImage:           ephemeralBuilder.Name(),
 		RunImage:                 runImageName,
 		ProjectMetadata:          projectMetadata,
+		ProjectDescriptorPath:    opts.ProjectDescriptorPath,
 		ClearCache:               opts.ClearCache,
 		Publish:                  opts.Publish,
 		TrustBuilder:             opts.TrustBuilder(opts.Builder),


### PR DESCRIPTION
## Summary

Pass the project descriptor path from `BuildOptions` to `LifecycleOptions`.

This keeps the descriptor path available during lifecycle execution so it can be passed to the detect phase.

## Output

#### Before

The descriptor path was available during the build command but was not passed to the lifecycle.

#### After

The descriptor path is passed through `LifecycleOptions` and is available for the detect phase.

## Documentation

- [x] No

## Related

Resolves #2648