### PR TITLE
Add ProofX build attestation to release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -403,3 +403,18 @@ jobs:
             ## Changelog
 
             ${{ steps.changelog.outputs.contents }}
+
+      - name: Generate ProofX build proof
+        if: env.PACK_VERSION != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -sSL https://github.com/EslaM-X/proofx/releases/latest/download/proofx-linux-amd64 -o /usr/local/bin/proofx
+          chmod +x /usr/local/bin/proofx
+          proofx init --bare
+          proofx collect
+          proofx bind
+          proofx sign --key .proofx/key.pem
+          proofx verify
+          mv proof.json "proofx-v${PACK_VERSION}-linux-amd64.json"
+          gh release upload "v${PACK_VERSION}" "proofx-v${PACK_VERSION}-linux-amd64.json" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ artifacts/
 # Travis unencrypted file
 .travis/key.pem
 
+# ProofX signing key
+.proofx/
+


### PR DESCRIPTION
## Summary

Adds [ProofX](https://github.com/EslaM-X/proofx) build attestation to the release workflow. After each release, a proof.json is generated that cryptographically binds the source commit, CI run, and build artifacts together — then uploaded as a release asset alongside existing .sha256 checksums.

## What changes

- **One new step** at the end of the \elease\ job in \.github/workflows/build.yml\
- **\.proofx/\** added to \.gitignore\

## What does NOT change

- No existing steps modified
- No new permissions required (\GITHUB_TOKEN\ already available)
- No new workflow files
- No README or badge changes
- No registry or package changes

## How it works

\\\ash
proofx init --bare        # generate signing key
proofx collect            # gather commit, CI, builder, OS, artifact digests
proofx bind               # Merkle root over evidence
proofx sign               # ed25519 signature
proofx verify             # self-verify before upload
\\\

The resulting \proofx-v<VERSION>-linux-amd64.json\ is uploaded to the release.

## Why

\pack\ ships 18 binaries per release with SHA256 checksums. Checksums prove _integrity_ (the file hasn't changed) but not _provenance_ (who built it and from what source). ProofX adds the provenance layer — anyone can verify that a binary was built from a specific commit via a specific CI run.

This is **additive only**: if the step fails or is removed, nothing else in the release process is affected.

## Links

- [ProofX repo](https://github.com/EslaM-X/proofx)
- [ProofX spec](https://github.com/EslaM-X/proofx/blob/main/docs/SPEC.md)
- [Cryptography spec](https://github.com/EslaM-X/proofx/blob/main/docs/CRYPTOGRAPHY.md)