### PR TITLE
build(deps): bump Go to 1.25.13 to fix stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -155,4 +155,4 @@ require (
 
 replace github.com/BurntSushi/toml => github.com/BurntSushi/toml v1.3.2
 
-go 1.25.12
+go 1.25.13


### PR DESCRIPTION
## Summary

Bumps the `go` directive in `go.mod` from `1.25.12` to `1.25.13` to clear six stdlib vulnerabilities (GO-2026-5026, GO-2026-5972, GO-2026-6088, GO-2026-6090 High; GO-2026-6218, GO-2026-6091 Medium) that `grype` reports against the released `v0.40.9` image. CI builds the release with `go-version-file: go.mod`, so the directive bump alone is sufficient to rebuild on the patched toolchain — no dependency bump needed for these findings.

The same scan also reports `github.com/moby/go-archive` (GHSA-hfg8-hc9c-6c3h) and `github.com/moby/buildkit` (GHSA-7236-3392-c5c6), but both already have dedicated open PRs (#2675, #2676), so this PR intentionally leaves those out to avoid duplicating that work. A third finding, `github.com/chrismellard/docker-credential-acr-env` (GO-2026-6225), is severity Unknown with no fixed version upstream, so it doesn't trip the `--fail-on medium` gate and needs no change (same treatment `.grype.yaml` already gives similar no-fix findings).

## Output

#### Before

```
grype docker.io/buildpacksio/pack:0.40.9 --fail-on medium -c .grype.yaml

NAME     INSTALLED  FIXED IN                       TYPE       VULNERABILITY  SEVERITY  
stdlib   go1.25.12  *1.25.13, 1.26.6, 1.27.0-rc.3  go-module  GO-2026-5026   High
stdlib   go1.25.12  *1.25.13, 1.26.6, 1.27.0-rc.3  go-module  GO-2026-5972   High
stdlib   go1.25.12  *1.25.13, 1.26.6, 1.27.0-rc.3  go-module  GO-2026-6088   High
stdlib   go1.25.12  *1.25.13, 1.26.6, 1.27.0-rc.3  go-module  GO-2026-6090   High
stdlib   go1.25.12  *1.25.13, 1.26.6, 1.27.0-rc.3  go-module  GO-2026-6218   Medium
stdlib   go1.25.12  *1.25.13, 1.26.6, 1.27.0-rc.3  go-module  GO-2026-6091   Medium
... (plus moby/go-archive, moby/buildkit, chrismellard -- tracked separately, see Summary)
```

#### After

Built locally with the go1.25.13 toolchain and scanned the resulting binary:

```
grype ./out/pack -c .grype.yaml --fail-on medium

NAME                                               INSTALLED  FIXED IN  SEVERITY
github.com/moby/go-archive                         v0.2.0     0.3.0     High      # tracked in #2675
github.com/moby/buildkit                           v0.30.0    0.31.1    Medium    # tracked in #2676
github.com/chrismellard/docker-credential-acr-env  ...                  Unknown   # no fix available, below medium cutoff
```

All six stdlib findings are gone.

## Documentation

- Should this change be documented?
    - [ ] Yes, see #___
    - [x] No

## Related

Resolves #2682