### PR TITLE
Add history metadata to builder layers

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/buildpacks/imgutil"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
 
 	"github.com/buildpacks/pack/builder"
@@ -483,7 +484,7 @@ func (b *Builder) Save(logger logging.Logger, creatorMetadata CreatorMetadata, a
 	if err != nil {
 		return err
 	}
-	if err := b.image.AddLayer(dirsTar); err != nil {
+	if err := addLayerWithHistory(b.image, dirsTar, "Buildpacks Builder Config"); err != nil {
 		return errors.Wrap(err, "adding default dirs layer")
 	}
 
@@ -496,7 +497,7 @@ func (b *Builder) Save(logger logging.Logger, creatorMetadata CreatorMetadata, a
 		if err != nil {
 			return err
 		}
-		if err := b.image.AddLayer(lifecycleTar); err != nil {
+		if err := addLayerWithHistory(b.image, lifecycleTar, "Buildpacks Lifecycle"); err != nil {
 			return errors.Wrap(err, "adding lifecycle layer")
 		}
 	}
@@ -564,7 +565,7 @@ func (b *Builder) Save(logger logging.Logger, creatorMetadata CreatorMetadata, a
 		if err != nil {
 			return err
 		}
-		if err := b.image.AddLayer(orderTar); err != nil {
+		if err := addLayerWithHistory(b.image, orderTar, "Buildpacks Order"); err != nil {
 			return errors.Wrap(err, "adding order.tar layer")
 		}
 		if err := dist.SetLabel(b.image, OrderLabel, b.order); err != nil {
@@ -585,7 +586,7 @@ func (b *Builder) Save(logger logging.Logger, creatorMetadata CreatorMetadata, a
 		if err != nil {
 			return err
 		}
-		if err := b.image.AddLayer(systemTar); err != nil {
+		if err := addLayerWithHistory(b.image, systemTar, "Buildpacks System"); err != nil {
 			return errors.Wrap(err, "adding system.tar layer")
 		}
 		if err := dist.SetLabel(b.image, SystemLabel, b.system); err != nil {
@@ -597,7 +598,7 @@ func (b *Builder) Save(logger logging.Logger, creatorMetadata CreatorMetadata, a
 	if err != nil {
 		return err
 	}
-	if err := b.image.AddLayer(stackTar); err != nil {
+	if err := addLayerWithHistory(b.image, stackTar, "Buildpacks Stack"); err != nil {
 		return errors.Wrap(err, "adding stack.tar layer")
 	}
 
@@ -605,7 +606,7 @@ func (b *Builder) Save(logger logging.Logger, creatorMetadata CreatorMetadata, a
 	if err != nil {
 		return err
 	}
-	if err := b.image.AddLayer(runImageTar); err != nil {
+	if err := addLayerWithHistory(b.image, runImageTar, "Buildpacks Run Images"); err != nil {
 		return errors.Wrap(err, "adding run.tar layer")
 	}
 
@@ -616,7 +617,7 @@ func (b *Builder) Save(logger logging.Logger, creatorMetadata CreatorMetadata, a
 			return errors.Wrap(err, "retrieving build-config-env layer")
 		}
 
-		if err := b.image.AddLayer(buildConfigEnvTar); err != nil {
+		if err := addLayerWithHistory(b.image, buildConfigEnvTar, "Buildpacks Build Config"); err != nil {
 			return errors.Wrap(err, "adding build-config-env layer")
 		}
 	}
@@ -630,7 +631,7 @@ func (b *Builder) Save(logger logging.Logger, creatorMetadata CreatorMetadata, a
 		return err
 	}
 
-	if err := b.image.AddLayer(envTar); err != nil {
+	if err := addLayerWithHistory(b.image, envTar, "Buildpacks Environment"); err != nil {
 		return errors.Wrap(err, "adding env layer")
 	}
 
@@ -660,6 +661,15 @@ func (b *Builder) Save(logger logging.Logger, creatorMetadata CreatorMetadata, a
 
 // Helpers
 
+func addLayerWithHistory(image imgutil.Image, layerPath, createdBy string) error {
+	diffID, err := dist.LayerDiffID(layerPath)
+	if err != nil {
+		return err
+	}
+
+	return image.AddLayerWithDiffIDAndHistory(layerPath, diffID.String(), v1.History{CreatedBy: createdBy})
+}
+
 func (b *Builder) addExplodedModules(kind string, logger logging.Logger, tmpDir string, image imgutil.Image, additionalModules []buildpack.BuildModule, layers dist.ModuleLayers) error {
 	collectionToAdd := map[string]moduleWithDiffID{}
 	toAdd, errs := explodeModules(kind, tmpDir, additionalModules, logger)
@@ -681,7 +691,11 @@ func (b *Builder) addExplodedModules(kind string, logger logging.Logger, tmpDir 
 					return err
 				}
 
-				if err := image.AddLayer(whiteoutsTar); err != nil {
+				if err := addLayerWithHistory(image, whiteoutsTar, fmt.Sprintf(
+					"%s: %s (removing previous contents)",
+					istrings.Title(kind),
+					info.FullName(),
+				)); err != nil {
 					return errors.Wrap(err, "adding whiteout layer tar")
 				}
 			}
@@ -712,7 +726,9 @@ func (b *Builder) addExplodedModules(kind string, logger logging.Logger, tmpDir 
 	for _, k := range keys {
 		module := collectionToAdd[k]
 		logger.Debugf("Adding %s %s (diffID=%s)", kind, style.Symbol(module.module.Descriptor().Info().FullName()), module.diffID)
-		if err := image.AddLayerWithDiffID(module.tarPath, module.diffID); err != nil {
+		if err := image.AddLayerWithDiffIDAndHistory(module.tarPath, module.diffID, v1.History{
+			CreatedBy: fmt.Sprintf("%s: %s", istrings.Title(kind), module.module.Descriptor().Info().FullName()),
+		}); err != nil {
 			return errors.Wrapf(err,
 				"adding layer tar for %s %s",
 				kind,
@@ -728,6 +744,7 @@ func (b *Builder) addExplodedModules(kind string, logger logging.Logger, tmpDir 
 
 func (b *Builder) addFlattenedModules(kind string, logger logging.Logger, tmpDir string, image imgutil.Image, flattenModules [][]buildpack.BuildModule, layers dist.ModuleLayers) ([]buildpack.BuildModule, error) {
 	collectionToAdd := map[string]moduleWithDiffID{}
+	historyByDiffID := map[string]string{}
 	var (
 		buildModuleExcluded []buildpack.BuildModule
 		finalTarPath        string
@@ -752,13 +769,22 @@ func (b *Builder) addFlattenedModules(kind string, logger logging.Logger, tmpDir
 			return nil, errors.Wrapf(err, "calculating diff layer %s", finalTarPath)
 		}
 
+		var moduleNames []string
+		moduleNamesAdded := map[string]struct{}{}
 		for _, module := range additionalModules {
-			collectionToAdd[module.Descriptor().Info().FullName()] = moduleWithDiffID{
+			fullName := module.Descriptor().Info().FullName()
+			if _, ok := moduleNamesAdded[fullName]; !ok {
+				moduleNames = append(moduleNames, fullName)
+				moduleNamesAdded[fullName] = struct{}{}
+			}
+			collectionToAdd[fullName] = moduleWithDiffID{
 				tarPath: finalTarPath,
 				diffID:  diffID.String(),
 				module:  module,
 			}
 		}
+		sort.Strings(moduleNames)
+		historyByDiffID[diffID.String()] = fmt.Sprintf("%ss: %s", istrings.Title(kind), strings.Join(moduleNames, ", "))
 	}
 
 	// Fixes 1453
@@ -778,7 +804,9 @@ func (b *Builder) addFlattenedModules(kind string, logger logging.Logger, tmpDir
 		}
 		if addLayer {
 			logger.Debugf("Adding %s %s (diffID=%s)", kind, style.Symbol(bp.Descriptor().Info().FullName()), module.diffID)
-			if err = image.AddLayerWithDiffID(module.tarPath, module.diffID); err != nil {
+			if err = image.AddLayerWithDiffIDAndHistory(module.tarPath, module.diffID, v1.History{
+				CreatedBy: historyByDiffID[module.diffID],
+			}); err != nil {
 				return nil, errors.Wrapf(err,
 					"adding layer tar for %s %s",
 					kind,

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/buildpacks/imgutil/fakes"
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/golang/mock/gomock"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/heroku/color"
 	"github.com/pkg/errors"
 	"github.com/sclevine/spec"
@@ -301,6 +302,80 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("#Save", func() {
+			it("adds history for layers created by pack", func() {
+				h.AssertNil(t, baseImage.SetHistory([]v1.History{{CreatedBy: "Base image layer"}}))
+				subject.AddBuildpack(bp1v1)
+
+				h.AssertNil(t, subject.Save(logger, builder.CreatorMetadata{}))
+
+				history, err := baseImage.History()
+				h.AssertNil(t, err)
+				h.AssertEq(t, history, []v1.History{
+					{CreatedBy: "Base image layer"},
+					{CreatedBy: "Buildpacks Builder Config"},
+					{CreatedBy: "Buildpacks Lifecycle"},
+					{CreatedBy: "Buildpack: buildpack-1-id@buildpack-1-version-1"},
+					{CreatedBy: "Buildpacks Stack"},
+					{CreatedBy: "Buildpacks Run Images"},
+					{CreatedBy: "Buildpacks Environment"},
+				})
+			})
+
+			it("adds history for optional builder layers", func() {
+				subject.AddBuildpack(bp1v1)
+				subject.SetOrder(dist.Order{{
+					Group: []dist.ModuleRef{{ModuleInfo: bp1v1.Descriptor().Info()}},
+				}})
+				subject.SetSystem(dist.System{
+					Pre: dist.SystemBuildpacks{
+						Buildpacks: []dist.ModuleRef{{ModuleInfo: bp1v1.Descriptor().Info()}},
+					},
+				})
+				subject.SetBuildConfigEnv(map[string]string{"SOME_KEY": "some-value"})
+
+				h.AssertNil(t, subject.Save(logger, builder.CreatorMetadata{}))
+
+				history, err := baseImage.History()
+				h.AssertNil(t, err)
+				h.AssertEq(t, history, []v1.History{
+					{CreatedBy: "Buildpacks Builder Config"},
+					{CreatedBy: "Buildpacks Lifecycle"},
+					{CreatedBy: "Buildpack: buildpack-1-id@buildpack-1-version-1"},
+					{CreatedBy: "Buildpacks Order"},
+					{CreatedBy: "Buildpacks System"},
+					{CreatedBy: "Buildpacks Stack"},
+					{CreatedBy: "Buildpacks Run Images"},
+					{CreatedBy: "Buildpacks Build Config"},
+					{CreatedBy: "Buildpacks Environment"},
+				})
+			})
+
+			it("adds history for a buildpack replacement whiteout layer", func() {
+				existingLayers := dist.ModuleLayers{
+					bp1v1.Descriptor().Info().ID: {
+						bp1v1.Descriptor().Info().Version: {
+							LayerDiffID: "sha256:previous-buildpack-layer",
+						},
+					},
+				}
+				h.AssertNil(t, dist.SetLabel(baseImage, dist.BuildpackLayersLabel, existingLayers))
+				subject.AddBuildpack(bp1v1)
+
+				h.AssertNil(t, subject.Save(logger, builder.CreatorMetadata{}))
+
+				history, err := baseImage.History()
+				h.AssertNil(t, err)
+				h.AssertEq(t, history, []v1.History{
+					{CreatedBy: "Buildpacks Builder Config"},
+					{CreatedBy: "Buildpacks Lifecycle"},
+					{CreatedBy: "Buildpack: buildpack-1-id@buildpack-1-version-1 (removing previous contents)"},
+					{CreatedBy: "Buildpack: buildpack-1-id@buildpack-1-version-1"},
+					{CreatedBy: "Buildpacks Stack"},
+					{CreatedBy: "Buildpacks Run Images"},
+					{CreatedBy: "Buildpacks Environment"},
+				})
+			})
+
 			it("creates a builder from the image and renames it", func() {
 				h.AssertNil(t, subject.Save(logger, builder.CreatorMetadata{}))
 				h.AssertEq(t, baseImage.IsSaved(), true)
@@ -1987,6 +2062,22 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 				it("it return one array with all buildpacks on it", func() {
 					h.AssertEq(t, len(bldr.FlattenedModules(buildpack.KindBuildpack)), 1)
 					h.AssertEq(t, len(bldr.FlattenedModules(buildpack.KindBuildpack)[0]), 3)
+				})
+			})
+
+			it("adds history for the flattened buildpack layer", func() {
+				bldr.AddBuildpack(bp1v1)
+				bldr.SetValidateMixins(false)
+				h.AssertNil(t, bldr.Save(logger, builder.CreatorMetadata{}))
+
+				history, err := baseImage.History()
+				h.AssertNil(t, err)
+				h.AssertEq(t, history, []v1.History{
+					{CreatedBy: "Buildpacks Builder Config"},
+					{CreatedBy: "Buildpacks: buildpack-1-id@buildpack-1-version-1, buildpack-1-id@buildpack-1-version-2, buildpack-2-id@buildpack-2-version-1"},
+					{CreatedBy: "Buildpacks Stack"},
+					{CreatedBy: "Buildpacks Run Images"},
+					{CreatedBy: "Buildpacks Environment"},
 				})
 			})
 

--- a/pkg/client/create_builder.go
+++ b/pkg/client/create_builder.go
@@ -215,7 +215,12 @@ func (c *Client) validateRunImageConfig(ctx context.Context, opts CreateBuilderO
 }
 
 func (c *Client) createBaseBuilder(ctx context.Context, opts CreateBuilderOptions, target *dist.Target, multiArch bool) (*builder.Builder, error) {
-	baseImage, err := c.imageFetcher.Fetch(ctx, opts.Config.Build.Image, image.FetchOptions{Daemon: !opts.Publish, PullPolicy: opts.PullPolicy, Target: target})
+	baseImage, err := c.imageFetcher.Fetch(ctx, opts.Config.Build.Image, image.FetchOptions{
+		Daemon:          !opts.Publish,
+		PullPolicy:      opts.PullPolicy,
+		Target:          target,
+		PreserveHistory: true,
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch build image")
 	}

--- a/pkg/client/create_builder_test.go
+++ b/pkg/client/create_builder_test.go
@@ -374,7 +374,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("should warn when the run image cannot be found", func() {
-				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", image.FetchOptions{Daemon: true, PullPolicy: image.PullAlways}).Return(fakeBuildImage, nil)
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", image.FetchOptions{Daemon: true, PullPolicy: image.PullAlways, PreserveHistory: true}).Return(fakeBuildImage, nil)
 
 				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", image.FetchOptions{Daemon: false, PullPolicy: image.PullAlways}).Return(nil, errors.Wrap(image.ErrNotFound, "yikes"))
 				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", image.FetchOptions{Daemon: true, PullPolicy: image.PullAlways}).Return(nil, errors.Wrap(image.ErrNotFound, "yikes"))
@@ -415,11 +415,11 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 
 			when("publish is true", func() {
 				it("should only try to validate the remote run image", func() {
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", image.FetchOptions{Daemon: true}).Times(0)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", image.FetchOptions{Daemon: true, PreserveHistory: true}).Times(0)
 					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", image.FetchOptions{Daemon: true}).Times(0)
 					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "localhost:5000/some/run-image", image.FetchOptions{Daemon: true}).Times(0)
 
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", image.FetchOptions{Daemon: false}).Return(fakeBuildImage, nil)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", image.FetchOptions{Daemon: false, PreserveHistory: true}).Return(fakeBuildImage, nil)
 					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/run-image", image.FetchOptions{Daemon: false}).Return(fakeRunImage, nil)
 					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "localhost:5000/some/run-image", image.FetchOptions{Daemon: false}).Return(fakeRunImageMirror, nil)
 
@@ -432,10 +432,21 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("creating the base builder", func() {
+			it("requests build image history preservation", func() {
+				prepareFetcherWithRunImages()
+				mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", image.FetchOptions{
+					Daemon:          true,
+					PullPolicy:      image.PullAlways,
+					PreserveHistory: true,
+				}).Return(fakeBuildImage, nil)
+
+				h.AssertNil(t, subject.CreateBuilder(context.TODO(), opts))
+			})
+
 			when("build image not found", func() {
 				it("should fail", func() {
 					prepareFetcherWithRunImages()
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", image.FetchOptions{Daemon: true, PullPolicy: image.PullAlways}).Return(nil, image.ErrNotFound)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", image.FetchOptions{Daemon: true, PullPolicy: image.PullAlways, PreserveHistory: true}).Return(nil, image.ErrNotFound)
 
 					err := subject.CreateBuilder(context.TODO(), opts)
 					h.AssertError(t, err, "fetch build image: not found")
@@ -447,7 +458,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 					fakeImage := fakeBadImageStruct{}
 
 					prepareFetcherWithRunImages()
-					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", image.FetchOptions{Daemon: true, PullPolicy: image.PullAlways}).Return(fakeImage, nil)
+					mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", image.FetchOptions{Daemon: true, PullPolicy: image.PullAlways, PreserveHistory: true}).Return(fakeImage, nil)
 
 					err := subject.CreateBuilder(context.TODO(), opts)
 					h.AssertError(t, err, "failed to create builder: invalid build-image")
@@ -471,7 +482,7 @@ func testCreateBuilder(t *testing.T, when spec.G, it spec.S) {
 						prepareFetcherWithRunImages()
 
 						h.AssertNil(t, fakeBuildImage.SetOS("windows"))
-						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", image.FetchOptions{Daemon: true, PullPolicy: image.PullAlways}).Return(fakeBuildImage, nil)
+						mockImageFetcher.EXPECT().Fetch(gomock.Any(), "some/build-image", image.FetchOptions{Daemon: true, PullPolicy: image.PullAlways, PreserveHistory: true}).Return(fakeBuildImage, nil)
 
 						err = packClientWithExperimental.CreateBuilder(context.TODO(), opts)
 						h.AssertNil(t, err)

--- a/pkg/image/fetcher.go
+++ b/pkg/image/fetcher.go
@@ -69,6 +69,7 @@ type FetchOptions struct {
 	PullPolicy         PullPolicy
 	LayoutOption       LayoutOption
 	InsecureRegistries []string
+	PreserveHistory    bool
 }
 
 func NewFetcher(logger logging.Logger, docker DockerClient, opts ...FetcherOption) *Fetcher {
@@ -94,19 +95,19 @@ func (f *Fetcher) Fetch(ctx context.Context, name string, options FetchOptions) 
 	}
 
 	if (options.LayoutOption != LayoutOption{}) {
-		return f.fetchLayoutImage(name, options.LayoutOption)
+		return f.fetchLayoutImage(name, options.LayoutOption, options.PreserveHistory)
 	}
 
 	if !options.Daemon {
-		return f.fetchRemoteImage(name, options.Target, options.InsecureRegistries)
+		return f.fetchRemoteImage(name, options.Target, options.InsecureRegistries, options.PreserveHistory)
 	}
 
 	switch options.PullPolicy {
 	case PullNever:
-		img, err := f.fetchDaemonImage(name)
+		img, err := f.fetchDaemonImage(name, options.PreserveHistory)
 		return img, err
 	case PullIfNotPresent:
-		img, err := f.fetchDaemonImage(name)
+		img, err := f.fetchDaemonImage(name, options.PreserveHistory)
 		if err == nil || !errors.Is(err, ErrNotFound) {
 			return img, err
 		}
@@ -132,14 +133,14 @@ func (f *Fetcher) Fetch(ctx context.Context, name string, options FetchOptions) 
 		return nil, err
 	}
 
-	return f.fetchDaemonImage(name)
+	return f.fetchDaemonImage(name, options.PreserveHistory)
 }
 
 func (f *Fetcher) CheckReadAccess(repo string, options FetchOptions) bool {
 	if !options.Daemon || options.PullPolicy == PullAlways {
 		return f.checkRemoteReadAccess(repo)
 	}
-	if _, err := f.fetchDaemonImage(repo); err != nil {
+	if _, err := f.fetchDaemonImage(repo, false); err != nil {
 		if errors.Is(err, ErrNotFound) {
 			// Image doesn't exist in the daemon
 			// 	Pull Never: should fail
@@ -170,8 +171,13 @@ func (f *Fetcher) checkRemoteReadAccess(repo string) bool {
 	}
 }
 
-func (f *Fetcher) fetchDaemonImage(name string) (imgutil.Image, error) {
-	image, err := local.NewImage(name, f.docker, local.FromBaseImage(name))
+func (f *Fetcher) fetchDaemonImage(name string, preserveHistory bool) (imgutil.Image, error) {
+	options := []imgutil.ImageOption{local.FromBaseImage(name)}
+	if preserveHistory {
+		options = append(options, local.WithHistory())
+	}
+
+	image, err := local.NewImage(name, f.docker, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +189,7 @@ func (f *Fetcher) fetchDaemonImage(name string) (imgutil.Image, error) {
 	return image, nil
 }
 
-func (f *Fetcher) fetchRemoteImage(name string, target *dist.Target, insecureRegistries []string) (imgutil.Image, error) {
+func (f *Fetcher) fetchRemoteImage(name string, target *dist.Target, insecureRegistries []string, preserveHistory bool) (imgutil.Image, error) {
 	var (
 		image   imgutil.Image
 		options []imgutil.ImageOption
@@ -194,6 +200,9 @@ func (f *Fetcher) fetchRemoteImage(name string, target *dist.Target, insecureReg
 		for _, registry := range insecureRegistries {
 			options = append(options, remote.WithRegistrySetting(registry, true))
 		}
+	}
+	if preserveHistory {
+		options = append(options, remote.WithHistory())
 	}
 
 	if target == nil {
@@ -214,7 +223,7 @@ func (f *Fetcher) fetchRemoteImage(name string, target *dist.Target, insecureReg
 	return image, nil
 }
 
-func (f *Fetcher) fetchLayoutImage(name string, options LayoutOption) (imgutil.Image, error) {
+func (f *Fetcher) fetchLayoutImage(name string, options LayoutOption, preserveHistory bool) (imgutil.Image, error) {
 	var (
 		image imgutil.Image
 		err   error
@@ -225,10 +234,16 @@ func (f *Fetcher) fetchLayoutImage(name string, options LayoutOption) (imgutil.I
 		return nil, err
 	}
 
+	var imageOptions []imgutil.ImageOption
+	if preserveHistory {
+		imageOptions = append(imageOptions, layout.WithHistory())
+	}
+
 	if options.Sparse {
-		image, err = sparse.NewImage(options.Path, v1Image)
+		image, err = sparse.NewImage(options.Path, v1Image, imageOptions...)
 	} else {
-		image, err = layout.NewImage(options.Path, layout.FromBaseImageInstance(v1Image))
+		imageOptions = append(imageOptions, layout.FromBaseImageInstance(v1Image))
+		image, err = layout.NewImage(options.Path, imageOptions...)
 	}
 
 	if err != nil {

--- a/pkg/image/fetcher_test.go
+++ b/pkg/image/fetcher_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/buildpacks/imgutil"
@@ -14,12 +16,15 @@ import (
 	"github.com/buildpacks/imgutil/remote"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/heroku/color"
 	"github.com/moby/moby/client"
 	"github.com/pkg/errors"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
+	"github.com/buildpacks/pack/pkg/archive"
 	"github.com/buildpacks/pack/pkg/dist"
 	"github.com/buildpacks/pack/pkg/image"
 	"github.com/buildpacks/pack/pkg/logging"
@@ -29,6 +34,55 @@ import (
 
 var docker *client.Client
 var registryConfig *h.TestRegistryConfig
+
+type anonymousKeychain struct{}
+
+func (anonymousKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
+	return authn.Anonymous, nil
+}
+
+func TestFetchPreservesHistoryWhenRequested(t *testing.T) {
+	registryServer := httptest.NewServer(registry.New())
+	defer registryServer.Close()
+
+	registryHost := strings.TrimPrefix(registryServer.URL, "http://")
+	repoName := registryHost + "/pack/history"
+	registryOption := remote.WithRegistrySetting(registryHost, true)
+	keychain := anonymousKeychain{}
+
+	baseLayerPath := filepath.Join(t.TempDir(), "base.tar")
+	h.AssertNil(t, archive.CreateSingleFileTar(baseLayerPath, "/base", "base"))
+	baseLayerDiffID, err := dist.LayerDiffID(baseLayerPath)
+	h.AssertNil(t, err)
+
+	baseImage, err := remote.NewImage(repoName, keychain, registryOption, remote.WithHistory())
+	h.AssertNil(t, err)
+	h.AssertNil(t, baseImage.AddLayerWithDiffIDAndHistory(baseLayerPath, baseLayerDiffID.String(), v1.History{CreatedBy: "Base image layer"}))
+	h.AssertNil(t, baseImage.Save())
+
+	var outBuf bytes.Buffer
+	imageFetcher := image.NewFetcher(logging.NewLogWithWriters(&outBuf, &outBuf), nil, image.WithKeychain(keychain))
+	fetchedImage, err := imageFetcher.Fetch(context.Background(), repoName, image.FetchOptions{
+		PullPolicy:         image.PullAlways,
+		InsecureRegistries: []string{registryHost},
+		PreserveHistory:    true,
+	})
+	h.AssertNil(t, err)
+
+	builderLayerPath := filepath.Join(t.TempDir(), "builder.tar")
+	h.AssertNil(t, archive.CreateSingleFileTar(builderLayerPath, "/builder", "builder"))
+	builderLayerDiffID, err := dist.LayerDiffID(builderLayerPath)
+	h.AssertNil(t, err)
+	h.AssertNil(t, fetchedImage.AddLayerWithDiffIDAndHistory(builderLayerPath, builderLayerDiffID.String(), v1.History{CreatedBy: "Builder layer"}))
+	h.AssertNil(t, fetchedImage.Save())
+
+	savedImage, err := remote.NewImage(repoName, keychain, remote.FromBaseImage(repoName), registryOption, remote.WithHistory())
+	h.AssertNil(t, err)
+	history, err := savedImage.History()
+	h.AssertNil(t, err)
+	h.AssertEq(t, len(history), 2)
+	h.AssertEq(t, []string{history[0].CreatedBy, history[1].CreatedBy}, []string{"Base image layer", "Builder layer"})
+}
 
 func TestFetcher(t *testing.T) {
 	color.Disable(true)

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -925,6 +925,19 @@ func (f *FakeAddedLayerImage) AddLayerWithDiffID(path, diffID string) error {
 	return f.Image.AddLayerWithDiffID(path, diffID)
 }
 
+func (f *FakeAddedLayerImage) AddLayerWithDiffIDAndHistory(path, diffID string, history v1.History) error {
+	// This fake tracks build module layers, not builder metadata layers.
+	if strings.HasPrefix(history.CreatedBy, "Buildpack: ") ||
+		strings.HasPrefix(history.CreatedBy, "Buildpacks: ") ||
+		strings.HasPrefix(history.CreatedBy, "Extension: ") ||
+		strings.HasPrefix(history.CreatedBy, "Extensions: ") {
+		if !strings.HasSuffix(history.CreatedBy, " (removing previous contents)") {
+			f.addedLayersOrder = append(f.addedLayersOrder, path)
+		}
+	}
+	return f.Image.AddLayerWithDiffIDAndHistory(path, diffID, history)
+}
+
 type FakeWithUnderlyingImage struct {
 	*fakes.Image
 	underlyingImage v1.Image


### PR DESCRIPTION
## Summary
Add OCI history descriptions to layers created by `pack builder create`. Buildpack and extension layers include their ID and version, flattened layers list their contents, and existing build-image layer history is retained while assembling the builder.

## Output

#### Before
Pack-created builder layers had empty descriptions in `docker history` and registry layer views.

#### After
Pack-created layers have descriptions for their contents, including entries such as `Buildpacks Lifecycle`, `Buildpack: example/buildpack@1.0.0`, and a deterministic module list for flattened layers.

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related

Resolves #2052