### PR TITLE
Fix docker URIs with registry ports

### DIFF
--- a/pkg/buildpack/locator_type.go
+++ b/pkg/buildpack/locator_type.go
@@ -71,7 +71,9 @@ func GetLocatorType(locator string, relativeBaseDir string, buildpacksFromBuilde
 
 	if paths.IsURI(locator) {
 		if HasDockerLocator(locator) {
-			if _, err := name.ParseReference(locator); err == nil {
+			ref := strings.TrimPrefix(locator, fromDockerPrefix)
+			ref = strings.TrimPrefix(ref, "/")
+			if _, err := name.ParseReference(ref); err == nil {
 				return PackageLocator, nil
 			}
 		}

--- a/pkg/buildpack/locator_type_test.go
+++ b/pkg/buildpack/locator_type_test.go
@@ -108,6 +108,10 @@ func testGetLocatorType(t *testing.T, when spec.G, it spec.S) {
 			expectedType: buildpack.PackageLocator,
 		},
 		{
+			locator:      "docker://localhost:5000/foo/bar",
+			expectedType: buildpack.PackageLocator,
+		},
+		{
 			locator:      "docker://registry.com/cnbs/some-bp@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 			expectedType: buildpack.PackageLocator,
 		},


### PR DESCRIPTION
## Summary
- normalize the docker URI scheme before parsing the image reference
- cover docker URIs whose registry includes a port

Fixes #2536

## Testing
- go test ./pkg/buildpack -run TestGetLocatorType -count=1 (blocked locally because the network cannot download Go modules from proxy.golang.org; setup failed before test execution)
- gofmt -d pkg/buildpack/locator_type.go pkg/buildpack/locator_type_test.go
- git diff --check